### PR TITLE
Add architecture diagrams with mermaid

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,244 @@
+# Rhiza Architecture
+
+Visual diagrams of Rhiza's architecture and component interactions.
+
+## System Overview
+
+```mermaid
+flowchart TB
+    subgraph User["User Interface"]
+        make[make commands]
+        local[local.mk]
+    end
+
+    subgraph Core[".rhiza/ Core"]
+        rhizamk[rhiza.mk<br/>Core Logic]
+        maked[make.d/*.mk<br/>Extensions]
+        scripts[scripts/<br/>Shell Scripts]
+        utils[utils/<br/>Python Utils]
+        template[template.yml<br/>Sync Config]
+    end
+
+    subgraph Config["Configuration"]
+        pyproject[pyproject.toml]
+        ruff[ruff.toml]
+        precommit[.pre-commit-config.yaml]
+        editorconfig[.editorconfig]
+    end
+
+    subgraph CI["GitHub Actions"]
+        ci[CI Workflow]
+        release[Release Workflow]
+        security[Security Workflow]
+        sync[Sync Workflow]
+    end
+
+    make --> rhizamk
+    local -.-> rhizamk
+    rhizamk --> maked
+    rhizamk --> scripts
+    rhizamk --> utils
+    maked --> pyproject
+    utils --> pyproject
+    ci --> make
+    release --> make
+    security --> make
+    sync --> template
+```
+
+## Makefile Hierarchy
+
+```mermaid
+flowchart TD
+    subgraph Entry["Entry Point"]
+        Makefile[Makefile<br/>9 lines]
+    end
+
+    subgraph Core["Core Logic"]
+        rhizamk[.rhiza/rhiza.mk<br/>268 lines]
+    end
+
+    subgraph Extensions["Auto-loaded Extensions"]
+        config[00-19: Configuration]
+        tasks[20-79: Task Definitions]
+        hooks[80-99: Hook Implementations]
+    end
+
+    subgraph Local["Local Customization"]
+        localmk[local.mk<br/>Not synced]
+    end
+
+    Makefile -->|includes| rhizamk
+    rhizamk -->|includes| config
+    rhizamk -->|includes| tasks
+    rhizamk -->|includes| hooks
+    rhizamk -.->|optional| localmk
+```
+
+## Hook System
+
+```mermaid
+flowchart LR
+    subgraph Hooks["Double-Colon Targets"]
+        pre_install[pre-install::]
+        post_install[post-install::]
+        pre_sync[pre-sync::]
+        post_sync[post-sync::]
+        pre_release[pre-release::]
+        post_release[post-release::]
+        pre_bump[pre-bump::]
+        post_bump[post-bump::]
+    end
+
+    subgraph Targets["Main Targets"]
+        install[make install]
+        sync[make sync]
+        release[make release]
+        bump[make bump]
+    end
+
+    pre_install --> install --> post_install
+    pre_sync --> sync --> post_sync
+    pre_release --> release --> post_release
+    pre_bump --> bump --> post_bump
+```
+
+## Release Pipeline
+
+```mermaid
+flowchart TD
+    tag[Push Tag v*] --> validate[Validate Tag]
+    validate --> build[Build Package]
+    build --> draft[Draft GitHub Release]
+    draft --> pypi[Publish to PyPI]
+    draft --> devcontainer[Publish Devcontainer]
+    pypi --> finalize[Finalize Release]
+    devcontainer --> finalize
+
+    subgraph Conditions
+        pypi_cond{Has dist/ &<br/>not Private?}
+        dev_cond{PUBLISH_DEVCONTAINER<br/>= true?}
+    end
+
+    draft --> pypi_cond
+    pypi_cond -->|yes| pypi
+    pypi_cond -->|no| finalize
+    draft --> dev_cond
+    dev_cond -->|yes| devcontainer
+    dev_cond -->|no| finalize
+```
+
+## Template Sync Flow
+
+```mermaid
+flowchart LR
+    upstream[Upstream Rhiza<br/>jebel-quant/rhiza] -->|template.yml| sync[make sync]
+    sync -->|updates| downstream[Downstream Project]
+
+    subgraph Synced["Synced Files"]
+        workflows[.github/workflows/]
+        rhiza[.rhiza/]
+        configs[Config Files]
+    end
+
+    subgraph Preserved["Preserved"]
+        localmk[local.mk]
+        src[src/]
+        tests[tests/]
+    end
+
+    sync --> Synced
+    downstream --> Preserved
+```
+
+## Directory Structure
+
+```mermaid
+flowchart TD
+    root[Project Root]
+
+    root --> rhiza[.rhiza/]
+    root --> github[.github/]
+    root --> src[src/]
+    root --> tests[tests/]
+    root --> docs[docs/]
+    root --> book[book/]
+
+    rhiza --> rhizamk[rhiza.mk]
+    rhiza --> maked[make.d/]
+    rhiza --> scripts[scripts/]
+    rhiza --> utils[utils/]
+    rhiza --> template[template.yml]
+
+    github --> workflows[workflows/]
+    workflows --> ci[rhiza_ci.yml]
+    workflows --> release[rhiza_release.yml]
+    workflows --> security[rhiza_security.yml]
+    workflows --> more[... 11 more]
+
+    maked --> m00[00-19: Config]
+    maked --> m20[20-79: Tasks]
+    maked --> m80[80-99: Hooks]
+```
+
+## CI/CD Workflow Triggers
+
+```mermaid
+flowchart TD
+    subgraph Triggers
+        push[Push]
+        pr[Pull Request]
+        schedule[Schedule]
+        manual[Manual]
+        tag[Tag v*]
+    end
+
+    subgraph Workflows
+        ci[CI]
+        security[Security]
+        codeql[CodeQL]
+        release[Release]
+        deptry[Deptry]
+        precommit[Pre-commit]
+    end
+
+    push --> ci
+    push --> security
+    push --> codeql
+    pr --> ci
+    pr --> deptry
+    pr --> precommit
+    schedule --> security
+    manual --> ci
+    tag --> release
+```
+
+## Python Execution Model
+
+```mermaid
+flowchart LR
+    subgraph Commands
+        make[make test]
+        direct[Direct Python]
+    end
+
+    subgraph UV["uv Layer"]
+        uv_run[uv run]
+        uvx[uvx]
+    end
+
+    subgraph Tools
+        pytest[pytest]
+        ruff[ruff]
+        hatch[hatch]
+    end
+
+    make --> uv_run
+    uv_run --> pytest
+    uv_run --> ruff
+    uvx --> hatch
+
+    direct -.->|Never| pytest
+
+    style direct stroke-dasharray: 5 5
+```


### PR DESCRIPTION
## Summary

- Adds `docs/ARCHITECTURE.md` with 8 mermaid diagrams
- All diagrams render natively on GitHub (no external tools needed)

## Diagrams Included

1. **System Overview** - Components and their interactions
2. **Makefile Hierarchy** - Entry point → core → extensions → local
3. **Hook System** - Double-colon target flow (pre/post hooks)
4. **Release Pipeline** - Tag → build → publish flow with conditions
5. **Template Sync Flow** - Upstream → downstream with preserved files
6. **Directory Structure** - Project layout tree
7. **CI/CD Workflow Triggers** - Which events trigger which workflows
8. **Python Execution Model** - uv layer between make and tools

## Test plan

- [ ] Verify diagrams render correctly on GitHub
- [ ] Check diagram accuracy against actual codebase
- [ ] Review for clarity and completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)