### PR TITLE
feat: add license compliance scan (make license + rhiza_license workflow)

### DIFF
--- a/.github/workflows/rhiza_license.yml
+++ b/.github/workflows/rhiza_license.yml
@@ -1,0 +1,45 @@
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
+#
+# Workflow: License compliance
+#
+# Purpose: This workflow checks that no copyleft-licensed dependencies
+#          (GPL, LGPL, AGPL) have been introduced via transitive updates.
+#
+# Trigger: This workflow runs on every push and on pull requests to main/master
+#          branches (including from forks)
+
+name: "(RHIZA) LICENSE"
+
+# Permissions: Only read access to repository contents is needed
+permissions:
+    contents: read
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  license:
+    name: License compliance scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7.6.0
+        with:
+          version: "0.10.12"
+
+      - name: Configure git auth for private packages
+        uses: ./.github/actions/configure-git-auth
+        with:
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Run license check
+        env:
+          UV_EXTRA_INDEX_URL: ${{ secrets.UV_EXTRA_INDEX_URL }}
+        run: make license

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,13 @@ post-validate::
 
 ## Custom targets
 
+##@ Quality
+
+.PHONY: license
+license: install ## run license compliance scan (fail on GPL, LGPL, AGPL)
+	@printf "${BLUE}[INFO] Running license compliance scan...${RESET}\n"
+	@${UV_BIN} run --with pip-licenses pip-licenses --fail-on="GPL;LGPL;AGPL"
+
 .PHONY: adr
 adr: install-gh-aw ## Create a new Architecture Decision Record (ADR) using AI assistance
 	@echo "Creating a new ADR..."


### PR DESCRIPTION
## Summary

- Adds `make license` target that runs `pip-licenses` and fails on copyleft licenses (GPL, LGPL, AGPL)
- Adds `rhiza_license.yml` CI workflow that runs the license check on every push and PR to main/master

## Test plan

- [ ] `make license` runs successfully locally
- [ ] CI workflow `(RHIZA) LICENSE` appears and passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)