### PR TITLE
feat: introduce layered bundle/profile model with local-first bundles

### DIFF
--- a/.rhiza/ROADMAP.md
+++ b/.rhiza/ROADMAP.md
@@ -37,6 +37,7 @@ Rhiza aims to be the definitive solution for maintaining consistency and best pr
 - Marp presentation generation (`make presentation`, `make presentation-pdf`, `make presentation-serve`)
 - Template bundles system — 13 bundles: `core`, `github`, `gitlab`, `tests`, `marimo`, `book`, `docker`, `devcontainer`, `presentation`, `lfs`, `legal`, `renovate`, `gh-aw`
 - GitHub Agentic Workflows (`make gh-aw-*`, 10+ targets, 3 starter workflows, `docs/development/GH_AW.md`)
+- Layered bundle/profile model — local-first feature bundles, GitHub overlay bundles, three starter profiles (`local`, `github-project`, `gitlab-project`)
 
 ### v0.9.0 - Enhanced Template Management (Q2 2026)
 **Theme: Flexibility & Extensibility**

--- a/.rhiza/template-bundles.yml
+++ b/.rhiza/template-bundles.yml
@@ -1,23 +1,35 @@
 # Rhiza Template Bundle Definitions
 #
-# This file defines template bundles - pre-configured sets of files that can be
-# included in downstream projects by selecting templates instead of listing
-# individual file paths.
+# This file defines two layers of configuration:
+#
+# 1. bundles: atomic, file-owning building blocks.
+#    Every synced file belongs to a bundle. Feature bundles are local-first —
+#    they do not include hosted workflow files. GitHub Actions workflows for a
+#    feature live in a dedicated github-<feature> overlay bundle.
+#
+# 2. profiles: higher-level named presets that expand to a set of bundles.
+#    Profiles represent stable user intents (local-only, GitHub-hosted, etc.)
+#    and do not own files directly.
 #
 # Usage in downstream projects (.rhiza/template.yml):
 #
+#   # Profile-based (recommended — picks a sensible bundle set for your context):
+#   profiles:
+#     - local
+#
+#   # Bundle-based (advanced — full manual control):
 #   templates:
+#     - core
 #     - tests
-#     - docker
+#     - github
+#     - github-tests
+#
+#   # Mixed (profile plus extra bundles):
+#   profiles:
+#     - github-project
+#   templates:
 #     - marimo
-#
-# Instead of manually listing:
-#
-#   include: |
-#     .rhiza/make.d/test.mk
-#     pytest.ini
-#     docker/Dockerfile
-#     ...
+#     - github-marimo
 
 # Bundle Definitions
 bundles:
@@ -116,6 +128,8 @@ bundles:
     description: "VS Code DevContainer configuration for consistent development environments"
     standalone: true
     requires: []
+    recommends:
+      - github-devcontainer  # Add for GitHub-hosted DevContainer publishing
     files:
       # DevContainer configuration
       - .devcontainer
@@ -123,7 +137,16 @@ bundles:
       # Documentation
       - docs/development/DEVCONTAINER.md
 
-      # GitHub Actions workflows
+  # ============================================================================
+  # GITHUB-DEVCONTAINER - GitHub Actions workflow for DevContainer publishing
+  # ============================================================================
+  github-devcontainer:
+    description: "GitHub Actions workflow for DevContainer image publishing"
+    standalone: false
+    requires:
+      - github
+      - devcontainer
+    files:
       - .github/workflows/rhiza_devcontainer.yml
 
   # ============================================================================
@@ -133,6 +156,8 @@ bundles:
     description: "Docker containerization support for building and running containers"
     standalone: true
     requires: []
+    recommends:
+      - github-docker  # Add for GitHub-hosted Docker build and publish workflows
     files:
       # Docker configuration and files
       - docker
@@ -143,7 +168,16 @@ bundles:
       # Documentation
       - docs/development/DOCKER.md
 
