### PR TITLE
add roborev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,4 +93,7 @@ instance/
 # Cython debug symbols
 cython_debug/
 
+# roborev
+.roborev.toml
+
 

--- a/.rhiza/.env
+++ b/.rhiza/.env
@@ -12,3 +12,4 @@ DOCFORMAT=google
 
 # Agentic-specific variables
 DEFAULT_AI_MODEL=gpt-4.1
+ROBOREV_AGENT=copilot

--- a/.rhiza/agentic/Makefile.agentic
+++ b/.rhiza/agentic/Makefile.agentic
@@ -2,12 +2,55 @@
 # This file is included by the main Makefile
 
 # Declare phony targets
-.PHONY: install-copilot analyse-repo summarize-changes
+.PHONY: install-copilot analyse-repo summarize-changes roborev roborev-init roborev-serve roborev-tui roborev-status roborev-stop roborev-review roborev-show
 
 ##@ Agentic Workflows
 
 copilot: install-copilot ## open interactive prompt for copilot
 	@${INSTALL_DIR}/copilot --model "${DEFAULT_AI_MODEL}"
+
+roborev-init: install-roborev ## initialize roborev in the current repository with default agent
+	@${INSTALL_DIR}/roborev init
+	@if [ ! -f .roborev.toml ] || ! grep -q "agent =" .roborev.toml; then \
+		echo 'agent = "$(ROBOREV_AGENT)"' >> .roborev.toml; \
+		printf "${GREEN}[INFO] Set default roborev agent to $(ROBOREV_AGENT) in .roborev.toml${RESET}\n"; \
+	fi
+
+review-latest: install-copilot install-roborev roborev-init roborev-serve ## review the current HEAD commit
+	@PATH="$$(pwd)/${INSTALL_DIR}:${PATH}" ${INSTALL_DIR}/roborev enqueue HEAD --agent $(ROBOREV_AGENT)
+
+review-status: install-roborev ## show code reviews
+	@PATH="$$(pwd)/${INSTALL_DIR}:${PATH}" ${INSTALL_DIR}/roborev status
+
+roborev-serve: install-roborev install-copilot ## start the roborev daemon
+	@PATH="$$(pwd)/${INSTALL_DIR}:${PATH}" ${INSTALL_DIR}/roborev daemon start
+
+review-dashboard: install-roborev install-copilot ## open the roborev interactive terminal UI
+	@PATH="$$(pwd)/${INSTALL_DIR}:${PATH}" ${INSTALL_DIR}/roborev tui
+
+roborev-stop: install-roborev install-copilot ## stop the roborev daemon
+	@PATH="$$(pwd)/${INSTALL_DIR}:${PATH}" ${INSTALL_DIR}/roborev daemon stop
+
+install-roborev: ## checks for roborev and prompts to install
+	@if [ -x "${INSTALL_DIR}/roborev" ]; then \
+		printf "${GREEN}[INFO] roborev is already installed in ${INSTALL_DIR}.${RESET}\n"; \
+	else \
+		printf "${YELLOW}[WARN] roborev not found in ${INSTALL_DIR}.${RESET}\n"; \
+		printf "${BLUE}Do you want to install roborev? [y/N] ${RESET}"; \
+		read -r response; \
+		if [ "$$response" = "y" ] || [ "$$response" = "Y" ]; then \
+			printf "${BLUE}[INFO] Installing roborev to ${INSTALL_DIR}...${RESET}\n"; \
+			mkdir -p "${INSTALL_DIR}"; \
+			if curl -fsSL https://raw.githubusercontent.com/wesm/roborev/main/scripts/install.sh | sed 's|local install_dir=$$(find_install_dir)|local install_dir="${INSTALL_DIR}"|' | bash; then \
+				printf "${GREEN}[INFO] roborev installed successfully.${RESET}\n"; \
+			else \
+				printf "${RED}[ERROR] Failed to install roborev.${RESET}\n"; \
+				exit 1; \
+			fi; \
+		else \
+			printf "${BLUE}[INFO] Skipping installation.${RESET}\n"; \
+		fi; \
+	fi
 
 analyse-repo: install-copilot ## run the analyser agent to update REPOSITORY_ANALYSIS.md
 	@${INSTALL_DIR}/copilot --agent analyser \

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ RED := \033[31m
 YELLOW := \033[33m
 RESET := \033[0m
 
+
 define RHIZA_LOGO
   ____  _     _
  |  _ \| |__ (_)______ _
@@ -159,7 +160,8 @@ clean: ## Clean project artifacts and stale local branches
 		build \
 		*.egg-info \
 		.coverage \
-		.pytest_cache
+		.pytest_cache \
+		.roborev.toml
 
 	@printf "%bRemoving local branches with no remote counterpart...%b\n" "$(BLUE)" "$(RESET)"
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,13 @@ Customisations
 
 Agentic Workflows
   copilot               open interactive prompt for copilot
+  roborev-init          initialize roborev in the current repository with default agent
+  review-latest         review the current HEAD commit
+  review-status         show code reviews
+  roborev-serve         start the roborev daemon
+  review-dashboard      open the roborev interactive terminal UI
+  roborev-stop          stop the roborev daemon
+  install-roborev       checks for roborev and prompts to install
   analyse-repo          run the analyser agent to update REPOSITORY_ANALYSIS.md
   summarize-changes     summarize changes since the most recent release/tag
   install-copilot       checks for copilot and prompts to install


### PR DESCRIPTION
This pull request introduces support for the Roborev code review agent into the Agentic workflows. It adds new Makefile targets for installing, initializing, and managing Roborev, updates environment configuration, and ensures the workspace is cleaned up appropriately. The README is also updated to document the new workflow commands.

**Roborev integration and workflow enhancements:**

* Added new Makefile targets in `.rhiza/agentic/Makefile.agentic` for Roborev, including installation, initialization, starting/stopping the daemon, reviewing commits, and launching the Roborev TUI dashboard. These commands streamline the process of setting up and using Roborev for code reviews.
* Updated the `README.md` to document the new Roborev-related workflow commands, making it easier for users to discover and use these features.

**Configuration and environment updates:**

* Added `ROBOREV_AGENT=copilot` to the `.rhiza/.env` file to set the default Roborev agent, ensuring consistent configuration across environments.

**Cleanup improvements:**

* Modified the main `Makefile` to remove `.roborev.toml` during the `clean` target, helping keep the workspace tidy.

**Minor formatting:**

* Added a blank line in the `Makefile` for improved readability.


---

A colleague of mine and @markrichardson had made us aware of https://github.com/wesm/roborev, made by the creator of pandas. This feels like a really cool tool to bring into rhiza. I think it becomes part of the rhiza-tools suite but for now putting this in draft for you both to play within the rhiza framework. It's installed in the same way as UV and copilot, inside the ./bin and cleaned up after make clean. Following the below steps to get a feel for how it works and let me know if this makes sense to exist within the Rhiza framework.

`make review-latest` - will install copilot and roborev within ./bin and run the daemon and kick off a worker to review latest commit
`make review-status` - shows the status of requested reviews
`make review-dashboard` - invokes the tui for roborev where you can interact with the reviews