### PR TITLE
Add docs/mkdocs-base.yml base config with INHERIT

### DIFF
--- a/.rhiza/make.d/book.mk
+++ b/.rhiza/make.d/book.mk
@@ -16,8 +16,8 @@ mkdocs-build:: install-uv
 
 BOOK_OUTPUT ?= _book
 
-# Detect mkdocs config: prefer root-level, fall back to docs/mkdocs.yml
-_MKDOCS_CFG := $(if $(wildcard mkdocs.yml),mkdocs.yml,$(if $(wildcard docs/mkdocs.yml),docs/mkdocs.yml,))
+# Detect mkdocs config: prefer root-level, fall back to docs/mkdocs-base.yml
+_MKDOCS_CFG := $(if $(wildcard mkdocs.yml),mkdocs.yml,$(if $(wildcard docs/mkdocs-base.yml),docs/mkdocs-base.yml,))
 
 ##@ Book
 

--- a/docs/mkdocs-base.yml
+++ b/docs/mkdocs-base.yml
@@ -1,4 +1,4 @@
-site_name: My Project
+site_name: Rhiza
 docs_dir: .
 site_dir: _mkdocs
 

--- a/docs/mkdocs-base.yml
+++ b/docs/mkdocs-base.yml
@@ -17,7 +17,8 @@
 #     repo_url: https://github.com/example/my-project
 #     repo_name: example/my-project
 #
-#     docs_dir: docs   # override: base uses docs_dir: . (relative to this file)
+#     docs_dir: docs   # always set this explicitly — base uses docs_dir: . which
+#                      # resolves relative to docs/mkdocs-base.yml, not mkdocs.yml
 #
 #     nav:             # nav is fully replaced — not merged — by the child config
 #       - Home: index.md

--- a/docs/mkdocs-base.yml
+++ b/docs/mkdocs-base.yml
@@ -33,3 +33,10 @@ markdown_extensions:
 
 extra_javascript:
   - https://unpkg.com/mermaid@11.4.0/dist/mermaid.esm.min.mjs
+
+# nav is overwritten completely in mkdocs.yml
+nav:
+  - Home: index.md
+  - Notebooks: notebooks.md
+  - Reports: reports.md
+  - Paper: paper/rhiza.pdf

--- a/docs/mkdocs-base.yml
+++ b/docs/mkdocs-base.yml
@@ -1,3 +1,31 @@
+# docs/mkdocs-base.yml — Base MkDocs configuration for rhiza-based projects.
+#
+# USAGE (standalone)
+#   Build or serve this file directly if you have no root-level mkdocs.yml:
+#     uvx --with mkdocs-material mkdocs serve -f docs/mkdocs-base.yml
+#   The rhiza build system (make book) will pick this file up automatically
+#   as a fallback when no root-level mkdocs.yml is found.
+#
+# USAGE (with INHERIT)
+#   To extend this config from a root-level mkdocs.yml, add the following
+#   at the top of your mkdocs.yml and override only what you need:
+#
+#     INHERIT: docs/mkdocs-base.yml
+#
+#     site_name: My Project
+#     site_url: https://example.github.io/my-project/
+#     repo_url: https://github.com/example/my-project
+#     repo_name: example/my-project
+#
+#     docs_dir: docs   # override: base uses docs_dir: . (relative to this file)
+#
+#     nav:             # nav is fully replaced — not merged — by the child config
+#       - Home: index.md
+#       - Guide: guide.md
+#
+#   Any key you omit in mkdocs.yml is inherited from this file.
+#   The 'nav' key is always fully replaced when defined in the child.
+
 site_name: Rhiza
 docs_dir: .
 site_dir: _mkdocs

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: My Project
 docs_dir: .
+site_dir: _mkdocs
 
 theme:
   name: material
@@ -9,6 +10,8 @@ theme:
     - navigation.top
     - search.suggest
     - search.highlight
+  logo: assets/rhiza-logo.svg
+  favicon: assets/rhiza-logo.svg
 
 plugins:
   - search

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,0 +1,32 @@
+site_name: My Project
+docs_dir: .
+
+theme:
+  name: material
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - search.suggest
+    - search.highlight
+
+plugins:
+  - search
+
+markdown_extensions:
+  - md_in_html
+  - pymdownx.highlight
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.snippets:
+      base_path: ["."]
+  - admonition
+  - toc:
+      permalink: true
+      toc_depth: 3
+
+extra_javascript:
+  - https://unpkg.com/mermaid@11.4.0/dist/mermaid.esm.min.mjs

