### PR TITLE
feat: restore workflow stubs in feature bundles with path remapping

### DIFF
--- a/.rhiza/stubs/workflows/rhiza_book.yml
+++ b/.rhiza/stubs/workflows/rhiza_book.yml
@@ -1,0 +1,32 @@
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
+#
+# Workflow: Book
+# Purpose: This workflow builds and deploys comprehensive documentation for the project.
+#          It combines API documentation, test coverage reports, test results, and
+#          interactive notebooks into a single GitHub Pages site.
+#
+# Trigger: This workflow runs on every push to the main or master branch
+#
+# Components:
+#   - 📓 Process Marimo notebooks
+#   - 📖 Generate API documentation with pdoc
+#   - 🧪 Run tests and generate coverage reports
+#   - 🚀 Deploy combined documentation to GitHub Pages
+
+name: "(RHIZA) BOOK"
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  book:
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v0.11.2
+    secrets: inherit
+    permissions:
+      contents: read
+      pages: write
+      id-token: write

--- a/.rhiza/stubs/workflows/rhiza_ci.yml
+++ b/.rhiza/stubs/workflows/rhiza_ci.yml
@@ -1,0 +1,25 @@
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
+#
+# Workflow: Continuous Integration
+#
+# Purpose: Run tests on multiple Python versions, check dependencies, run
+#          pre-commit hooks, verify documentation coverage, validate the
+#          project, run security scans, and check license compliance.
+#
+# Trigger: On push and pull_request.
+
+name: (RHIZA) CI
+
+permissions:
+  contents: read
+  actions: read
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  ci:
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v0.11.1
+    secrets: inherit

--- a/.rhiza/stubs/workflows/rhiza_codeql.yml
+++ b/.rhiza/stubs/workflows/rhiza_codeql.yml
@@ -1,0 +1,46 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+# ******** IMPORTANT: GitHub Advanced Security Required ********
+# CodeQL is FREE for public repositories, but requires GitHub Advanced Security
+# (part of GitHub Enterprise) for private repositories.
+#
+# This workflow automatically:
+# - Runs on public repositories
+# - Skips on private repositories (unless Advanced Security is available)
+#
+# To control this behavior, set the CODEQL_ENABLED repository variable:
+# - Set to 'true' to force enable (if you have Advanced Security on private repos)
+# - Set to 'false' to disable entirely
+# - Leave unset for automatic behavior (recommended)
+#
+# To learn more about customizing this workflow, see the comments below
+#
+name: "(RHIZA) CODEQL"
+
+permissions:
+  security-events: write
+  packages: read
+  actions: read
+  contents: read
+
+on:
+  push:
+    branches: [ "main", "master" ]
+  pull_request:
+    branches: [ "main", "master" ]
+  schedule:
+    - cron: '27 1 * * 1'
+
+jobs:
+  codeql:
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v0.11.3
+    secrets: inherit

--- a/.rhiza/stubs/workflows/rhiza_marimo.yml
+++ b/.rhiza/stubs/workflows/rhiza_marimo.yml
@@ -1,0 +1,32 @@
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
+#
+# Workflow: Marimo Notebooks
+#
+# Purpose: This workflow discovers and executes all Marimo notebooks in the
+#          repository. It builds a dynamic matrix to run each notebook in
+#          parallel to surface errors early and keep notebooks reproducible.
+#
+# Trigger: This workflow runs on every push and on pull requests to main/master
+#          branches (including from forks)
+#
+# Components:
+#   - 🔎 Discover notebooks in book/marimo
+#   - 🧪 Run each notebook in parallel using a matrix strategy
+#   - ✅ Fail-fast disabled to report all failing notebooks
+
+name: "(RHIZA) MARIMO"
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  marimo:
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v0.11.2
+    secrets: inherit

