### PR TITLE
ignore benchmark folder by default when running make test

### DIFF
--- a/tests/Makefile.tests
+++ b/tests/Makefile.tests
@@ -12,7 +12,7 @@ test: install ## run all tests
 	@if [ -d ${SOURCE_FOLDER} ] && [ -d ${TESTS_FOLDER} ]; then \
 	  mkdir -p _tests/html-coverage _tests/html-report; \
 	  ${UV_BIN} pip install pytest pytest-cov pytest-html; \
-	  ${UV_BIN} run pytest ${TESTS_FOLDER} --cov=${SOURCE_FOLDER} --cov-report=term --cov-report=html:_tests/html-coverage --html=_tests/html-report/report.html; \
+	  ${UV_BIN} run pytest ${TESTS_FOLDER} --ignore=${TESTS_FOLDER}/benchmarks --cov=${SOURCE_FOLDER} --cov-report=term --cov-report=html:_tests/html-coverage --html=_tests/html-report/report.html; \
 	else \
 	  printf "${YELLOW}[WARN] Source folder ${SOURCE_FOLDER} or tests folder ${TESTS_FOLDER} not found, skipping tests${RESET}\n"; \
 	fi
@@ -29,3 +29,4 @@ benchmark: install ## run performance benchmarks
 	else \
 	  printf "${YELLOW}[WARN] Benchmarks folder not found, skipping benchmarks${RESET}\n"; \
 	fi
+


### PR DESCRIPTION
This pull request makes a minor improvement to the test execution process. The main change is that benchmark tests are now excluded from the regular test run, ensuring that only relevant tests are run during standard testing.

- **Test execution improvements:**
  * Updated the test command in `tests/Makefile.tests` to ignore the `benchmarks` folder during normal test runs, so performance benchmarks are not included when running all tests.

- **Minor formatting:**
  * Added a blank line at the end of the benchmarks section in `tests/Makefile.tests` for consistency.