### PR TITLE
Add bundles.yml configuration for template-driven bundle selection

### DIFF
--- a/.rhiza/bundles.yml
+++ b/.rhiza/bundles.yml
@@ -1,0 +1,118 @@
+version: "1.0"
+bundles:
+  core:
+    description: "Essential development configuration files"
+    files:
+      - .rhiza
+      - .editorconfig
+      - .gitignore
+      - .pre-commit-config.yaml
+      - ruff.toml
+      - Makefile
+      - pytest.ini
+    workflows: []
+    depends-on: []
+
+  tests:
+    description: "Testing configuration and workflows"
+    files:
+      - .rhiza/make.d/01-test.mk
+      - tests
+    workflows:
+      - .github/workflows/rhiza_ci.yml
+      - .gitlab/workflows/rhiza_ci.yml
+    depends-on: []
+
+  docs:
+    description: "Documentation generation setup"
+    files:
+      - .rhiza/make.d/08-docs.mk
+      - docs
+    workflows: []
+    depends-on:
+      - tests
+
+  book:
+    description: "Companion book with API docs, coverage, tests"
+    files:
+      - .rhiza/make.d/02-book.mk
+      - book
+    workflows:
+      - .github/workflows/rhiza_book.yml
+      - .gitlab/workflows/rhiza_book.yml
+    depends-on:
+      - tests
+      - docs
+
+  docker:
+    description: "Docker build configuration"
+    files:
+      - .rhiza/make.d/07-docker.mk
+      - docker
+    workflows:
+      - .github/workflows/rhiza_docker.yml
+    depends-on: []
+
+  github:
+    description: "GitHub Actions workflows and configurations"
+    files:
+      - .rhiza/make.d/05-github.mk
+    workflows:
+      - .github/workflows/rhiza_ci.yml
+      - .github/workflows/rhiza_codeql.yml
+      - .github/workflows/rhiza_deptry.yml
+      - .github/workflows/rhiza_mypy.yml
+      - .github/workflows/rhiza_pre-commit.yml
+      - .github/workflows/rhiza_release.yml
+      - .github/workflows/rhiza_security.yml
+      - .github/workflows/rhiza_sync.yml
+      - .github/workflows/rhiza_validate.yml
+    depends-on:
+      - core
+
+  gitlab:
+    description: "GitLab CI/CD pipelines and configurations"
+    files:
+      - .gitlab-ci.yml
+    workflows:
+      - .gitlab/workflows/rhiza_ci.yml
+      - .gitlab/workflows/rhiza_book.yml
+      - .gitlab/workflows/rhiza_deptry.yml
+      - .gitlab/workflows/rhiza_pre-commit.yml
+      - .gitlab/workflows/rhiza_release.yml
+      - .gitlab/workflows/rhiza_renovate.yml
+      - .gitlab/workflows/rhiza_sync.yml
+      - .gitlab/workflows/rhiza_validate.yml
+    depends-on:
+      - core
+
+  marimo:
+    description: "Interactive Marimo notebooks"
+    files:
+      - .rhiza/make.d/03-marimo.mk
+    workflows:
+      - .github/workflows/rhiza_marimo.yml
+    depends-on: []
+
+  presentation:
+    description: "Presentation generation from markdown"
+    files:
+      - .rhiza/make.d/04-presentation.mk
+      - presentation
+    workflows: []
+    depends-on: []
+
+  devcontainer:
+    description: "VS Code dev container"
+    files:
+      - .devcontainer
+    workflows:
+      - .github/workflows/rhiza_devcontainer.yml
+    depends-on: []
+
+  agentic:
+    description: "AI-assisted development workflows"
+    files:
+      - .rhiza/make.d/06-agentic.mk
+    workflows: []
+    depends-on: []


### PR DESCRIPTION
Defines all available template bundles (core, tests, docs, book, docker, github, gitlab, marimo, presentation, devcontainer, agentic) with their associated files, workflows, and dependencies. This enables bundle-based template selection as an alternative to path-based include/exclude patterns.