### PR TITLE
fix(docker): upgrade pip to 26.1 to fix CVE-2026-6357

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -63,7 +63,8 @@ RUN apt-get update && \
 # CVE-2026-1703 (pip: information disclosure via path traversal)
 # CVE-2026-23949 (jaraco.context: path traversal)
 # CVE-2026-24049 (wheel: privilege escalation)
-RUN pip install --no-cache-dir --upgrade pip==26.0 && \
+# CVE-2026-6357 (pip: arbitrary code execution or information disclosure via malicious wheel)
+RUN pip install --no-cache-dir --upgrade pip==26.1 && \
     pip install --no-cache-dir setuptools==82.0.0
 
 # Create non-root user


### PR DESCRIPTION
## Summary

- Bumps `pip` from `26.0` to `26.1` in the runtime Docker stage
- Adds `CVE-2026-6357` to the security comment block documenting the fix
- No other changes

## Security

**CVE-2026-6357** (MEDIUM) — Arbitrary code execution or information disclosure via malicious wheel package installation. Fixed in pip 26.1.

## Test plan

- [ ] Docker image builds successfully with updated pip version
- [ ] Trivy scan no longer reports CVE-2026-6357

🤖 Generated with [Claude Code](https://claude.com/claude-code)