### PR TITLE
Remove page link cards from minibook template

### DIFF
--- a/.rhiza/templates/minibook/custom.html.jinja2
+++ b/.rhiza/templates/minibook/custom.html.jinja2
@@ -30,10 +30,6 @@
             font-family: 'Inter', sans-serif;
         }
 
-        .link-card {
-            /* Animation removed as requested */
-        }
-
         .gradient-text {
             background-clip: text;
             -webkit-background-clip:  text;
@@ -60,16 +56,6 @@
         html: not(.dark) .content-container {
             background-color: rgba(255, 255, 255, 0.8);
             border-color: #e5e7eb;
-        }
-
-        html:not(.dark) .link-card a {
-            background-color: rgba(243, 244, 246, 0.5);
-            border-color: #e5e7eb;
-        }
-
-        html:not(.dark) .link-card a:hover {
-            background-color: rgba(249, 250, 251, 0.5);
-            border-color: #6366f1;
         }
 
         html:not(.dark) .card-title {
@@ -162,24 +148,6 @@
                         <span class="dark:text-white text-gray-800 text-sm font-medium">Home Repo</span>
                     </a>
                 </div>
-            </div>
-
-            <div class="grid grid-cols-1 md: grid-cols-2 gap-4 mb-8">
-                {% for name, url in links %}
-                <div class="link-card group">
-                    <a href="{{ url }}" target="_blank" class="block p-4 rounded-lg dark:bg-gray-800/50 bg-gray-100/80 border dark:border-gray-700 border-gray-300 dark:hover:border-indigo-500 hover: border-indigo-600 transition-all duration-200">
-                        <div class="flex items-center">
-                            <div class="flex-shrink-0 w-10 h-10 rounded-full bg-gradient-to-r from-indigo-500 to-purple-600 flex items-center justify-center mr-4 group-hover:from-purple-600 group-hover:to-pink-600 transition-all duration-200">
-                                <span class="text-white font-bold">{{ name[0] | upper }}</span>
-                            </div>
-                            <div>
-                                <h3 class="card-title text-lg font-medium dark:text-white text-gray-800 dark:group-hover:text-indigo-300 group-hover:text-indigo-600 transition-colors duration-200">{{ name }}</h3>
-                                <p class="card-url text-xs dark:text-gray-400 text-gray-500 truncate">{{ url }}</p>
-                            </div>
-                        </div>
-                    </a>
-                </div>
-                {% endfor %}
             </div>
 
             <div class="mt-12 pt-6 border-t footer-border dark:border-gray-800 border-gray-300 text-center">


### PR DESCRIPTION
Removes the section navigation link cards ({% for name, url in links %} grid) from the GitHub Pages book landing page, along with their associated CSS rules.

https://claude.ai/code/session_01Jz5RmsTAsq9K2NsktztPcT

## Summary

<!-- One or two sentences describing what this PR does and why. -->

Closes #<!-- issue number -->

## Changes

<!-- Bullet list of what changed. -->

-

## Testing

- [ ] `make test` passes locally
- [ ] `make fmt` has been run
- [ ] New tests added (or explain why not needed)

## Checklist

- [ ] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated if behaviour changed
- [ ] `make deptry` passes (no unused or missing dependencies)
