### PR TITLE
extend asserts in test_notebooks.py to cover marimo sandbox setup error

### DIFF
--- a/tests/test_rhiza/test_notebooks.py
+++ b/tests/test_rhiza/test_notebooks.py
@@ -79,9 +79,9 @@ def test_notebook_execution(notebook_path: Path):
     lower_output = combined_output.lower()
 
     failure_keywords = [
-        "some cells failed to execute",
         "cells failed to execute",
         "marimoexceptionraisederror",
+        "Couldn't parse requirement",  # sandbox setup fails because of invalid dependencies section in the notebook
     ]
     for kw in failure_keywords:
         assert kw.lower() not in lower_output, (


### PR DESCRIPTION
Example marimo error to be covered (happens if notebook-embedded dependencies section has problems):
```
stderr="Running in a sandbox: /home/vscode/.local/bin/uv run --isolated --no-project --compile-bytecode --with-requirements /tmp/tmp7_iqghrf.txt --python >=3.11 marimo export html book/marimo/notebooks/demo.py -o /dev/null\nerror: Couldn't parse requirement in `/tmp/tmp7_iqghrf.txt` at position 3\n  Caused by: path could not be normalized: <...>```