-      # GitHub Actions workflows
+  # ============================================================================
+  # GITHUB-DOCKER - GitHub Actions workflow for Docker builds
+  # ============================================================================
+  github-docker:
+    description: "GitHub Actions workflow for Docker image building and publishing"
+    standalone: false
+    requires:
+      - github
+      - docker
+    files:
       - .github/workflows/rhiza_docker.yml
 
   # ============================================================================
@@ -195,10 +229,12 @@ bundles:
   # TESTS - Testing infrastructure with pytest, coverage, and type checking
   # ============================================================================
   tests:
-    description: "Testing infrastructure with pytest, coverage, and type checking"
+    description: "Local testing infrastructure with pytest, coverage, and type checking"
     standalone: true
     requires:
       - book
+    recommends:
+      - github-tests  # Add for GitHub-hosted CI workflows
     files:
       # Make targets and configuration
       - .rhiza/make.d/test.mk
@@ -210,8 +246,19 @@ bundles:
       - .rhiza/tests
       - docs/development/TESTS.md
 
-      # GitHub Actions workflows
+      # Semgrep config (local static analysis, not a workflow)
       - .rhiza/semgrep.yml
+
+  # ============================================================================
+  # GITHUB-TESTS - GitHub Actions workflows for test automation
+  # ============================================================================
+  github-tests:
+    description: "GitHub Actions workflows for test automation (CI, CodeQL, weekly runs)"
+    standalone: false
+    requires:
+      - github
+      - tests
+    files:
       - .github/workflows/rhiza_ci.yml
       - .github/workflows/rhiza_codeql.yml
       - .github/workflows/rhiza_weekly.yml
@@ -236,6 +283,8 @@ bundles:
     standalone: true
     requires:
       - book
+    recommends:
+      - github-marimo  # Add for GitHub-hosted notebook automation
     files:
       # Marimo configuration
       - .rhiza/make.d/marimo.mk
@@ -244,7 +293,16 @@ bundles:
       # Documentation
       - docs/development/MARIMO.md
 
-      # GitHub Actions workflows
+  # ============================================================================
+  # GITHUB-MARIMO - GitHub Actions workflow for Marimo notebooks
+  # ============================================================================
+  github-marimo:
+    description: "GitHub Actions workflow for Marimo notebook automation"
+    standalone: false
+    requires:
+      - github
+      - marimo
+    files:
       - .github/workflows/rhiza_marimo.yml
 
   # ============================================================================
@@ -261,11 +319,21 @@ bundles:
     recommends:
       - tests   # Optional: book includes coverage and test reports when tests are enabled
       - marimo  # Optional: book works better with notebook exports
+      - github-book  # Add for GitHub-hosted docs publishing
     files:
       # Book building configuration
       - .rhiza/make.d/book.mk
 
-      # GitHub Actions workflows
+  # ============================================================================
+  # GITHUB-BOOK - GitHub Actions workflow for documentation publishing
+  # ============================================================================
+  github-book:
+    description: "GitHub Actions workflow for documentation building and publishing"
+    standalone: false
+    requires:
+      - github
+      - book
+    files:
       - .github/workflows/rhiza_book.yml
 
   # ============================================================================
@@ -273,7 +341,7 @@ bundles:
   # ============================================================================
   gh-aw:
     description: "GitHub Agentic Workflows for AI-driven repository automation"
-    standalone: true
+    standalone: false
     requires: [github]
     recommends: [tests]
     notes: |
@@ -282,6 +350,7 @@ bundles:
       - Starter workflow templates
       - CI validation for lock file freshness
       - Documentation
+      Note: gh-aw is inherently GitHub-specific and has no local-only split.
     files:
       # Makefile extensions
       - .rhiza/make.d/github.mk
@@ -303,3 +372,78 @@ bundles:
 
       # Documentation
       - docs/development/GH_AW.md
