### PR TITLE
docs: fix dead links, stale bundle docs, and add missing CONFIG.md

### DIFF
--- a/.github/actions/configure-git-auth/README.md
+++ b/.github/actions/configure-git-auth/README.md
@@ -76,5 +76,4 @@ jobs:
 
 ## See Also
 
-- [PRIVATE_PACKAGES.md](../../../.rhiza/docs/PRIVATE_PACKAGES.md) - Complete guide to using private packages
-- [TOKEN_SETUP.md](../../../.rhiza/docs/TOKEN_SETUP.md) - Setting up Personal Access Tokens
+- [GitHub Actions Configuration](../../../bundles/github/.github/CONFIG.md) - Setting up Personal Access Tokens and workflow secrets

--- a/.rhiza/template-bundles.yml
+++ b/.rhiza/template-bundles.yml
@@ -109,10 +109,10 @@ bundles:
     requires: []
 
   # ============================================================================
-  # PRESENTATION - Presentation building with reveal.js
+  # PRESENTATION - Presentation building with Marp
   # ============================================================================
   presentation:
-    description: "Presentation building using reveal.js and Marimo"
+    description: "Presentation slides built from PRESENTATION.md using Marp"
     standalone: true
     requires: []
     recommends:

--- a/.rhiza/tests/stress/README.md
+++ b/.rhiza/tests/stress/README.md
@@ -140,4 +140,3 @@ def test_concurrent_operation(stress_iterations, concurrent_workers):
 - [Main Test README](../README.md) - Overview of all test categories
 - [Integration Tests](../integration/) - End-to-end workflow tests
 - [Benchmarks](../../../tests/benchmarks/) - Performance benchmarks
-- [Property Tests](../../../tests/property/) - Property-based tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,17 +47,25 @@ The virtual environment is managed automatically by `make` and `uv run`. No manu
 
 ### Template Bundles
 
-The core abstraction is the **bundle** — a named group of configuration files. The 13 bundles are defined in `.rhiza/template-bundles.yml`:
+The core abstraction is the **bundle** — a named group of configuration files. All bundles are defined in `.rhiza/template-bundles.yml` (the authoritative list) and fall into three groups:
+
+**Feature bundles** — one per capability:
 
 - `core` (required): Makefiles, linting, base infrastructure
 - `tests`: pytest, coverage, type checking
-- `github`: GitHub Actions workflows
-- `gitlab`: GitLab CI
+- `benchmarks`: pytest-benchmark infrastructure and reporting
+- `github`: GitHub repository configuration (actions, dependabot, core workflows)
+- `gitlab`: GitLab CI/CD pipeline configuration and core workflows
 - `docker`, `devcontainer`: containerisation
 - `marimo`: interactive notebooks
 - `book`: documentation with MkDocs + zensical
 - `presentation`: Marp slides
+- `paper`: LaTeX paper compilation
 - `lfs`, `legal`, `renovate`, `gh-aw`: miscellaneous tooling
+
+**Platform overlay bundles** — CI workflow stubs that pair a feature with a platform: `github-tests`, `github-book`, `github-marimo`, `github-docker`, `github-devcontainer`, `github-paper`, `gitlab-tests`, `gitlab-book`, `gitlab-marimo`.
+
+**Meta-bundles** — curated compositions of other bundles: `github-project`, `gitlab-project`, `local` (no hosted CI).
 
 ### Modular Makefile System
 

--- a/README.md
+++ b/README.md
@@ -298,10 +298,10 @@ For a full step-by-step tutorial covering init, bundle selection, first material
 Keep your templates up-to-date with automated sync workflows:
 
 - Configure `.rhiza/template.yml` to define which templates to include/exclude
-- The `.github/workflows/sync.yml` workflow runs on schedule or manually
+- The `.github/workflows/rhiza_sync.yml` workflow runs on schedule or manually
 - Creates pull requests with template updates
 
-For GitHub Token configuration and details, see the [GitHub Actions documentation](.github/CONFIG.md).
+For GitHub Token configuration and details, see the [GitHub Actions documentation](bundles/github/.github/CONFIG.md).
 
 ### What to Expect After Integration
 
@@ -359,7 +359,7 @@ See [docs/guides/CUSTOMIZATION.md](docs/guides/CUSTOMIZATION.md) for worked exam
 - **Makefile conflicts**: Merge targets with existing build scripts
 - **Pre-commit failures**: Run `make fmt` to fix formatting issues
 - **Workflow failures**: Check Python version in `.python-version` and `pyproject.toml`