--- a/.rhiza/stubs/workflows/rhiza_release.yml
+++ b/.rhiza/stubs/workflows/rhiza_release.yml
@@ -1,0 +1,84 @@
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
+#
+# Release Workflow for Python Packages with Optional Devcontainer Publishing
+#
+# This workflow implements a secure, maintainable release pipeline with distinct phases:
+#
+# 📋 Pipeline Phases:
+#   1. 🔍 Validate Tag - Check tag format and ensure release doesn't already exist
+#   2. 🏗️ Build - Build Python package with Hatch (if [build-system] is defined in pyproject.toml)
+#   3. 📦 Generate SBOM - Create Software Bill of Materials (CycloneDX format)
+#   4. 📝 Draft Release - Create draft GitHub release with build artifacts and SBOM
+#   5. 📄 Update CHANGELOG - Generate and commit CHANGELOG.md to the default branch
+#   6. 🚀 Publish to PyPI - Publish package using OIDC or custom feed
+#   7. 🐳 Publish Devcontainer - Build and publish devcontainer image (conditional)
+#   8. ✅ Finalize Release - Publish the GitHub release with links
+#
+# 📦 SBOM Generation:
+#   - Generated using CycloneDX format (industry standard for software supply chain security)
+#   - Creates both JSON and XML formats for maximum compatibility
+#   - SBOM attestations are created and stored (public repos only)
+#   - Attached to GitHub releases for transparency and compliance
+#   - Skipped if pyproject.toml doesn't exist
+#
+# 🐳 Devcontainer Publishing:
+#   - Only occurs when PUBLISH_DEVCONTAINER repository variable is set to "true"
+#   - Requires .devcontainer directory to exist
+#   - Uses the release tag (e.g., v1.2.3) as the image tag
+#   - Image name: {registry}/{owner}/{repository}/devcontainer
+#   - Registry defaults to ghcr.io (override with DEVCONTAINER_REGISTRY variable)
+#   - Config file: Always .devcontainer/devcontainer.json
+#   - Adds devcontainer image link to GitHub release notes
+#
+# 🚀 PyPI Publishing:
+#   - Skipped if no dist/ artifacts exist
+#   - Skipped if pyproject.toml contains "Private :: Do Not Upload"
+#   - Uses Trusted Publishing (OIDC) for PyPI (no stored credentials)
+#   - For custom feeds, use PYPI_REPOSITORY_URL and PYPI_TOKEN secrets
+#   - Adds PyPI/custom feed link to GitHub release notes
+#
+# 🔐 Security:
+#   - No PyPI credentials stored; relies on Trusted Publishing via GitHub OIDC
+#   - For custom feeds, PYPI_TOKEN secret is used with default username __token__
+#   - Container registry uses GITHUB_TOKEN for authentication
+#   - SLSA provenance attestations generated for build artifacts (public repos only)
+#   - SBOM attestations generated for supply chain transparency (public repos only)
+#
+# 📄 Requirements:
+#   - pyproject.toml with top-level version field (for Python packages)
+#   - Package registered on PyPI as Trusted Publisher (for PyPI publishing)
+#   - PUBLISH_DEVCONTAINER variable set to "true" (for devcontainer publishing)
+#   - .devcontainer/devcontainer.json file (for devcontainer publishing)
+#
+# ✅ To Trigger:
+#   Create and push a version tag:
+#     git tag v1.2.3
+#     git push origin v1.2.3
+#
+# 🎯 For repos without Python packages:
+#   The workflow gracefully skips Python-related steps if pyproject.toml doesn't exist.
+#
+# 🎯 For repos without devcontainers:
+#   The workflow gracefully skips devcontainer steps if PUBLISH_DEVCONTAINER is not
+#   set to "true" or .devcontainer directory doesn't exist.
+
+
+name: (RHIZA) RELEASE
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write       # Needed to create releases
+  id-token: write       # Needed for OIDC authentication with PyPI
+  packages: write       # Needed to publish devcontainer image
+  attestations: write   # Needed for SLSA provenance attestations (public repos only)
+
+jobs:
+  release:
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_release.yml@v0.11.4
+    secrets: inherit
+