+
+# ==============================================================================
+# PROFILE DEFINITIONS
+#
+# Profiles are higher-level named presets that expand to a set of bundles.
+# They represent stable user intents (local-only, GitHub-hosted, etc.) and do
+# not own files directly.
+#
+# Rules:
+#   - profiles reference bundles only, not raw file paths
+#   - selecting a profile is equivalent to selecting all its constituent bundles
+#   - users may combine profiles with additional manual bundle selection
+#
+# Usage in .rhiza/template.yml:
+#
+#   profiles:
+#     - local
+#
+#   # or combined with extra bundles:
+#   profiles:
+#     - github-project
+#   templates:
+#     - marimo
+#     - github-marimo
+# ==============================================================================
+profiles:
+
+  # ============================================================================
+  # LOCAL - Local-first development with no hosted workflows
+  # ============================================================================
+  local:
+    description: |
+      Local-first development setup with no hosted CI/CD workflow files.
+      Suitable for:
+        - experiments and research codebases
+        - early-stage projects not yet ready for hosted automation
+        - projects hosted privately or on platforms other than GitHub/GitLab
+      Includes core infrastructure, testing tooling, and documentation.
+      No .github/workflows/* files are synced.
+    bundles:
+      - core
+      - book
+      - tests
+
+  # ============================================================================
+  # GITHUB-PROJECT - Standard GitHub-hosted project
+  # ============================================================================
+  github-project:
+    description: |
+      Standard GitHub-hosted project with CI/CD and release automation.
+      Suitable for open-source or team projects hosted on GitHub.
+      Includes core infrastructure, testing tooling, documentation,
+      and GitHub Actions workflows for CI, CodeQL, release, and sync.
+    bundles:
+      - core
+      - github
+      - book
+      - github-book
+      - tests
+      - github-tests
+
+  # ============================================================================
+  # GITLAB-PROJECT - Standard GitLab-hosted project
+  # ============================================================================
+  gitlab-project:
+    description: |
+      Standard GitLab-hosted project with GitLab CI/CD pipelines.
+      Suitable for projects hosted on GitLab.com or a self-hosted GitLab instance.
+      Includes core infrastructure, testing tooling, documentation,
+      and GitLab CI pipelines. No .github/ files are synced.
+    bundles:
+      - core
+      - gitlab
+      - book
+      - tests

--- a/.rhiza/tests/structure/test_template_bundles.py
+++ b/.rhiza/tests/structure/test_template_bundles.py
@@ -3,8 +3,11 @@
 This file and its associated tests flow down via a SYNC action from the jebel-quant/rhiza repository
 (https://github.com/jebel-quant/rhiza).
 
-This module ensures that template bundle definitions in .rhiza/template-bundles.yml
-reference only files and folders that actually exist in the repository.
+This module ensures that:
+  - template bundle definitions reference only files that exist in the repository
+  - profile definitions reference only bundles that exist
+  - the local profile resolves to zero .github/workflows/* files
+  - bundle dependency references (requires/recommends) point to existing bundles
 """
 
 import pytest
@@ -32,6 +35,16 @@ class TestTemplateBundles:
             pytest.fail("Invalid template-bundles.yml format - missing 'bundles' key")
 
         return data
+
+    @pytest.fixture
+    def bundle_names(self, bundles_data):
+        """Return the set of all defined bundle names."""
+        return set(bundles_data["bundles"].keys())
+
+    @pytest.fixture
+    def profiles_data(self, bundles_data):
+        """Return the profiles section, or an empty dict if absent."""
+        return bundles_data.get("profiles", {})
 
     def test_bundles_file_exists_or_skip(self, bundles_file):
         """Test that template-bundles.yml exists, or skip if not present."""
@@ -87,3 +100,77 @@ class TestTemplateBundles:
                 for missing in missing_in_bundle:
                     error_msg += f"   - {missing}\n"
                 pytest.fail(error_msg)
+
+    def test_bundle_requires_reference_existing_bundles(self, bundles_data, bundle_names):
+        """Test that all requires and recommends entries point to existing bundles."""
+        bundles = bundles_data["bundles"]
+        errors = []
+
+        for bundle_name, bundle_config in bundles.items():
+            for field in ("requires", "recommends"):
+                for dep in bundle_config.get(field, []):
+                    if dep not in bundle_names:
+                        errors.append(f"  [{bundle_name}] {field}: '{dep}' does not exist")
+
+        if errors:
+            pytest.fail("\nBundle dependency references missing:\n" + "\n".join(errors))
+
+    def test_profiles_reference_existing_bundles(self, profiles_data, bundle_names):
+        """Test that all bundles listed in profiles exist."""
+        if not profiles_data:
+            pytest.skip("No profiles defined in template-bundles.yml")
+
+        errors = []
+        for profile_name, profile_config in profiles_data.items():
+            for bundle_ref in profile_config.get("bundles", []):
+                if bundle_ref not in bundle_names:
+                    errors.append(f"  [profile:{profile_name}] bundle '{bundle_ref}' does not exist")
+
+        if errors:
+            pytest.fail("\nProfile bundle references missing:\n" + "\n".join(errors))
+
+    def test_local_profile_contains_no_github_workflows(self, bundles_data, profiles_data):
+        """Test that the local profile resolves to no .github/workflows/* files.
+
+        The local profile is designed for projects that do not use hosted GitHub Actions.
+        If any bundle it references includes .github/workflows/ paths, the invariant is broken.
+        """
+        if not profiles_data:
+            pytest.skip("No profiles defined in template-bundles.yml")
+
+        if "local" not in profiles_data:
+            pytest.skip("No 'local' profile defined")
+
+        bundles = bundles_data["bundles"]
+        local_bundles = profiles_data["local"].get("bundles", [])
+        workflow_files = []
+
+        for bundle_name in local_bundles:
+            bundle_config = bundles.get(bundle_name, {})
+            for file_path in bundle_config.get("files", []):
+                if ".github/workflows/" in file_path:
+                    workflow_files.append(f"  [{bundle_name}] {file_path}")
+
+        if workflow_files:
+            pytest.fail(
+                "\nThe 'local' profile must not resolve to any .github/workflows/* files.\n"
+                "The following workflow files were found:\n" + "\n".join(workflow_files)
+            )
+
+    def test_each_profile_has_description(self, profiles_data):
+        """Test that every profile has a non-empty description."""
+        if not profiles_data:
+            pytest.skip("No profiles defined in template-bundles.yml")
+
+        missing = [name for name, cfg in profiles_data.items() if not cfg.get("description", "").strip()]
+        if missing:
+            pytest.fail(f"\nProfiles missing description: {missing}")
+
+    def test_each_profile_has_at_least_one_bundle(self, profiles_data):
+        """Test that every profile references at least one bundle."""
+        if not profiles_data:
+            pytest.skip("No profiles defined in template-bundles.yml")
+
+        empty = [name for name, cfg in profiles_data.items() if not cfg.get("bundles")]
+        if empty:
+            pytest.fail(f"\nProfiles with no bundles listed: {empty}")

--- a/README.md
+++ b/README.md
@@ -43,24 +43,35 @@ When you run `uvx rhiza init` or `uvx rhiza sync`, you are invoking the `rhiza-c
 
 ### How It Works
 
-Rhiza uses a simple configuration file (`.rhiza/template.yml`) to control which templates sync to your project. The recommended approach is to select **template bundles** by name — pre-configured sets of related files grouped by feature:
+Rhiza uses a simple configuration file (`.rhiza/template.yml`) to control which templates sync to your project. The recommended approach is to select a **profile** — a named preset for common project contexts — or to select individual **bundles** for full control:
 
 ```yaml
-# .rhiza/template.yml
+# .rhiza/template.yml — profile-based (recommended)
 repository: Jebel-Quant/rhiza
-ref: v0.7.1
+ref: v0.9.0
+
+profiles:
+  - github-project
+```
+
+```yaml
+# .rhiza/template.yml — bundle-based (advanced)
+repository: Jebel-Quant/rhiza
+ref: v0.9.0
 
 templates:
   - core
   - tests
   - github
+  - github-tests
   - docker
 ```
 
 **What you're seeing:**
 - **`repository`** - The upstream template source (**can be any repository, not just Rhiza!**)
-- **`ref`** - Which version tag/branch to sync from (e.g., `v0.7.1` or `main`)
-- **`templates`** - Template bundles to include by name (see [Available Template Bundles](#-available-template-bundles) below)
+- **`ref`** - Which version tag/branch to sync from (e.g., `v0.9.0` or `main`)
+- **`profiles`** - Named presets that expand to a set of bundles (see [Profiles](#profiles-recommended-starting-point) below)
+- **`templates`** - Individual template bundles for advanced or additional selection
 
 For advanced use cases you can still use explicit `include`/`exclude` file patterns alongside or instead of bundles:
 
@@ -160,26 +171,73 @@ For more information about the ADR format and how to create new records, see the
 - 🎤 **Presentations** - Generate slides from Markdown using Marp
 - 🐳 **Containerization** - Docker and Dev Container configurations
 
+### Profiles (Recommended Starting Point)
+
+Rhiza provides **profiles** — named presets that select a sensible set of bundles for common project contexts. Profiles are the recommended way to get started.
+
+| Profile | Description | Includes |
+|---------|-------------|---------|
+| `local` | Local-first development with no hosted CI/CD workflow files | `core`, `book`, `tests` |
+| `github-project` | GitHub-hosted project with CI/CD and release automation | `core`, `github`, `book`, `github-book`, `tests`, `github-tests` |
+| `gitlab-project` | GitLab-hosted project with GitLab CI/CD pipelines | `core`, `gitlab`, `book`, `tests` |
+
+Declare a profile in `.rhiza/template.yml`:
+
+```yaml
+repository: Jebel-Quant/rhiza
+ref: v0.9.0
+
+profiles:
+  - local
+```
+
+You can combine a profile with additional bundles:
+
+```yaml
+profiles:
+  - github-project
+templates:
+  - marimo
+  - github-marimo
+```
+
 ### Available Template Bundles
 
-Rhiza organises its templates into **bundles** — pre-configured sets of related files grouped by feature. Select the bundles you need in `.rhiza/template.yml`:
+Bundles are the atomic building blocks. Feature bundles are **local-first** — they do not include hosted workflow files. Platform overlay bundles (prefixed `github-` or `gitlab-`) add the CI/CD workflows for a given feature.
+
+**Feature bundles**
 
 | Bundle | Description | Requires | Standalone |
 |--------|-------------|----------|------------|
 | `core` | Core Rhiza infrastructure (Makefile, linting, docs) | — | ✅ |
-| `github` | GitHub Actions workflows for CI/CD | `core` | ❌ |
-| `tests` | Testing infrastructure with pytest, coverage, and type checking | — | ✅ |
-| `marimo` | Interactive Marimo notebooks for data exploration and documentation | `book` | ❌ |
+| `tests` | Local testing infrastructure with pytest, coverage, and type checking | `book` | ✅ |
+| `book` | Comprehensive documentation book (API docs, coverage, notebooks) | — | ✅ |
+| `marimo` | Interactive Marimo notebooks for data exploration and documentation | `book` | ✅ |
 | `benchmarks` | Performance benchmarking with pytest-benchmark and reporting | `tests` | ❌ |
-| `book` | Comprehensive documentation book (API docs, coverage, notebooks) | - | ✅ |
 | `docker` | Docker containerization support | — | ✅ |
 | `devcontainer` | VS Code DevContainer configuration | — | ✅ |
-| `gitlab` | GitLab CI/CD pipeline configuration | `core` | ❌ |
 | `presentation` | Presentation building using Marp | — | ✅ |
 | `lfs` | Git LFS (Large File Storage) support | — | ✅ |
 | `legal` | Legal and community files (LICENSE, CONTRIBUTING, CODE_OF_CONDUCT) | — | ✅ |
 | `renovate` | Renovate bot configuration for automated dependency updates | — | ✅ |
+
+**Platform bundles — GitHub**
+
+| Bundle | Description | Requires | Standalone |
+|--------|-------------|----------|------------|
+| `github` | Base GitHub repository automation (sync, release, dependabot) | `core` | ❌ |
+| `github-tests` | GitHub Actions workflows for test automation (CI, CodeQL, weekly) | `github`, `tests` | ❌ |
+| `github-book` | GitHub Actions workflow for documentation publishing | `github`, `book` | ❌ |
+| `github-marimo` | GitHub Actions workflow for Marimo notebook automation | `github`, `marimo` | ❌ |
+| `github-docker` | GitHub Actions workflow for Docker image building and publishing | `github`, `docker` | ❌ |
+| `github-devcontainer` | GitHub Actions workflow for DevContainer image publishing | `github`, `devcontainer` | ❌ |
 | `gh-aw` | GitHub Agentic Workflows for AI-driven repository automation | `github` | ❌ |
+
+**Platform bundles — GitLab**
+
+| Bundle | Description | Requires | Standalone |
+|--------|-------------|----------|------------|
+| `gitlab` | GitLab CI/CD pipeline configuration and workflows | `core` | ❌ |
 
 **Tip:** Bundles marked **Standalone: ❌** cannot be used alone and must be combined with the bundles listed in the *Requires* column.
 

--- a/docs/adr/0010-layered-bundle-profile-model.md
+++ b/docs/adr/0010-layered-bundle-profile-model.md
@@ -1,0 +1,145 @@
+# 10. Introduce a Layered Bundle and Profile Model
+
+Date: 2026-05-02
+
+## Status
+
+Accepted
+
+## Context
+
+Rhiza's bundle model (ADR-0006) maps named groups of files to a `files:` list and lets
+downstream projects select bundles by name. This works well for feature adoption, but
+over time a structural problem emerged:
+
+**Feature bundles conflate local tooling with hosted automation.**
+
+Several bundles that represent stand-alone local features also directly own
+`.github/workflows/*` files:
+
+- `tests` owns `rhiza_ci.yml`, `rhiza_codeql.yml`, `rhiza_weekly.yml`
+- `book` owns `rhiza_book.yml`
+- `marimo` owns `rhiza_marimo.yml`
+- `docker` owns `rhiza_docker.yml`
+- `devcontainer` owns `rhiza_devcontainer.yml`
+
+This makes it impossible to adopt, say, the testing tooling without also syncing GitHub
+Actions workflows into the project. Projects that are:
+
+- local-only experiments or research codebases
+- hosted on GitLab, not GitHub
+- private repositories that do not use GitHub Actions
+- early-stage projects not yet ready for hosted automation
+
+...have no clean way to express "give me the tooling but not the workflows". They must
+either accept unwanted files or manually add `exclude:` patterns in their
+`.rhiza/template.yml`.
+
+A second problem is discoverability at init time. There is no concept of a recommended
+starting set. Users running `rhiza init` see a flat list of bundle names with no
+guidance about which bundles are typically used together, what a sensible first setup
+looks like for their hosting context, or which combinations are known to work well.
+
+## Decision
+
+We will introduce a two-layer model separating file ownership from user-facing intent.
+
+### Layer 1: Bundles (unchanged role, refined boundaries)
+
+Bundles remain the atomic sync unit. Every synced file belongs to a bundle. Bundles
+own files via `files:`, declare hard dependencies via `requires:`, and declare soft
+suggestions via `recommends:`.
+
+**Key rule change**: feature bundles must be local-first. A feature bundle should
+include only the files needed to use that feature locally. Platform-specific automation
+files (`.github/workflows/*`, `.gitlab/`) belong in dedicated platform overlay bundles,
+not in the feature bundle itself.
+
+Concretely, GitHub workflow files are moved out of feature bundles and into new
+GitHub-specific overlay bundles:
+
+- `github-tests`: CI/CodeQL/weekly workflows for the `tests` feature
+- `github-book`: book publishing workflow for the `book` feature
+- `github-marimo`: Marimo notebook workflow for the `marimo` feature
+- `github-docker`: Docker build and publish workflow for the `docker` feature
+- `github-devcontainer`: DevContainer publish workflow for the `devcontainer` feature
+
+These overlay bundles have `standalone: false` and `requires:` the corresponding feature
+bundle and the `github` bundle.
+
+The existing `github` bundle keeps base GitHub repository automation: the sync and
+release workflows, `dependabot.yml`, issue and discussion templates, and secret scanning.
+
+### Layer 2: Profiles (new)
+
+A new top-level `profiles:` section in `template-bundles.yml` defines named presets that
+expand to a set of bundles.
+
+Rules:
+
+- profiles do not own files directly
+- profiles reference bundles only, not raw file paths
+- profiles represent stable, tested user intents rather than every possible combination
+- selecting a profile is equivalent to selecting all its constituent bundles
+- users may combine profile selection with additional manual bundle selection
+
+Initial profiles:
+
+- `local`: local-first development with no hosted workflow files
+- `github-project`: GitHub-hosted project with CI/CD and release automation
+- `gitlab-project`: GitLab-hosted project with GitLab CI pipelines
+
+### Config
+
+Downstream projects will be able to express profile selection in `.rhiza/template.yml`:
+
+```yaml
+repository: Jebel-Quant/rhiza
+ref: v0.9.0
+
+profiles:
+  - local
+
+templates:
+  - presentation    # any extra bundles beyond the profile
+```
+
+`rhiza-cli` is responsible for expanding profiles to bundles, merging manual bundle
+selections, deduplicating, and validating the result. The CLI implementation is a
+separate concern; this ADR covers the template repository structure and metadata.
+
+## Consequences
+
+### Positive
+
+- **Clean local mode**: Selecting the `local` profile installs no `.github/workflows/*`
+  files. Projects that do not use GitHub Actions get exactly what they need.
+- **Explicit platform separation**: It is now clear which files belong to the feature
+  and which belong to its GitHub automation. Bundle names reflect this — `tests` is
+  the feature; `github-tests` is the GitHub automation layer for that feature.
+- **Better onboarding**: Profiles give `rhiza init` a recommended starting path without
+  forcing users to understand every bundle upfront.
+- **Composable**: Power users retain full control by selecting individual bundles.
+  Profiles are an addition, not a replacement.
+- **GitLab parity**: The split makes it straightforward to produce matching
+  `gitlab-tests`, `gitlab-book`, and similar overlay bundles for GitLab CI in a
+  follow-on step, without restructuring feature bundles again.
+
+### Neutral
+
+- **More bundles**: The total bundle count increases as each feature bundle gets one or
+  more platform overlay siblings. The `template-bundles.yml` file grows. The existing
+  automated structure tests mitigate risk.
+- **Migration for existing consumers**: Downstream projects using bundles such as
+  `tests` today will need to explicitly add `github-tests` if they want the CI
+  workflows. The `github-project` profile bundles both, so profile users are unaffected.
+
+### Negative
+
+- **CLI changes required**: Profiles are defined in the template repository, but
+  consumed by `rhiza-cli`. Until the CLI supports the `profiles:` key in
+  `.rhiza/template.yml`, users can approximate local mode by selecting only local
+  bundles manually, or the CLI can expand profiles at `init` time and write the
+  resulting bundle list.
+- **Profile maintenance overhead**: Profiles must be kept current as bundles are added
+  or renamed. Automated tests enforce that every bundle referenced in a profile exists.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,6 +30,7 @@ Each ADR follows a consistent format defined in [0000-adr-template.md](../../.gi
 | [0007](0007-support-dual-cicd-github-and-gitlab.md) | Support Dual CI/CD with GitHub Actions and GitLab CI | Accepted | 2024-08-01 |
 | [0008](0008-use-marimo-for-interactive-notebooks.md) | Use Marimo for Interactive Notebooks | Accepted | 2025-03-01 |
 | [0009](0009-use-pre-commit-hooks-for-code-quality.md) | Use Pre-commit Hooks for Automated Code Quality Enforcement | Accepted | 2024-04-01 |
+| [0010](0010-layered-bundle-profile-model.md) | Introduce a Layered Bundle and Profile Model | Accepted | 2026-05-02 |
 
 ## Creating a New ADR
 

--- a/docs/reference/ARCHITECTURE.md
+++ b/docs/reference/ARCHITECTURE.md
@@ -416,21 +416,36 @@ post-release::   # Runs after make release
    - Named by **purpose**: `tests.txt`, `docs.txt`, `marimo.txt`, `tools.txt`
    - Not by library: ❌ `pytest.txt`, `pdoc.txt`
 
-### Template Bundle Naming
+### Template Bundle and Profile Naming
 
-Template bundles in `template-bundles.yml` follow these conventions:
+`template-bundles.yml` defines two layers: **bundles** (file-owning building blocks) and **profiles** (user-facing presets). See [ADR-0010](../adr/0010-layered-bundle-profile-model.md) for the rationale.
 
-1. **Lowercase singular**: `core`, `github`, `tests`, `marimo`, `book`
-2. **Domain-focused**: Named after the feature domain, not implementation
-   - ✅ `marimo` (notebooks)
-   - ✅ `book` (documentation)
-   - ❌ `notebooks`, `documentation-generation`
+#### Bundles
 
-3. **Bundle metadata**:
+1. **Lowercase, hyphen-separated**: `core`, `github`, `tests`, `github-tests`
+2. **Feature bundles are local-first**: they do not own hosted workflow files
+3. **Platform overlays use a `<platform>-` prefix**: `github-tests`, `github-book`, `gitlab`
+   - ✅ `github-tests` (GitHub Actions for the `tests` feature)
+   - ✅ `github-book` (GitHub Actions for the `book` feature)
+   - ❌ embedding workflow files directly in `tests` or `book`
+
+4. **Bundle metadata**:
    - `description` - Clear, concise explanation
    - `standalone` - Whether bundle can be used independently
    - `requires` - Hard dependencies on other bundles
    - `recommends` - Soft dependencies that enhance functionality
+
+#### Profiles
+
+1. **Lowercase, hyphen-separated**: `local`, `github-project`, `gitlab-project`
+2. **Intent-focused**: Named after the hosting and automation context, not the tool
+   - ✅ `local` (no hosted automation)
+   - ✅ `github-project` (standard GitHub project)
+   - ❌ `no-workflows`, `full-setup`
+
+3. **Profile metadata**:
+   - `description` - Clear summary of the intended context
+   - `bundles` - Ordered list of bundles this profile expands to
 
 ### Variable Naming
 


### PR DESCRIPTION
## Summary

- Refactors feature bundles (`tests`, `book`, `marimo`, `docker`, `devcontainer`) to be local-first by removing `.github/workflows/*` ownership from each
- Adds five GitHub overlay bundles (`github-tests`, `github-book`, `github-marimo`, `github-docker`, `github-devcontainer`) that pair with their feature bundle and the `github` bundle
- Introduces a new `profiles:` layer in `template-bundles.yml` with three starter profiles: `local`, `github-project`, `gitlab-project`

## Motivation

Projects that don't use GitHub Actions (local experiments, GitLab-hosted, early-stage) had no clean way to adopt Rhiza tooling without also syncing unwanted workflow files. This change makes `local` a first-class selection.

## Changes

| File | Change |
|------|--------|
| `.rhiza/template-bundles.yml` | Local-first bundle refactor, new overlay bundles, new `profiles:` section |
| `.rhiza/tests/structure/test_template_bundles.py` | Four new tests including `local` profile invariant (no `.github/workflows/*`) |
| `docs/adr/0010-layered-bundle-profile-model.md` | ADR recording the decision |
| `README.md` | Profiles table, split bundle tables by feature/GitHub/GitLab |
| `docs/reference/ARCHITECTURE.md` | Updated naming conventions for bundles and profiles |
| `docs/adr/README.md` | ADR-0010 added to index |
| `.rhiza/ROADMAP.md` | Profiles work noted |

## Testing

All 84 existing tests pass. 5 new structure tests added, all green.

## Notes for rhiza-cli

This PR lands the template-side of the model. A follow-up in `rhiza-cli` is needed to:
- parse `profiles:` in `.rhiza/template.yml`
- expand profiles to bundles before sync/validate
- update `rhiza init` to present profiles with descriptions