### PR TITLE
ensure commit on bump and update lock

### DIFF
--- a/.rhiza/.cfg.toml
+++ b/.rhiza/.cfg.toml
@@ -11,7 +11,7 @@ sign_tags = false
 tag_name = "v{new_version}"
 tag_message = "Bump version: {current_version} → {new_version}"
 allow_dirty = false
-commit = false
+commit = true
 message = "Chore: bump version {current_version} → {new_version}"
 commit_args = ""
 
@@ -27,5 +27,10 @@ values = [
 
 [[tool.bumpversion.files]]
 filename = "pyproject.toml"
+search = 'version = "{current_version}"'
+replace = 'version = "{new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "uv.lock"
 search = 'version = "{current_version}"'
 replace = 'version = "{new_version}"'


### PR DESCRIPTION
This pull request updates the version bumping configuration in `.rhiza/.cfg.toml` to ensure version changes are committed automatically and to extend version updates to the `uv.lock` file in addition to `pyproject.toml`.

Version bumping workflow improvements:

* Changed the configuration to automatically commit version bumps by setting `commit = true` instead of `false`.

File update coverage:

* Added `uv.lock` to the list of files whose version string is updated during a version bump, ensuring consistency across project files.

@tschm update not needed in rhiza-tools (https://github.com/Jebel-Quant/rhiza-tools/issues/25) I had the commit flag set to false in the rhiza config.