### PR TITLE
bundle rhiza tests into rhiza workflows

### DIFF
--- a/.github/workflows/rhiza_validate.yml
+++ b/.github/workflows/rhiza_validate.yml
@@ -12,8 +12,6 @@ on:
 jobs:
   validation:
     runs-on: ubuntu-latest
-    # don't run this in rhiza itself. Rhiza has no template.yml file.
-    if: ${{ github.repository != 'jebel-quant/rhiza' }}
     container:
       image: ghcr.io/astral-sh/uv:0.9.30-bookworm
 
@@ -27,6 +25,13 @@ jobs:
           token: ${{ secrets.GH_PAT }}
 
       - name: Validate Rhiza config
+        # don't run this in rhiza itself. Rhiza has no template.yml file.
+        if: ${{ github.repository != 'jebel-quant/rhiza' }}
         shell: bash
         run: |
           uvx "rhiza>=0.8.0" validate .
+        
+      - name: Run Rhiza Tests
+        shell: bash
+        run: |
+          make rhiza-test

--- a/.rhiza/rhiza.mk
+++ b/.rhiza/rhiza.mk
@@ -116,7 +116,14 @@ summarise-sync: install-uv ## summarise differences created by sync with templat
 		${UVX_BIN} "rhiza>=$(RHIZA_VERSION)" summarise .; \
 	fi
 
-validate: pre-validate ## validate project structure against template repository as defined in .rhiza/template.yml
+rhiza-test: install ## run rhiza's own tests (if any)
+	@if [ -d ".rhiza/tests" ]; then \
+		${UV_BIN} run pytest .rhiza/tests; \
+	else \
+		printf "${YELLOW}[WARN] No .rhiza/tests directory found, skipping rhiza-tests${RESET}\n"; \
+	fi
+
+validate: pre-validate rhiza-test ## validate project structure against template repository as defined in .rhiza/template.yml
 	@if git remote get-url origin 2>/dev/null | grep -iqE 'jebel-quant/rhiza(\.git)?$$'; then \
 		printf "${BLUE}[INFO] Skipping validate in rhiza repository (no template.yml by design)${RESET}\n"; \
 	else \

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-testpaths = .rhiza/tests tests
+testpaths = tests
 # Enable live logs on console
 log_cli = true
 # Show DEBUG+ messages


### PR DESCRIPTION
This pull request updates the Rhiza validation workflow and related test configuration to ensure that Rhiza-specific tests are run when available, and clarifies where tests should be located. The most significant changes are the conditional execution of validation steps, the addition of a dedicated Rhiza test target, and an update to the test discovery configuration.

**Workflow and Validation Updates:**

* The validation job in `.github/workflows/rhiza_validate.yml` now only runs the Rhiza config validation step if the repository is not `jebel-quant/rhiza`, preventing errors due to the absence of a `template.yml` in the Rhiza repo. [[1]](diffhunk://#diff-7e9447c9859f5dacffb89b400e6dd47197402c9a5c42c2cb73cea7659da433b5L15-L16) [[2]](diffhunk://#diff-7e9447c9859f5dacffb89b400e6dd47197402c9a5c42c2cb73cea7659da433b5R28-R37)
* A new "Run Rhiza Tests" step is added to the workflow, which executes `make rhiza-test` to run any available Rhiza-specific tests.

**Makefile Enhancements:**

* Introduced a `rhiza-test` target in `.rhiza/rhiza.mk` that runs tests in `.rhiza/tests` if the directory exists, otherwise prints a warning. The `validate` target now depends on `rhiza-test`, ensuring tests are run as part of validation.

**Test Configuration:**

* The `pytest.ini` configuration is updated so that only the `tests` directory is included in test discovery by default, not `.rhiza/tests`.