### PR TITLE
fix make customisations

### DIFF
--- a/.rhiza/.env
+++ b/.rhiza/.env
@@ -1,7 +1,7 @@
 MARIMO_FOLDER=book/marimo
 SOURCE_FOLDER=src
 SCRIPTS_FOLDER=.rhiza/scripts
-CUSTOM_SCRIPTS_FOLDER=.rhiza/scripts/customisations
+CUSTOM_SCRIPTS_FOLDER=.rhiza/customisations/scripts
 
 # Book-specific variables
 BOOK_TITLE=Project Documentation

--- a/tests/test_rhiza/test_makefile.py
+++ b/tests/test_rhiza/test_makefile.py
@@ -45,9 +45,11 @@ def setup_tmp_makefile(logger, root, tmp_path: Path):
     # Copy the main Makefile into the temporary working directory
     shutil.copy(root / "Makefile", tmp_path / "Makefile")
 
-    if (root / ".rhiza" / ".env").exists():
-        (tmp_path / ".rhiza").mkdir(exist_ok=True)
-        shutil.copy(root / ".rhiza" / ".env", tmp_path / ".rhiza" / ".env")
+    # Create a minimal, deterministic .rhiza/.env for tests so they don't
+    # depend on the developer's local configuration which may vary.
+    (tmp_path / ".rhiza").mkdir(exist_ok=True)
+    env_content = "SCRIPTS_FOLDER=.rhiza/scripts\nCUSTOM_SCRIPTS_FOLDER=.rhiza/customisations/scripts\n"
+    (tmp_path / ".rhiza" / ".env").write_text(env_content)
 
     logger.debug("Copied Makefile from %s to %s", root / "Makefile", tmp_path / "Makefile")
 
@@ -187,10 +189,10 @@ class TestMakefile:
         assert "Value of SCRIPTS_FOLDER:\n.rhiza/scripts" in out
 
     def test_custom_scripts_folder_is_set(self, logger):
-        """`CUSTOM_SCRIPTS_FOLDER` should point to `.rhiza/scripts/customisations`."""
+        """`CUSTOM_SCRIPTS_FOLDER` should point to `.rhiza/customisations/scripts`."""
         proc = run_make(logger, ["print-CUSTOM_SCRIPTS_FOLDER"], dry_run=False)
         out = strip_ansi(proc.stdout)
-        assert "Value of CUSTOM_SCRIPTS_FOLDER:\n.rhiza/scripts/customisations" in out
+        assert "Value of CUSTOM_SCRIPTS_FOLDER:\n.rhiza/customisations/scripts" in out
 
 
 class TestMakefileRootFixture:


### PR DESCRIPTION
This pull request updates the handling and configuration of the `CUSTOM_SCRIPTS_FOLDER` environment variable to use a new directory structure, and ensures that tests use a deterministic `.env` file. The changes improve consistency between the configuration and the test expectations.

Configuration changes:

* Updated the `CUSTOM_SCRIPTS_FOLDER` path in `.rhiza/.env` from `.rhiza/scripts/customisations` to `.rhiza/customisations/scripts` to reflect the new directory structure.

Test improvements:

* Modified the test setup in `test_makefile.py` to create a minimal, deterministic `.rhiza/.env` file during tests, ensuring tests do not depend on the developer's local configuration.
* Updated the test assertion and docstring in `test_custom_scripts_folder_is_set` to match the new `CUSTOM_SCRIPTS_FOLDER` path, ensuring the test checks for `.rhiza/customisations/scripts`.