--- a/.rhiza/stubs/workflows/rhiza_sync.yml
+++ b/.rhiza/stubs/workflows/rhiza_sync.yml
@@ -1,0 +1,35 @@
+name: (RHIZA) SYNC
+# Synchronizes the repository with its rhiza template.
+# - On Renovate/rhiza branch push: auto-commits synced files directly to the branch.
+# - On schedule/dispatch: opens a pull request with the synced changes.
+#
+# IMPORTANT: A PAT with 'workflow' scope (PAT_TOKEN) is required when workflow
+# files are modified. See .rhiza/docs/TOKEN_SETUP.md for setup instructions.
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  push:
+    branches:
+      - 'renovate/jebel-quant-rhiza-**'
+      - 'rhiza/**'
+    paths:
+      - '.rhiza/template.yml'
+  schedule:
+    - cron: '0 0 * * 1'  # Weekly on Monday
+  workflow_dispatch:
+    inputs:
+      create-pr:
+        description: "Create a pull request"
+        type: boolean
+        default: true
+
+jobs:
+  sync:
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_sync.yml@v0.11.3
+    with:
+      direct: ${{ github.event_name == 'push' }}
+      create-pr: ${{ github.event_name != 'push' && (github.event_name == 'schedule' || inputs.create-pr == true) }}
+    secrets: inherit

--- a/.rhiza/stubs/workflows/rhiza_weekly.yml
+++ b/.rhiza/stubs/workflows/rhiza_weekly.yml
@@ -1,0 +1,29 @@
+name: "(RHIZA) WEEKLY"
+
+# Runs weekly checks that are too slow or noisy for every push:
+#
+#   dep-compat-test  — Resolves all dependencies fresh (ignoring the lockfile)
+#                      and runs the full test suite. Catches newly-released
+#                      packages that break compatibility before Renovate picks
+#                      them up. Runs on schedule/dispatch only.
+#
+#   link-check       — Verifies that all hyperlinks in README.md are reachable.
+#                      Runs on schedule/dispatch only.
+
+permissions:
+  contents: read
+
+on:
+  #push:
+  #  branches: [main]
+  #  paths: [README.md]
+  #pull_request:
+  #  paths: [README.md]
+  schedule:
+    - cron: "0 8 * * 1"  # Every Monday at 08:00 UTC
+  workflow_dispatch:
+
+jobs:
+  weekly:
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v0.11.4
+    secrets: inherit

--- a/.rhiza/template-bundles.yml
+++ b/.rhiza/template-bundles.yml
@@ -4,8 +4,9 @@
 #
 # 1. bundles: atomic, file-owning building blocks.
 #    Every synced file belongs to a bundle. Feature bundles are local-first —
-#    they do not include hosted workflow files. GitHub Actions workflows for a
-#    feature live in a dedicated github-<feature> overlay bundle.
+#    they do not include hosted workflow files. GitHub Actions workflow stubs
+#    (thin wrappers that delegate to reusable workflows in jebel-quant/rhiza)
+#    live in dedicated github-<feature> overlay bundles.
 #
 # 2. profiles: higher-level named presets that expand to a set of bundles.
 #    Profiles represent stable user intents (local-only, GitHub-hosted, etc.)
@@ -72,7 +73,7 @@ bundles:
       - docs/assets                    # The rhiza logo
 
   github:
-    description: "GitHub repository configuration (actions, dependabot, templates)"
+    description: "GitHub repository configuration (actions, dependabot, templates, core workflows)"
     standalone: true
     requires: [core]
     files:
@@ -81,6 +82,14 @@ bundles:
       - .github/secret_scanning.yml
       - .github/ISSUE_TEMPLATE
       - .github/DISCUSSION_TEMPLATE
+
+      # GitHub Actions workflow stubs (synced to .github/workflows/ in downstream repos)
+      - source: .rhiza/stubs/workflows/rhiza_sync.yml
+        dest: .github/workflows/rhiza_sync.yml
+      - source: .rhiza/stubs/workflows/rhiza_release.yml
+        dest: .github/workflows/rhiza_release.yml
+      - source: .rhiza/stubs/workflows/rhiza_weekly.yml
+        dest: .github/workflows/rhiza_weekly.yml
 
   # ============================================================================
   # RENOVATE - Automated dependency updates
@@ -212,6 +221,19 @@ bundles:
       - .rhiza/semgrep.yml
 
   # ============================================================================