-- **Dev container issues**: See [.devcontainer/README.md](.devcontainer/README.md)
+- **Dev container issues**: See [.devcontainer/README.md](bundles/devcontainer/.devcontainer/README.md)
 
 ## 📋 Available Tasks
 
@@ -575,7 +575,7 @@ cp -r .gitlab/ /path/to/your/project/
 cp .gitlab-ci.yml /path/to/your/project/
 ```
 
-For complete GitLab setup instructions, configuration variables, and troubleshooting, see **[.gitlab/README.md](.gitlab/README.md)**.
+For complete GitLab setup instructions, configuration variables, and troubleshooting, see **[.gitlab/README.md](bundles/gitlab/.gitlab/README.md)**.
 
 ## 📋 Project Maintainability
 

--- a/bundles/devcontainer/docs/development/VSCODE_EXTENSIONS.md
+++ b/bundles/devcontainer/docs/development/VSCODE_EXTENSIONS.md
@@ -1,6 +1,6 @@
 # VSCode Extensions
 
-This document describes the VSCode extensions that are automatically configured when using the [Dev Container](.devcontainer/) or [GitHub Codespaces](https://github.com/features/codespaces) environment.
+This document describes the VSCode extensions that are automatically configured when using the [Dev Container](../../.devcontainer/) or [GitHub Codespaces](https://github.com/features/codespaces) environment.
 
 ## Extension Overview
 
@@ -94,7 +94,7 @@ The project configures extensions in `.devcontainer/devcontainer.json` to provid
 - Build problem matching
 - IntelliSense for make targets
 
-**Why included**: This project uses a comprehensive [Makefile](../Makefile) as its primary task runner (`make install`, `make test`, `make fmt`, etc.). This extension makes it easy to discover and run available tasks.
+**Why included**: This project uses a comprehensive [Makefile](../../Makefile) as its primary task runner (`make install`, `make test`, `make fmt`, etc.). This extension makes it easy to discover and run available tasks.
 
 ### AI Assistance
 
@@ -200,7 +200,7 @@ Alternatively, create `.vscode/extensions.json` with:
 ## Related Documentation
 
 - [DevContainer Configuration](DEVCONTAINER.md) - Dev container setup and usage
-- [Makefile Customisation](../.rhiza/make.d/README.md) - Task automation and customization
+- [Makefile Customisation](../../.rhiza/make.d/README.md) - Task automation and customization
 - [Marimo Documentation](MARIMO.md) - Interactive notebooks and Marimo integration
 - [Quick Reference](../guides/QUICK_REFERENCE.md) - Common development tasks
 

--- a/bundles/gh-aw/docs/development/GH_AW.md
+++ b/bundles/gh-aw/docs/development/GH_AW.md
@@ -619,7 +619,6 @@ engine: copilot
 
 ### Rhiza-Specific
 
-- [Integration Plan](GH_AW_INTEGRATION.md) - Technical implementation details
 - [Extending Rhiza](../guides/EXTENDING_RHIZA.md) - Creating custom template bundles
 - [Quick Reference](../guides/QUICK_REFERENCE.md) - Rhiza command reference
 

--- a/bundles/github/.github/CONFIG.md
+++ b/bundles/github/.github/CONFIG.md
@@ -1,0 +1,66 @@
+# GitHub Actions Configuration
+
+This document describes the secrets used by the Rhiza-provided GitHub Actions workflows
+(`.github/workflows/rhiza_*.yml`) and how to configure them.
+
+## PAT_TOKEN (template sync)
+
+The sync workflow (`.github/workflows/rhiza_sync.yml`) keeps your repository up to date with the
+upstream Rhiza template. It commits the synced files directly to a branch or opens a pull request.
+
+By default the workflow authenticates with the automatic `github.token`. That token **cannot push
+changes to files under `.github/workflows/`** — GitHub rejects such pushes unless the token has the
+`workflow` scope. Since template syncs regularly update workflow files, you should configure a
+Personal Access Token (PAT) with that scope and store it as a repository secret named `PAT_TOKEN`.
+
+If `PAT_TOKEN` is not configured, the workflow falls back to `github.token` and prints a warning.
+Syncs that touch only non-workflow files will still succeed.
+
+### Creating the token
+
+**Fine-grained PAT** (recommended):
+
+1. Go to **Settings → Developer settings → Fine-grained tokens → Generate new token**
+   (<https://github.com/settings/personal-access-tokens/new>).
+2. Restrict **Repository access** to the repository (or repositories) using Rhiza.
+3. Under **Repository permissions**, grant:
+   - **Contents**: Read and write
+   - **Workflows**: Read and write
+   - **Pull requests**: Read and write (needed for the scheduled sync-PR mode)
+4. Generate the token and copy it.
+
+**Classic PAT** (alternative):
+
+1. Go to **Settings → Developer settings → Tokens (classic) → Generate new token**.
+2. Select the `repo` and `workflow` scopes.
+3. Generate the token and copy it.
+
+### Storing the secret
+
+In the repository that consumes Rhiza:
+
+1. Go to **Settings → Secrets and variables → Actions → New repository secret**.
+2. Name: `PAT_TOKEN`
+3. Value: the token created above.
+
+Or with the GitHub CLI:
+
+```bash
+gh secret set PAT_TOKEN
+```
+
+A PAT expires; when sync pushes start failing with a `refusing to allow ... workflow` error,
+regenerate the token and update the secret.
+
+## Release workflow secrets (optional)
+
+The release workflow (`.github/workflows/rhiza_release.yml`) supports additional secrets, all
+optional depending on which release features you use:
+
+| Secret | Purpose |
+| --- | --- |
+| `PYPI_TOKEN` | Publish the built package to PyPI. Not needed when using trusted publishing (OIDC). |
+| `GH_PAT` | Git authentication for installing private dependencies during the release build. |
+| `UV_EXTRA_INDEX_URL` | Extra package index URL (with credentials) for private dependencies. |
+
+`GITHUB_TOKEN` is provided automatically by GitHub Actions and needs no configuration.

--- a/bundles/presentation/docs/development/PRESENTATION.md
+++ b/bundles/presentation/docs/development/PRESENTATION.md
@@ -29,7 +29,7 @@ style: |
 
 **Reusable Configuration Templates for Modern Python Projects**
 
-![w:200](assets/rhiza-logo.svg)
+![w:200](.rhiza/assets/rhiza-logo.svg)
 
 *ῥίζα (ree-ZAH) — Ancient Greek for "root"*
 
@@ -587,4 +587,4 @@ make marimo                    # Interactive notebooks
 
 **Get Started**: [github.com/jebel-quant/rhiza](https://github.com/jebel-quant/rhiza)
 
-![w:300](assets/rhiza-logo.svg)
+![w:300](.rhiza/assets/rhiza-logo.svg)

--- a/bundles/tests/.rhiza/tests/stress/README.md
+++ b/bundles/tests/.rhiza/tests/stress/README.md
@@ -140,4 +140,3 @@ def test_concurrent_operation(stress_iterations, concurrent_workers):
 - [Main Test README](../README.md) - Overview of all test categories
 - [Integration Tests](../integration/) - End-to-end workflow tests
 - [Benchmarks](../../../tests/benchmarks/) - Performance benchmarks
-- [Property Tests](../../../tests/property/) - Property-based tests

--- a/docs/guides/CUSTOMIZATION.md
+++ b/docs/guides/CUSTOMIZATION.md
@@ -179,6 +179,6 @@ For more details on customizing the documentation, see [docs/BOOK.md](BOOK.md).
 
 ## 📖 Complete Documentation
 
-For detailed information about extending and customizing the Makefile system, see [.rhiza/make.d/README.md](../.rhiza/make.d/README.md).
+For detailed information about extending and customizing the Makefile system, see [.rhiza/make.d/README.md](../../.rhiza/make.d/README.md).
 
 For a tutorial walkthrough of these extension points — including the rule about template-managed files, the exclude mechanism, and forking the template for your organisation — see [rhiza-education Lesson 10: Customising Safely](https://github.com/Jebel-Quant/rhiza-education/blob/main/lessons/10-customizing-safely.md).

--- a/docs/guides/EXTENDING_RHIZA.md
+++ b/docs/guides/EXTENDING_RHIZA.md
@@ -1075,7 +1075,7 @@ For more details on customizing the documentation book, see [BOOK.md](BOOK.md).
 
 - [Quick Reference](QUICK_REFERENCE.md) - Command quick reference
 - [Tools Reference](../reference/TOOLS_REFERENCE.md) - Comprehensive tool documentation
-- [Makefile Cookbook](.rhiza/make.d/README.md) - Make recipes
+- [Makefile Cookbook](../../.rhiza/make.d/README.md) - Make recipes
 - [rhiza-education Lesson 10: Customising Safely](https://github.com/Jebel-Quant/rhiza-education/blob/main/lessons/10-customizing-safely.md) - Tutorial overview of extension mechanisms and the template-managed file rule
 
 ---

--- a/docs/ops/CHANGELOG_GUIDE.md
+++ b/docs/ops/CHANGELOG_GUIDE.md
@@ -458,6 +458,6 @@ After implementing changelog enhancements:
 **Last Updated**: February 2026
 
 For related documentation:
-- [ROADMAP.md](../ROADMAP.md) - Project roadmap
-- [CONTRIBUTING.md](../CONTRIBUTING.md) - Contribution guidelines
-- [.github/workflows/rhiza_release.yml](../.github/workflows/rhiza_release.yml) - Release workflow
+- `ROADMAP.md` - Project roadmap (create one in your repository root)
+- [CONTRIBUTING.md](../../.rhiza/CONTRIBUTING.md) - Contribution guidelines
+- [.github/workflows/rhiza_release.yml](../../.github/workflows/rhiza_release.yml) - Release workflow

--- a/docs/ops/PROJECT_BOARD.md
+++ b/docs/ops/PROJECT_BOARD.md
@@ -290,6 +290,6 @@ For inspiration, see the Rhiza project board:
 **Last Updated**: February 2026
 
 For related documentation:
-- [ROADMAP.md](../ROADMAP.md) - Project roadmap and planned features
+- `ROADMAP.md` - Project roadmap and planned features (create one in your repository root)
 - [TECHNICAL_DEBT.md](TECHNICAL_DEBT.md) - Known limitations and debt items
-- [CONTRIBUTING.md](../CONTRIBUTING.md) - Contribution guidelines
+- [CONTRIBUTING.md](../../.rhiza/CONTRIBUTING.md) - Contribution guidelines

--- a/docs/ops/TECHNICAL_DEBT.md
+++ b/docs/ops/TECHNICAL_DEBT.md
@@ -270,11 +270,11 @@ Found technical debt? Help us improve:
 4. Suggest potential solutions
 5. Link to relevant code sections
 
-See [CONTRIBUTING.md](../CONTRIBUTING.md) for general contribution guidelines.
+See [CONTRIBUTING.md](../../.rhiza/CONTRIBUTING.md) for general contribution guidelines.
 
 ---
 
 **Last Updated**: February 2026  
 **Next Review**: March 2026
 
-For planned features and improvements, see [ROADMAP.md](../ROADMAP.md).
+For planned features and improvements, see `ROADMAP.md` (if your project keeps one).

--- a/docs/reference/TOOLS_REFERENCE.md
+++ b/docs/reference/TOOLS_REFERENCE.md
@@ -808,8 +808,8 @@ PYTHON_VERSION = 3.12
 
 - [Quick Reference](../guides/QUICK_REFERENCE.md) - Condensed command reference
 - [Extending Rhiza](../guides/EXTENDING_RHIZA.md) - Extending and customizing Rhiza
-- [Contributing Guide](../CONTRIBUTING.md) - How to contribute
-- [README](../README.md) - Project overview
+- [Contributing Guide](../../.rhiza/CONTRIBUTING.md) - How to contribute
+- [README](../../README.md) - Project overview
 
 ---
 

--- a/docs/security/SECURITY_TESTING.md
+++ b/docs/security/SECURITY_TESTING.md
@@ -329,4 +329,4 @@ Before merging any PR with code changes:
 
 ## Contact
 
-For security vulnerabilities, please see [SECURITY.md](SECURITY.md) for our responsible disclosure process.
+For security vulnerabilities, please see [SECURITY.md](../../SECURITY.md) for our responsible disclosure process.

--- a/tests/docs/__init__.py
+++ b/tests/docs/__init__.py
@@ -1,0 +1,1 @@
+"""Documentation consistency tests."""

--- a/tests/docs/test_doc_consistency.py
+++ b/tests/docs/test_doc_consistency.py
@@ -1,0 +1,154 @@
+"""Tests that documentation stays consistent with the repository state.
+
+Two gated invariants:
+
+1. Every relative markdown link (and image) resolves to an existing file or
+   directory — either in this repository's layout or in the downstream layout
+   produced by syncing bundles (each ``bundles/<name>/`` directory maps onto
+   the downstream repository root).
+2. Every bundle defined in ``.rhiza/template-bundles.yml`` is documented in
+   CLAUDE.md, so the bundle overview cannot silently drift as bundles are
+   added or renamed.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+_ROOT = Path(__file__).resolve().parents[2]
+_BUNDLES_DIR = _ROOT / "bundles"
+_TEMPLATE_BUNDLES = _ROOT / ".rhiza" / "template-bundles.yml"
+
+_EXCLUDED_DIRS = {
+    ".git",
+    ".venv",
+    ".idea",
+    ".ruff_cache",
+    ".pytest_cache",
+    ".benchmarks",
+    "__pycache__",
+    "node_modules",
+    "_tests",
+}
+
+# Link targets that are intentionally unresolvable (e.g. placeholders inside
+# document templates that downstream authors are expected to replace).
+_PLACEHOLDER_TARGETS = {"XXXX-title.md"}
+
+# Templates that are copied elsewhere before use: deployment-relative file
+# path -> directory its links actually resolve from. PRESENTATION.md is
+# rendered by Marp from the repository root (see .rhiza/make.d/presentation.mk).
+_DEPLOYED_DIR_OVERRIDES = {
+    Path("docs/development/PRESENTATION.md"): Path(),
+}
+
+_LINK_RE = re.compile(r"\[[^\]]*\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
+_FENCED_CODE_RE = re.compile(r"```.*?```", re.DOTALL)
+_INLINE_CODE_RE = re.compile(r"`[^`\n]*`")
+_HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+_SCHEME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
+
+
+def _markdown_files() -> list[Path]:
+    """Return all markdown files in the repository outside excluded directories."""
+    return sorted(
+        path for path in _ROOT.rglob("*.md") if not _EXCLUDED_DIRS.intersection(path.relative_to(_ROOT).parts)
+    )
+
+
+def _deployment_rel_path(md_file: Path) -> Path:
+    """Return the file's path relative to its deployment root.
+
+    Files under bundles/<name>/ are synced to the downstream repository root,
+    so their deployment path drops the leading bundles/<name>/ prefix. All
+    other files deploy where they live.
+    """
+    rel = md_file.relative_to(_ROOT)
+    if rel.parts[0] == "bundles" and len(rel.parts) > 2:
+        return Path(*rel.parts[2:])
+    return rel
+
+
+def _normalised_target(rel_dir: Path, target: str) -> Path | None:
+    """Resolve a link target against its file's directory, relative to the deployment root.
+
+    Returns None when the target escapes the deployment root (such links can
+    never resolve in a downstream repository).
+    """
+    path = target.split("#", 1)[0].split("?", 1)[0]
+    if not path:
+        return None
+    candidate = path.lstrip("/") if path.startswith("/") else os.path.normpath(str(rel_dir / path))
+    if candidate.startswith(".."):
+        return None
+    return Path(candidate)
+
+
+def _relative_link_cases() -> list[tuple[str, Path, str]]:
+    """Collect (label, markdown file, link target) for every relative link."""
+    cases: list[tuple[str, Path, str]] = []
+    for md_file in _markdown_files():
+        text = md_file.read_text(encoding="utf-8", errors="replace")
+        text = _FENCED_CODE_RE.sub("", text)
+        text = _INLINE_CODE_RE.sub("", text)
+        text = _HTML_COMMENT_RE.sub("", text)
+        for match in _LINK_RE.finditer(text):
+            target = match.group(1)
+            if _SCHEME_RE.match(target) or target.startswith(("#", "<")):
+                continue
+            if target.split("#", 1)[0] in _PLACEHOLDER_TARGETS:
+                continue
+            label = f"{md_file.relative_to(_ROOT)} -> {target}"
+            cases.append((label, md_file, target))
+    return cases
+
+
+_LINK_CASES = _relative_link_cases()
+
+
+def _load_bundle_names() -> list[str]:
+    """Return all bundle names defined in template-bundles.yml."""
+    config = yaml.safe_load(_TEMPLATE_BUNDLES.read_text(encoding="utf-8"))
+    return sorted(config["bundles"])
+
+
+class TestMarkdownLinks:
+    """Verify that every relative markdown link points at something that exists."""
+
+    @pytest.mark.parametrize(
+        ("label", "md_file", "target"),
+        _LINK_CASES,
+        ids=[case[0] for case in _LINK_CASES],
+    )
+    def test_relative_link_resolves(self, label: str, md_file: Path, target: str) -> None:
+        """Each relative link must resolve in the repo or in any bundle's downstream layout."""
+        rel = _deployment_rel_path(md_file)
+        rel_dir = _DEPLOYED_DIR_OVERRIDES.get(rel, rel.parent)
+        resolved = _normalised_target(rel_dir, target)
+        assert resolved is not None, f"{label}: link escapes the repository root"
+
+        roots = [_ROOT, *(d for d in sorted(_BUNDLES_DIR.iterdir()) if d.is_dir())]
+        assert any((root / resolved).exists() for root in roots), (
+            f"{label}: target does not exist in this repository or in any bundle's downstream layout"
+        )
+
+    def test_links_were_collected(self) -> None:
+        """Guard against the link scanner silently collecting nothing."""
+        assert len(_LINK_CASES) > 50, "expected to find a substantial number of relative links"
+
+
+class TestBundleDocumentation:
+    """Verify that the bundle documentation tracks the authoritative bundle list."""
+
+    @pytest.mark.parametrize("bundle_name", _load_bundle_names())
+    def test_bundle_documented_in_claude_md(self, bundle_name: str) -> None:
+        """Every bundle defined in template-bundles.yml must be mentioned in CLAUDE.md."""
+        claude_md = (_ROOT / "CLAUDE.md").read_text(encoding="utf-8")
+        assert f"`{bundle_name}`" in claude_md, (
+            f"bundle '{bundle_name}' is defined in .rhiza/template-bundles.yml but not documented in CLAUDE.md"
+        )


### PR DESCRIPTION
## Summary

Closes the documentation-accuracy gap found during a repo review: fixes all dead links, adds the missing `CONFIG.md`, and — most importantly — adds the **test gates that make this class of defect impossible to reintroduce**.

### Commit 1 — fix the defects found by hand

- **Add `bundles/github/.github/CONFIG.md`** — the sync workflow shipped to downstream projects warns *"See .github/CONFIG.md for setup instructions"* when `PAT_TOKEN` is missing, but that file never existed. The new doc covers the `workflow`-scoped PAT, fine-grained/classic setup, secret storage, and the optional release-workflow secrets. Bundles sync whole directories, so downstream projects receive it automatically.
- **Fix three dead README links** and the stale `sync.yml` → `rhiza_sync.yml` reference.
- **Update CLAUDE.md bundle section** — 27 bundles in three groups instead of the stale list of 13.
- **Correct `presentation` bundle description** — Marp, not reveal.js.

### Commit 2 — gate the invariant (`tests/docs/test_doc_consistency.py`)

Two new gated invariants, in the repo's usual style (parametrized pytest, one case per link/bundle):

1. **Every relative markdown link must resolve** — either in this repository or in the downstream layout any bundle produces (`bundles/<name>/` maps onto the downstream repo root, and `PRESENTATION.md` resolves from the repo root where Marp renders it). ADR template placeholders are allowlisted.
2. **Every bundle in `template-bundles.yml` must be documented in CLAUDE.md**, so the bundle overview can no longer drift as bundles are added or renamed.

The new gate immediately caught **13 more genuine dead links**, all fixed in the same commit: wrong relative depths across `docs/` (links to `SECURITY.md`, `Makefile`, `.rhiza/make.d/`, `CONTRIBUTING.md`, `README.md`, `rhiza_release.yml`), links to files that exist nowhere (`GH_AW_INTEGRATION.md`, `tests/property/`, `PRIVATE_PACKAGES.md`, `TOKEN_SETUP.md` — the latter repointed to the new `CONFIG.md`), de-linked `ROADMAP.md` references (a downstream convention, not a shipped file), and `PRESENTATION.md` logo paths now using `.rhiza/assets/` shipped by `core`. Bundle-owned copies were updated in lockstep with their root counterparts.

## Test plan

- [x] `uv run pytest tests/ -m "not stress"` — **559 passed** (126 new doc-consistency cases)
- [x] Pre-commit hooks pass on all changed files (ruff, markdownlint, bandit, yaml, rhiza config checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)