### PR TITLE
ensure correct rhiza version for sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ install: install-uv install-extras ## install
 	fi
 
 sync: install-uv ## sync with template repository as defined in .github/rhiza/template.yml
-	@${UVX_BIN} rhiza materialize --force .
+	@${UVX_BIN} "rhiza>=0.7.1" materialize --force .
 
 clean: ## clean
 	@printf "${BLUE}Cleaning project...${RESET}\n"


### PR DESCRIPTION
This pull request makes a small update to the `Makefile` to ensure the correct version of the `rhiza` tool is used during the sync process.

* Updated the `sync` target to explicitly require `rhiza>=0.7.1` when running the materialize command, ensuring compatibility with expected features and behavior.