+  # GITHUB-TESTS - GitHub Actions workflows for CI
+  # ============================================================================
+  github-tests:
+    description: "GitHub Actions workflow stubs for CI (rhiza_ci, rhiza_codeql)"
+    standalone: true
+    requires: [tests]
+    files:
+      - source: .rhiza/stubs/workflows/rhiza_ci.yml
+        dest: .github/workflows/rhiza_ci.yml
+      - source: .rhiza/stubs/workflows/rhiza_codeql.yml
+        dest: .github/workflows/rhiza_codeql.yml
+
+  # ============================================================================
   # BENCHMARKS - Performance benchmarking with pytest-benchmark
   # ============================================================================
   benchmarks:
@@ -241,6 +263,17 @@ bundles:
       - docs/development/MARIMO.md
 
   # ============================================================================
+  # GITHUB-MARIMO - GitHub Actions workflow for Marimo notebooks
+  # ============================================================================
+  github-marimo:
+    description: "GitHub Actions workflow stub for Marimo notebook publishing"
+    standalone: true
+    requires: [marimo]
+    files:
+      - source: .rhiza/stubs/workflows/rhiza_marimo.yml
+        dest: .github/workflows/rhiza_marimo.yml
+
+  # ============================================================================
   # BOOK - Documentation book generation
   # ============================================================================
   book:
@@ -258,6 +291,17 @@ bundles:
     files:
       # Book building configuration
       - .rhiza/make.d/book.mk
+
+  # ============================================================================
+  # GITHUB-BOOK - GitHub Actions workflow for book/docs publishing
+  # ============================================================================
+  github-book:
+    description: "GitHub Actions workflow stub for book/docs publishing to GitHub Pages"
+    standalone: true
+    requires: [book]
+    files:
+      - source: .rhiza/stubs/workflows/rhiza_book.yml
+        dest: .github/workflows/rhiza_book.yml
 
   # ============================================================================
   # GH-AW - GitHub Agentic Workflows
@@ -324,7 +368,7 @@ profiles:
         - early-stage projects not yet ready for hosted automation
         - projects hosted privately or on platforms other than GitHub/GitLab
       Includes core infrastructure, testing tooling, and documentation.
-      No .github/workflows/* files are synced.
+      No GitHub Actions workflow stubs are synced.
     bundles:
       - book
       - tests
@@ -338,12 +382,15 @@ profiles:
       Standard GitHub-hosted project.
       Suitable for open-source or team projects hosted on GitHub.
       Includes core infrastructure, GitHub repository configuration,
-      testing tooling, documentation, and notebooks.
+      testing tooling, documentation, notebooks, and CI workflow stubs.
     bundles:
       - github
       - book
+      - github-book
       - tests
+      - github-tests
       - marimo
+      - github-marimo
 
   # ============================================================================
   # GITLAB-PROJECT - Standard GitLab-hosted project


### PR DESCRIPTION
## Summary

- Add 7 workflow stubs to `.rhiza/stubs/workflows/` — thin wrappers that delegate to the reusable workflows hosted in this repo via `workflow_call:`
- Restore the pre-v0.12.0 pattern of embedding stubs inside their feature bundles, using the new `{source, dest}` path remapping syntax from rhiza-cli (requires [rhiza-cli#rhizaCI](https://github.com/Jebel-Quant/rhiza-cli/pull/new/rhizaCI))
- Add `github-tests`, `github-marimo`, `github-book` overlay bundles
- `github-project` profile updated to include all three overlay bundles

## Bundle assignments

| Bundle | Stubs |
|---|---|
| `github` | `rhiza_sync`, `rhiza_release`, `rhiza_weekly` |
| `github-tests` | `rhiza_ci`, `rhiza_codeql` |
| `github-marimo` | `rhiza_marimo` |
| `github-book` | `rhiza_book` |

## Test plan

- [ ] `rhiza sync` on a downstream repo with `github-project` profile places stubs at `.github/workflows/` (not `.rhiza/stubs/workflows/`)
- [ ] `local` profile still syncs no workflow files
- [ ] Stubs call the correct versioned reusable workflow endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)