--- a/docs/paper/rhiza.tex
+++ b/docs/paper/rhiza.tex
@@ -53,7 +53,7 @@
 
 \author{
   Thomas Schmelzer\\
-  \texttt{tschmelzer@jqr.io}
+  \texttt{thomas@jqr.ae}
   \and
   Harry Campion
   \and

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,7 @@ site_url: https://jebel-quant.github.io/rhiza/
 repo_url: https://github.com/Jebel-Quant/rhiza
 repo_name: Jebel-Quant/rhiza
 
-docs_dir: docs
+#docs_dir: docs
 
 nav:
   - Home: index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,3 +1,5 @@
+INHERIT: docs/mkdocs.yml
+
 site_name: rhiza
 site_description: Reusable configuration templates for modern Python projects.
 site_url: https://jebel-quant.github.io/rhiza/
@@ -11,33 +13,6 @@ theme:
   name: material
   logo: assets/rhiza-logo.svg
   favicon: assets/rhiza-logo.svg
-  features:
-    - navigation.tabs
-    - navigation.sections
-    - navigation.top
-    - search.suggest
-    - search.highlight
-
-plugins:
-  - search
-
-markdown_extensions:
-  - md_in_html
-  - pymdownx.highlight
-  - pymdownx.superfences:
-      custom_fences:
-        - name: mermaid
-          class: mermaid
-          format: !!python/name:pymdownx.superfences.fence_code_format
-  - pymdownx.snippets:
-      base_path: ["."]
-  - admonition
-  - toc:
-      permalink: true
-      toc_depth: 3
-
-extra_javascript:
-  - https://unpkg.com/mermaid@11.4.0/dist/mermaid.esm.min.mjs
 
 nav:
   - Home: index.md
@@ -66,7 +41,6 @@ nav:
     - Project Board: PROJECT_BOARD.md
     - Technical Debt: TECHNICAL_DEBT.md
   - Security:
-    - Security Policy: SECURITY.md
     - Security Testing: SECURITY_TESTING.md
   - Architecture Decision Records:
     - Overview: adr/README.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,7 @@ site_url: https://jebel-quant.github.io/rhiza/
 repo_url: https://github.com/Jebel-Quant/rhiza
 repo_name: Jebel-Quant/rhiza
 
-#docs_dir: docs
+docs_dir: docs
 
 nav:
   - Home: index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,12 +7,6 @@ repo_url: https://github.com/Jebel-Quant/rhiza
 repo_name: Jebel-Quant/rhiza
 
 docs_dir: docs
-site_dir: _mkdocs
-
-theme:
-  name: material
-  logo: assets/rhiza-logo.svg
-  favicon: assets/rhiza-logo.svg
 
 nav:
   - Home: index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-INHERIT: docs/mkdocs.yml
+INHERIT: docs/mkdocs-base.yml
 
 site_name: rhiza
 site_description: Reusable configuration templates for modern Python projects.


### PR DESCRIPTION
  Summary

  This PR introduces a two-level MkDocs configuration structure to make the documentation setup reusable for projects adopting the
  rhiza template.

  docs/mkdocs-base.yml (new)

  A standalone base config that ships as part of the rhiza template. It contains all shared settings — Material theme, plugins,
  markdown extensions, and Mermaid support — along with a minimal nav (Home, Notebooks, Reports, Paper). Projects without a root-level
  mkdocs.yml can use this directly; the build system (book.mk) already falls back to docs/mkdocs-base.yml when no root config is found.

  mkdocs.yml (updated)

  Now uses INHERIT: docs/mkdocs-base.yml to pull in the shared settings, and only declares rhiza-specific overrides: site metadata,
  docs_dir, and the full nav. This removes ~30 lines of duplication from the root config.

  Other fixes

  - Removed the Security Policy: SECURITY.md nav entry (file was deleted in a prior commit)
  - Added paper/rhiza.pdf to the base nav so the paper is accessible from the docs site
  - Corrected Thomas Schmelzer's email address in docs/paper/rhiza.tex

  Test plan

  - mkdocs serve -f docs/mkdocs-base.yml — builds and serves with minimal nav including PDF link
  - mkdocs serve -f mkdocs.yml — builds and serves with full rhiza nav via INHERIT
  - Confirm make book still works end-to-end