### PR TITLE
Fail fast on native Windows shells and run Windows CI tests under bash

### DIFF
--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -117,6 +117,7 @@ jobs:
       - name: Run tests
         env:
           UV_EXTRA_INDEX_URL: ${{ secrets.UV_EXTRA_INDEX_URL }}
+        shell: bash
         run: |
           make test
 

--- a/.rhiza/rhiza.mk
+++ b/.rhiza/rhiza.mk
@@ -10,6 +10,37 @@ ifndef MAKE_VERSION
 $(error GNU Make is required. macOS ships BSD make — install GNU Make with: brew install make)
 endif
 
+# Require a working POSIX shell.
+# Recipes use POSIX shell syntax (mkdir -p, printf, [ ... ], curl | sh). GNU Make
+# runs recipes with sh when it finds one on PATH -- even when make itself was
+# launched from PowerShell or cmd -- so e.g. CI on windows-latest (which ships
+# Git's sh.exe) works fine. Only when no POSIX shell is found does make fall back
+# to cmd.exe, where the recipes fail on the first non-cmd line with errors like:
+#   process_begin: CreateProcess(NULL, # Ensure ... folder exists, ...) failed.
+# So probe the shell make actually uses rather than guessing from the OS: run a
+# POSIX command and require its output. Guarded by $(OS) so the probe only runs
+# on Windows (no subprocess cost on Linux/macOS/WSL, where the shell is POSIX).
+ifeq ($(OS),Windows_NT)
+ifneq ($(shell printf POSIX),POSIX)
+define RHIZA_WINDOWS_SHELL_ERROR
+
+  This project's Makefile requires a POSIX shell, but make could not find one
+  and fell back to cmd.exe, which is not supported.
+
+  Run 'make' from an environment that provides a POSIX shell, e.g.:
+    - WSL (recommended):  https://learn.microsoft.com/windows/wsl/install
+    - Git Bash:           bundled with Git for Windows (https://git-scm.com/download/win)
+
+  Tip: if 'sh.exe' (from Git for Windows) is on your PATH, make will use it
+  automatically even from PowerShell or cmd.
+
+  See README.md > Prerequisites for details.
+
+endef
+$(error $(RHIZA_WINDOWS_SHELL_ERROR))
+endif
+endif
+
 # Colours for pretty output in help messages
 BLUE := \033[36m
 BOLD := \033[1m

--- a/bundles/core/.rhiza/rhiza.mk
+++ b/bundles/core/.rhiza/rhiza.mk
@@ -10,6 +10,37 @@ ifndef MAKE_VERSION
 $(error GNU Make is required. macOS ships BSD make — install GNU Make with: brew install make)
 endif
 
+# Require a working POSIX shell.
+# Recipes use POSIX shell syntax (mkdir -p, printf, [ ... ], curl | sh). GNU Make
+# runs recipes with sh when it finds one on PATH -- even when make itself was
+# launched from PowerShell or cmd -- so e.g. CI on windows-latest (which ships
+# Git's sh.exe) works fine. Only when no POSIX shell is found does make fall back
+# to cmd.exe, where the recipes fail on the first non-cmd line with errors like:
+#   process_begin: CreateProcess(NULL, # Ensure ... folder exists, ...) failed.
+# So probe the shell make actually uses rather than guessing from the OS: run a
+# POSIX command and require its output. Guarded by $(OS) so the probe only runs
+# on Windows (no subprocess cost on Linux/macOS/WSL, where the shell is POSIX).
+ifeq ($(OS),Windows_NT)
+ifneq ($(shell printf POSIX),POSIX)
+define RHIZA_WINDOWS_SHELL_ERROR
+
+  This project's Makefile requires a POSIX shell, but make could not find one
+  and fell back to cmd.exe, which is not supported.
+
+  Run 'make' from an environment that provides a POSIX shell, e.g.:
+    - WSL (recommended):  https://learn.microsoft.com/windows/wsl/install
+    - Git Bash:           bundled with Git for Windows (https://git-scm.com/download/win)
+
+  Tip: if 'sh.exe' (from Git for Windows) is on your PATH, make will use it
+  automatically even from PowerShell or cmd.
+
+  See README.md > Prerequisites for details.
+
+endef
+$(error $(RHIZA_WINDOWS_SHELL_ERROR))
+endif
+endif
+
 # Colours for pretty output in help messages
 BLUE := \033[36m
 BOLD := \033[1m

--- a/tests/api/test_ci_workflow.py
+++ b/tests/api/test_ci_workflow.py
@@ -94,3 +94,13 @@ def test_ci_cache_keys_match_audit_policy(root):
         pre_commit_cache_step["with"]["key"]
         == "${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}"
     )
+
+
+def test_ci_test_job_runs_make_under_bash(root):
+    """CI test job must run make under bash for Windows compatibility."""
+    with (root / WORKFLOW_PATH).open(encoding="utf-8") as fh:
+        workflow = yaml.safe_load(fh)
+
+    run_tests_step = next(step for step in workflow["jobs"]["test"]["steps"] if step.get("name") == "Run tests")
+    assert run_tests_step["shell"] == "bash"
+    assert "make test" in run_tests_step["run"]


### PR DESCRIPTION
## Summary

Add an early make-time guard that fails fast with a helpful message when Rhiza is run from native Windows shells without a POSIX environment, and update the Windows CI test step to invoke `make test` under `bash` so the supported workflow keeps passing.

## Changes

- Add a Windows-only guard in `.rhiza/rhiza.mk` and `bundles/core/.rhiza/rhiza.mk` that stops early under `cmd.exe` / PowerShell and points users to WSL or Git Bash.
- Keep the mirrored `rhiza.mk` files in sync so downstream consumers receive the same fail-fast behavior.
- Update `.github/workflows/rhiza_ci.yml` so the Windows `Run tests` step uses `shell: bash` before running `make test`, matching the repository’s POSIX shell requirement.
- Add a regression test in `tests/api/test_ci_workflow.py` that verifies the CI test step runs `make test` under `bash`.

## Testing

- [ ] `make test` passes locally
- [x] `make fmt` has been run
- [x] New tests added (or explain why not needed)

## Checklist

- [x] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated if behaviour changed
- [ ] `make deptry` passes (no unused or missing dependencies)