### PR TITLE
fix(security): warn on tooling CVEs, fail only on runtime dep vulnera…

### DIFF
--- a/.rhiza/make.d/test.mk
+++ b/.rhiza/make.d/test.mk
@@ -62,11 +62,11 @@ typecheck: install ## run ty type checking
 PIP_AUDIT_ARGS ?=
 
 # The 'security' target performs security vulnerability scans.
-# 1. Runs pip-audit to check for known vulnerabilities in dependencies.
+# 1. Runs pip-audit via pip_audit_policy.py: fails on runtime dep CVEs, warns on tooling (pip/setuptools/wheel).
 # 2. Runs bandit to find common security issues in the source code.
 security: install ## run security scans (pip-audit and bandit)
 	@printf "${BLUE}[INFO] Running pip-audit for dependency vulnerabilities...${RESET}\n"
-	@${UVX_BIN} pip-audit ${PIP_AUDIT_ARGS}
+	@${UV_BIN} run python .rhiza/utils/pip_audit_policy.py ${PIP_AUDIT_ARGS}
 	@printf "${BLUE}[INFO] Running bandit security scan...${RESET}\n"
 	@${UVX_BIN} bandit -r ${SOURCE_FOLDER} -ll -q --ini .bandit
 

--- a/.rhiza/utils/pip_audit_policy.py
+++ b/.rhiza/utils/pip_audit_policy.py
@@ -1,0 +1,67 @@
+"""Run pip-audit with a tiered vulnerability policy.
+
+Fails the build for vulnerabilities in runtime dependencies.
+Warns (without failing) for tooling packages: pip, setuptools, wheel, distribute.
+Any extra arguments are forwarded to pip-audit (e.g. ``--ignore-vuln CVE-XXXX-YYYY``).
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess  # nosec B404
+import sys
+
+_RESET = "\033[0m"
+_RED = "\033[31m"
+_YELLOW = "\033[33m"
+_GREEN = "\033[32m"
+
+# Packages treated as build tooling — CVEs warn but do not fail CI.
+_TOOLING: frozenset[str] = frozenset({"pip", "setuptools", "wheel", "distribute"})
+
+
+def _vuln_ids(vuln: dict) -> str:  # type: ignore[type-arg]
+    """Return a human-readable string of all IDs for a vulnerability entry."""
+    ids = [vuln["id"]] + [a for a in vuln.get("aliases", []) if a != vuln["id"]]
+    return ", ".join(ids)
+
+
+def main() -> int:
+    """Run pip-audit and apply tiered vulnerability policy."""
+    uvx = shutil.which("uvx") or "uvx"
+    cmd = [uvx, "pip-audit", "--format", "json", *sys.argv[1:]]
+    proc = subprocess.run(cmd, capture_output=True, text=True)  # noqa: S603  # nosec B603
+
+    if proc.returncode == 0:
+        print(f"{_GREEN}[OK] pip-audit: no vulnerabilities found{_RESET}")
+        return 0
+
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        sys.stdout.write(proc.stdout)
+        sys.stderr.write(proc.stderr)
+        return proc.returncode
+
+    deps = data.get("dependencies", [])
+    tooling_vulns = [d for d in deps if d.get("vulns") and d["name"].lower() in _TOOLING]
+    runtime_vulns = [d for d in deps if d.get("vulns") and d["name"].lower() not in _TOOLING]
+
+    for dep in tooling_vulns:
+        for v in dep["vulns"]:
+            print(
+                f"{_YELLOW}[WARN] {dep['name']}=={dep['version']}: {_vuln_ids(v)} (tooling — not failing build){_RESET}"
+            )
+
+    if not runtime_vulns:
+        return 0
+
+    for dep in runtime_vulns:
+        for v in dep["vulns"]:
+            print(f"{_RED}[FAIL] {dep['name']}=={dep['version']}: {_vuln_ids(v)}{_RESET}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
…bilities

Replaces the hard-fail pip-audit call with a policy script that separates findings into tooling (pip, setuptools, wheel, distribute) and runtime deps. Tooling CVEs (e.g. CVE-2026-3219 in pip itself) print a warning and exit 0; runtime CVEs still fail the build.

## Summary

<!-- One or two sentences describing what this PR does and why. -->

Closes #<!-- issue number -->

## Changes

<!-- Bullet list of what changed. -->

-

## Testing

- [ ] `make test` passes locally
- [ ] `make fmt` has been run
- [ ] New tests added (or explain why not needed)

## Checklist

- [ ] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated if behaviour changed
- [ ] `make deptry` passes (no unused or missing dependencies)
