### PR TITLE
test: verify latest git tag matches pyproject.toml version

### DIFF
--- a/.rhiza/tests/structure/test_pyproject.py
+++ b/.rhiza/tests/structure/test_pyproject.py
@@ -13,15 +13,20 @@ Validates that pyproject.toml:
 - includes at least one Python version classifier
 - declares a [dependency-groups] test group containing pytest
 - declares a [dependency-groups] lint group
+- version matches the latest git tag (vX.Y.Z → X.Y.Z)
 """
 
 from __future__ import annotations
 
 import re
+import shutil
+import subprocess  # nosec B404
 import tomllib
 from pathlib import Path
 
 import pytest
+
+_GIT = shutil.which("git") or "/usr/bin/git"
 
 _SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+")
 _REQUIRED_PROJECT_FIELDS = ("name", "version", "description", "readme", "requires-python", "license", "authors")
@@ -182,3 +187,30 @@ class TestDependencyGroups:
     def test_lint_group_present(self, dependency_groups: dict) -> None:
         """A 'lint' dependency group must be declared."""
         assert "lint" in dependency_groups, "[dependency-groups] must include a 'lint' group"
+
+
+class TestGitTagVersion:
+    """Tests for harmony between the latest git tag and pyproject.toml version."""
+
+    @pytest.fixture(scope="class")
+    def latest_tag(self, root: Path) -> str:
+        """Return the latest semver git tag, or skip if none exist."""
+        result = subprocess.run(  # nosec B603
+            [_GIT, "tag", "--list", "v*", "--sort=-version:refname"],
+            capture_output=True,
+            text=True,
+            cwd=root,
+        )
+        tags = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+        if not tags:
+            pytest.skip("No version tags found in repository")
+        return tags[0]
+
+    def test_latest_tag_matches_pyproject_version(self, latest_tag: str, project: dict) -> None:
+        """The latest git tag (vX.Y.Z) must match [project].version in pyproject.toml."""
+        tag_version = latest_tag.lstrip("v")
+        pyproject_version = project.get("version", "")
+        assert tag_version == pyproject_version, (
+            f"Latest git tag {latest_tag!r} (→ {tag_version!r}) does not match "
+            f"[project].version {pyproject_version!r} in pyproject.toml"
+        )

--- a/bundles/tests/.rhiza/tests/structure/test_pyproject.py
+++ b/bundles/tests/.rhiza/tests/structure/test_pyproject.py
@@ -13,15 +13,20 @@ Validates that pyproject.toml:
 - includes at least one Python version classifier
 - declares a [dependency-groups] test group containing pytest
 - declares a [dependency-groups] lint group
+- version matches the latest git tag (vX.Y.Z → X.Y.Z)
 """
 
 from __future__ import annotations
 
 import re
+import shutil
+import subprocess  # nosec B404
 import tomllib
 from pathlib import Path
 
 import pytest
+
+_GIT = shutil.which("git") or "/usr/bin/git"
 
 _SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+")
 _REQUIRED_PROJECT_FIELDS = ("name", "version", "description", "readme", "requires-python", "license", "authors")
@@ -182,3 +187,30 @@ class TestDependencyGroups:
     def test_lint_group_present(self, dependency_groups: dict) -> None:
         """A 'lint' dependency group must be declared."""
         assert "lint" in dependency_groups, "[dependency-groups] must include a 'lint' group"
+
+
+class TestGitTagVersion:
+    """Tests for harmony between the latest git tag and pyproject.toml version."""
+
+    @pytest.fixture(scope="class")
+    def latest_tag(self, root: Path) -> str:
+        """Return the latest semver git tag, or skip if none exist."""
+        result = subprocess.run(  # nosec B603
+            [_GIT, "tag", "--list", "v*", "--sort=-version:refname"],
+            capture_output=True,
+            text=True,
+            cwd=root,
+        )
+        tags = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+        if not tags:
+            pytest.skip("No version tags found in repository")
+        return tags[0]
+
+    def test_latest_tag_matches_pyproject_version(self, latest_tag: str, project: dict) -> None:
+        """The latest git tag (vX.Y.Z) must match [project].version in pyproject.toml."""
+        tag_version = latest_tag.lstrip("v")
+        pyproject_version = project.get("version", "")
+        assert tag_version == pyproject_version, (
+            f"Latest git tag {latest_tag!r} (→ {tag_version!r}) does not match "
+            f"[project].version {pyproject_version!r} in pyproject.toml"
+        )


### PR DESCRIPTION
## Summary

Stacks on top of #1133 — adds a test that verifies the latest `v*` git tag matches `[project].version` in `pyproject.toml`, complementing the release monotonicity guard introduced there.

## Changes

- Added `TestGitTagVersion` class to `.rhiza/tests/structure/test_pyproject.py` (and its synced bundle copy) with:
  - `latest_tag` fixture — runs `git tag --list 'v*' --sort=-version:refname`, skips gracefully if no tags exist
  - `test_latest_tag_matches_pyproject_version` — strips `v` prefix from tag and compares to `[project].version`
- Added `subprocess` / `shutil` imports and `_GIT` resolver (via `shutil.which`) to support git operations

Test skips automatically in repos with no version tags (new projects, shallow clones).

## Depends on

- #1133

🤖 Generated with [Claude Code](https://claude.com/claude-code)