### PR TITLE
Update documentation

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -9,6 +9,6 @@ This directory contains the configuration for [GitHub Codespaces](https://github
 
 ## Features
 
-- **Python Environment**: Pre-configured with Python 3.12.
+- **Python Environment**: Pre-configured with Python 3.14.
 - **Tools**: Includes `uv` for fast package management and `make` for project tasks.
 - **Extensions**: Recommended VS Code extensions for Python development, including Ruff and Marimo.

--- a/README.md
+++ b/README.md
@@ -310,20 +310,27 @@ Before integrating Rhiza into your existing project:
 
 ### Quick Start: Automated Injection
 
-The fastest way to integrate Rhiza is using the provided `inject_rhiza.sh` script:
+The fastest way to integrate Rhiza is by following the steps below:
 
 ```bash
 # Navigate to your repository
 cd /path/to/your/project
 
-# Run the injection script
-uvx rhiza .
+# Initialize configuration templates
+uvx rhiza init
 ```
 
 This will:
 - ✅ Create a default template configuration (`.github/template.yml`)
-- ✅ Perform an initial sync of a basic set of templates
-- ✅ Provide clear next steps for review and customization
+
+Then, update the generated `.github/template.yml` file with your chosen templates that you can find from [Available Templates](#-available-templates).
+
+You will then need to run the following, to inject templates into your repository:
+
+```bash
+# Inject templates into your repository
+uvx rhiza materialize
+```
 
 **Options:**
 - `--branch <branch>` - Use a specific rhiza branch (default: main)

--- a/book/README.md
+++ b/book/README.md
@@ -1,4 +1,4 @@
-se# Project Book and Documentation
+# Project Book and Documentation
 
 This directory contains the source and templates for generating the Rhiza companion book and API documentation.
 


### PR DESCRIPTION
**Summary:**
This PR updates documentation across the repository to improve clarity and accuracy for first-time users of Rhiza.

**Issues:**
Mainly wanted to highlight the use of ```uvx rhiza .```, which is documented in the README. This throws the error: ```No such command '.'```. My naive assumption here is that this method of command line injection is deprecated, and replaced via 
```
uv rhiza init
uv rhiza materialize
```

**Changes:**
Updated the Quick Start section in README.md to reflect the up-to-date workflow for injecting into a pre-existing project
Changed from single uvx rhiza . command to a two-step process:
uvx rhiza init - Initialise configuration templates
uvx rhiza materialize - Inject templates into repository
Added clearer instructions for customizing .github/template.yml with reference to Available Templates section
Updated README.md to reflect Python 3.14 instead of 3.12
Fixed typo in README.md (removed stray "se" prefix)