### PR TITLE
feat: add coverage badge generation via gh-pages

### DIFF
--- a/.github/workflows/rhiza_deptry.yml
+++ b/.github/workflows/rhiza_deptry.yml
@@ -27,7 +27,7 @@ jobs:
     name: Check dependencies with deptry
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/astral-sh/uv:0.10.11-bookworm
+      image: ghcr.io/astral-sh/uv:0.9.30-bookworm
 
     steps:
       - uses: actions/checkout@v6.0.2


### PR DESCRIPTION
- Upload coverage.xml as artifact from primary Python version (3.12) only
- Add coverage-badge job that generates SVG and pushes to gh-pages branch
