### PR TITLE
ci: add concurrency groups and enforce precise action pinning

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -20,6 +20,11 @@ on:
     paths:
       - .github/workflows/copilot-setup-steps.yml
 
+# Cancel superseded in-progress runs of this workflow for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   copilot-setup-steps:
     runs-on: ubuntu-latest

--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -10,6 +10,11 @@
 
 name: "(RHIZA) BENCHMARK"
 
+# Cancel superseded in-progress runs of this workflow for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -23,6 +23,11 @@ on:
       - master
   workflow_call:
 
+# Cancel superseded in-progress runs of this workflow for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   book:
     if: ${{ !github.event.repository.fork }}
@@ -61,7 +66,7 @@ jobs:
           uv sync --all-extras --all-groups --frozen
 
       - name: Cache MkDocs plugin cache
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: .cache/plugin/
           key: mkdocs-plugin-${{ runner.os }}-${{ hashFiles('mkdocs.yml', 'uv.lock', 'pyproject.toml') }}

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -11,6 +11,11 @@
 
 name: "(RHIZA) CI"
 
+# Cancel superseded in-progress runs of this workflow for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   actions: read
@@ -107,7 +112,7 @@ jobs:
           token: ${{ secrets.GH_PAT }}
 
       - name: Cache uv artifacts
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: ~/.cache/uv
           key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}
@@ -123,7 +128,7 @@ jobs:
 
       - name: Upload coverage report
         if: matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: coverage-report
           path: _tests/coverage.xml
@@ -232,7 +237,7 @@ jobs:
           token: ${{ secrets.GH_PAT }}
 
       - name: Cache pre-commit environments
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: ~/.cache/pre-commit
           key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
@@ -354,7 +359,7 @@ jobs:
           uv run --with pip-licenses pip-licenses --format markdown --output-file LICENSES.md
 
       - name: Upload LICENSES.md
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: LICENSES.md
           path: LICENSES.md

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -22,6 +22,11 @@ on:
     - cron: '27 1 * * 1'
   workflow_call:
 
+# Cancel superseded in-progress runs of this workflow for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/rhiza_devcontainer.yml
+++ b/.github/workflows/rhiza_devcontainer.yml
@@ -50,6 +50,11 @@ on:
 
   workflow_call:
 
+# Cancel superseded in-progress runs of this workflow for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   packages: write
@@ -130,7 +135,7 @@ jobs:
           echo "sanitized_tag=$SANITIZED_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Build Devcontainer Image
-        uses: devcontainers/ci@v0.3
+        uses: devcontainers/ci@v0.3.1900000450
         if: steps.check.outputs.exists == 'true'
         with:
           configFile: .devcontainer/devcontainer.json

--- a/.github/workflows/rhiza_docker.yml
+++ b/.github/workflows/rhiza_docker.yml
@@ -12,6 +12,11 @@
 
 name: "(RHIZA) DOCKER"
 
+# Cancel superseded in-progress runs of this workflow for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   security-events: write
@@ -97,7 +102,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results to GitHub Security
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@v4.36.0
         if: always() && steps.check_dockerfile.outputs.docker_present == 'true'
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/rhiza_gh-aw-validate.yml
+++ b/.github/workflows/rhiza_gh-aw-validate.yml
@@ -12,6 +12,11 @@
 
 name: "(RHIZA) VALIDATE AGENTIC WORKFLOWS"
 
+# Cancel superseded in-progress runs of this workflow for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -29,7 +34,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Install gh-aw extension
         id: install-gh-aw

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -17,6 +17,11 @@
 
 name: "(RHIZA) MARIMO"
 
+# Cancel superseded in-progress runs of this workflow for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/rhiza_paper.yml
+++ b/.github/workflows/rhiza_paper.yml
@@ -26,6 +26,11 @@ on:
   workflow_dispatch:
   workflow_call:
 
+# Cancel superseded in-progress runs of this workflow for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
 

--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -91,6 +91,12 @@ on:
       PYPI_TOKEN:
         required: false
 
+# Queue runs instead of cancelling: a release or sync must never be
+# interrupted mid-publish or mid-push.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write       # Needed to create releases
   id-token: write       # Needed for OIDC authentication with PyPI
@@ -276,7 +282,7 @@ jobs:
 
       - name: Generate SLSA provenance attestations
         if: steps.buildable.outputs.buildable == 'true' && github.event.repository.private == false
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@v4.1.0
         with:
           subject-path: dist/*
 
@@ -393,7 +399,7 @@ jobs:
       # repository-url and password only used for custom feeds, not for PyPI with OIDC
       - name: Publish to PyPI
         if: ${{ steps.check_dist.outputs.should_publish == 'true' }}
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@v1.14.0
         with:
           packages-dir: dist/
           skip-existing: true
@@ -543,7 +549,7 @@ jobs:
 
       - name: Build and Publish Devcontainer Image
         if: steps.check_publish.outputs.should_publish == 'true'
-        uses: devcontainers/ci@v0.3
+        uses: devcontainers/ci@v0.3.1900000450
         with:
           configFile: .devcontainer/devcontainer.json
           push: always

--- a/.github/workflows/rhiza_sync.yml
+++ b/.github/workflows/rhiza_sync.yml
@@ -14,6 +14,12 @@
 
 name: "(RHIZA) SYNC"
 
+# Queue runs instead of cancelling: a release or sync must never be
+# interrupted mid-publish or mid-push.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -15,6 +15,11 @@
 
 name: "(RHIZA) WEEKLY"
 
+# Cancel superseded in-progress runs of this workflow for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -119,7 +124,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
 
       - name: Check links in README.md
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@v2.8.0
         with:
           args: >-
             --verbose

--- a/bundles/gh-aw/.github/workflows/copilot-setup-steps.yml
+++ b/bundles/gh-aw/.github/workflows/copilot-setup-steps.yml
@@ -20,6 +20,11 @@ on:
     paths:
       - .github/workflows/copilot-setup-steps.yml
 
+# Cancel superseded in-progress runs of this workflow for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   copilot-setup-steps:
     runs-on: ubuntu-latest
@@ -32,12 +37,12 @@ jobs:
           lfs: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v7.6.0
         with:
           version: "0.11.16"
 
       - name: Configure git auth for private packages
-        uses: ./.github/actions/configure-git-auth
+        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v0.18.8
         with:
           token: ${{ secrets.GH_PAT }}
 

--- a/bundles/gh-aw/.github/workflows/rhiza_gh-aw-validate.yml
+++ b/bundles/gh-aw/.github/workflows/rhiza_gh-aw-validate.yml
@@ -12,6 +12,11 @@
 
 name: "(RHIZA) VALIDATE AGENTIC WORKFLOWS"
 
+# Cancel superseded in-progress runs of this workflow for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -28,7 +33,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Install gh-aw extension
         id: install-gh-aw

--- a/bundles/github-book/.github/workflows/rhiza_book.yml
+++ b/bundles/github-book/.github/workflows/rhiza_book.yml
@@ -22,6 +22,11 @@ on:
       - main
       - master
 
+# Cancel superseded in-progress runs of this workflow for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   book:
     uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v0.18.7

--- a/bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml
+++ b/bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml
@@ -10,6 +10,11 @@
 
 name: (RHIZA) DEVCONTAINER
 
+# Cancel superseded in-progress runs of this workflow for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   packages: write

--- a/bundles/github-docker/.github/workflows/rhiza_docker.yml
+++ b/bundles/github-docker/.github/workflows/rhiza_docker.yml
@@ -10,6 +10,11 @@
 
 name: "(RHIZA) DOCKER"
 
+# Cancel superseded in-progress runs of this workflow for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   security-events: write

--- a/bundles/github-marimo/.github/workflows/rhiza_marimo.yml
+++ b/bundles/github-marimo/.github/workflows/rhiza_marimo.yml
@@ -17,6 +17,11 @@
 
 name: "(RHIZA) MARIMO"
 
+# Cancel superseded in-progress runs of this workflow for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/bundles/github-paper/.github/workflows/rhiza_paper.yml
+++ b/bundles/github-paper/.github/workflows/rhiza_paper.yml
@@ -10,6 +10,11 @@
 
 name: "(RHIZA) PAPER"
 
+# Cancel superseded in-progress runs of this workflow for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
 

--- a/bundles/github-tests/.github/workflows/rhiza_benchmark.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_benchmark.yml
@@ -10,6 +10,11 @@
 
 name: "(RHIZA) BENCHMARK"
 
+# Cancel superseded in-progress runs of this workflow for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/bundles/github-tests/.github/workflows/rhiza_ci.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_ci.yml
@@ -11,6 +11,11 @@
 
 name: "(RHIZA) CI"
 
+# Cancel superseded in-progress runs of this workflow for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   actions: read

--- a/bundles/github-tests/.github/workflows/rhiza_codeql.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_codeql.yml
@@ -13,6 +13,11 @@
 
 name: "(RHIZA) CODEQL"
 
+# Cancel superseded in-progress runs of this workflow for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   security-events: write
   packages: read

--- a/bundles/github/.github/workflows/rhiza_release.yml
+++ b/bundles/github/.github/workflows/rhiza_release.yml
@@ -102,6 +102,12 @@ on:
       PYPI_TOKEN:
         required: false
 
+# Queue runs instead of cancelling: a release or sync must never be
+# interrupted mid-publish or mid-push.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write       # Needed to create releases
   id-token: write       # Needed for OIDC authentication with PyPI
@@ -207,7 +213,7 @@ jobs:
           version: "0.11.16"
 
       - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v0.15.2
+        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v0.18.8
         with:
           token: ${{ secrets.GH_PAT }}
 
@@ -287,7 +293,7 @@ jobs:
 
       - name: Generate SLSA provenance attestations
         if: steps.buildable.outputs.buildable == 'true' && github.event.repository.private == false
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@v4.1.0
         with:
           subject-path: dist/*
 
@@ -404,7 +410,7 @@ jobs:
       # repository-url and password only used for custom feeds, not for PyPI with OIDC
       - name: Publish to PyPI
         if: ${{ steps.check_dist.outputs.should_publish == 'true' }}
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@v1.14.0
         with:
           packages-dir: dist/
           skip-existing: true
@@ -554,7 +560,7 @@ jobs:
 
       - name: Build and Publish Devcontainer Image
         if: steps.check_publish.outputs.should_publish == 'true'
-        uses: devcontainers/ci@v0.3
+        uses: devcontainers/ci@v0.3.1900000450
         with:
           configFile: .devcontainer/devcontainer.json
           push: always

--- a/bundles/github/.github/workflows/rhiza_sync.yml
+++ b/bundles/github/.github/workflows/rhiza_sync.yml
@@ -14,6 +14,12 @@
 
 name: "(RHIZA) SYNC"
 
+# Queue runs instead of cancelling: a release or sync must never be
+# interrupted mid-publish or mid-push.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write

--- a/bundles/github/.github/workflows/rhiza_weekly.yml
+++ b/bundles/github/.github/workflows/rhiza_weekly.yml
@@ -13,6 +13,11 @@
 
 name: "(RHIZA) WEEKLY"
 
+# Cancel superseded in-progress runs of this workflow for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/tests/api/test_workflow_hygiene.py
+++ b/tests/api/test_workflow_hygiene.py
@@ -1,0 +1,111 @@
+"""Tests that gate workflow hygiene: concurrency groups and precise action pins.
+
+Rhiza-specific: covers both rhiza's own workflows (.github/workflows/) and the
+workflow stubs shipped to downstream projects (bundles/*/.github/workflows/).
+Lives in tests/, not .rhiza/tests/, so it does not sync downstream.
+
+Two invariants:
+
+1. Every workflow declares a top-level ``concurrency`` block so superseded
+   runs are cancelled instead of wasting CI minutes. Release and sync
+   workflows are the exception: they queue (``cancel-in-progress: false``)
+   because they must never be interrupted mid-publish or mid-push.
+2. Every ``uses:`` reference is pinned to an exact version — a full
+   ``vX.Y.Z``-style tag or a 40-character commit SHA — so upgrades only
+   happen through reviewed dependency-update PRs. Local actions (``./...``)
+   are exempt.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+# Workflows that must queue rather than cancel in-progress runs.
+_QUEUE_WORKFLOWS = {"rhiza_release.yml", "rhiza_sync.yml"}
+
+# Exact tag (v1.2.3, optionally deeper like v0.3.1900000450) or full commit SHA.
+_PRECISE_REF_RE = re.compile(r"@(v?\d+(\.\d+){2,}|[0-9a-f]{40})$")
+
+
+def _workflow_files() -> list[Path]:
+    """Return every workflow file, rhiza's own and bundle-shipped stubs.
+
+    Generated files (*.lock.yml, compiled from gh-aw .md sources) are excluded:
+    their content is owned by the gh-aw compiler, not by hand.
+    """
+    patterns = (".github/workflows/*.yml", "bundles/*/.github/workflows/*.yml")
+    return sorted(path for pattern in patterns for path in _ROOT.glob(pattern) if not path.name.endswith(".lock.yml"))
+
+
+_WORKFLOWS = _workflow_files()
+_IDS = [str(p.relative_to(_ROOT)) for p in _WORKFLOWS]
+
+
+def _load(path: Path) -> dict:
+    """Load a workflow YAML file and return the parsed document."""
+    with path.open(encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def _uses_refs(workflow: dict) -> list[str]:
+    """Return every ``uses:`` reference in a workflow (job-level and step-level)."""
+    refs: list[str] = []
+    for job in (workflow.get("jobs") or {}).values():
+        if "uses" in job:
+            refs.append(job["uses"])
+        for step in job.get("steps") or []:
+            if "uses" in step:
+                refs.append(step["uses"])
+    return refs
+
+
+class TestWorkflowConcurrency:
+    """Every workflow must manage concurrency explicitly."""
+
+    @pytest.mark.parametrize("workflow_file", _WORKFLOWS, ids=_IDS)
+    def test_has_concurrency_group(self, workflow_file: Path) -> None:
+        """Each workflow must declare a top-level concurrency group."""
+        workflow = _load(workflow_file)
+        concurrency = workflow.get("concurrency")
+        assert isinstance(concurrency, dict), (
+            f"{workflow_file.name}: missing top-level 'concurrency' block — "
+            f"superseded runs will pile up instead of being cancelled or queued"
+        )
+        assert "group" in concurrency, f"{workflow_file.name}: concurrency block has no 'group'"
+
+    @pytest.mark.parametrize("workflow_file", _WORKFLOWS, ids=_IDS)
+    def test_cancel_in_progress_policy(self, workflow_file: Path) -> None:
+        """Release/sync workflows queue; everything else cancels superseded runs."""
+        concurrency = _load(workflow_file).get("concurrency") or {}
+        expected = workflow_file.name not in _QUEUE_WORKFLOWS
+        assert concurrency.get("cancel-in-progress") is expected, (
+            f"{workflow_file.name}: cancel-in-progress must be {expected} "
+            f"({'cancel superseded runs' if expected else 'a release or sync must never be interrupted'})"
+        )
+
+
+class TestActionPinning:
+    """Every action reference must be pinned to an exact version."""
+
+    @pytest.mark.parametrize("workflow_file", _WORKFLOWS, ids=_IDS)
+    def test_uses_refs_are_precisely_pinned(self, workflow_file: Path) -> None:
+        """All uses: refs must carry an exact vX.Y.Z tag or a full commit SHA."""
+        imprecise = [
+            ref
+            for ref in _uses_refs(_load(workflow_file))
+            if not ref.startswith("./") and not _PRECISE_REF_RE.search(ref)
+        ]
+        assert not imprecise, (
+            f"{workflow_file.name}: imprecisely pinned actions {imprecise} — "
+            f"pin to an exact vX.Y.Z tag or full commit SHA"
+        )
+
+    def test_workflows_were_collected(self) -> None:
+        """Guard against the collector silently matching nothing."""
+        assert len(_WORKFLOWS) >= 20, "expected to collect rhiza and bundle workflows"


### PR DESCRIPTION
## Summary

Plan item **A** of the 10-across-the-board plan (CI/CD 8 → 10). Both invariants land with their test gate, so they cannot regress.

### A1 — Concurrency groups (26 workflow files)

Every workflow — rhiza's own and the bundle-shipped stubs — now declares:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

Superseded runs for the same ref are cancelled instead of piling up. **Exception:** `rhiza_release.yml` and `rhiza_sync.yml` use `cancel-in-progress: false` — a release or sync must never be interrupted mid-publish or mid-push; new runs queue instead. Workflow-level concurrency is ignored when a reusable workflow runs via `workflow_call`, so downstream repos are covered by the stubs, which carry the block too.

### A2 — Precise action pinning

All `uses:` refs normalized to exact tags: `checkout@v6` → `v6.0.2`, `upload-artifact@v7` → `v7.0.1`, `cache@v5` → `v5.0.5`, `attest-build-provenance@v4` → `v4.1.0`, `upload-sarif@v4` → `v4.36.0`, `devcontainers/ci@v0.3` → `v0.3.1900000450`, `lychee-action@v2` → `v2.8.0`, `pypa/gh-action-pypi-publish@release/v1` → `v1.14.0`. Renovate/dependabot keep these current; precision makes upgrades reviewable.

Two genuine staleness bugs fixed along the way:

- `bundles/github/.github/workflows/rhiza_release.yml` still pinned `configure-git-auth@v0.15.2` while the root copy is on `v0.18.8`.
- The gh-aw bundle's `copilot-setup-steps.yml` referenced the action by **local path** (`./.github/actions/configure-git-auth`), which doesn't exist in downstream repos — the root copy was fixed to a remote versioned ref in 78c0a0f but the bundle source was missed. Both copies are now byte-identical.

### The gate — `tests/api/test_workflow_hygiene.py` (79 cases)

- Every workflow (excluding generated `*.lock.yml`) must declare a `concurrency` group, with `cancel-in-progress` matching the release/sync queue policy.
- Every `uses:` ref must be an exact `vX.Y.Z` tag or full commit SHA (local `./` actions exempt).

## Test plan

- [x] `uv run pytest tests/ -m "not stress"` — **638 passed** (79 new hygiene cases)
- [x] actionlint, workflow jsonschema validation, and all other pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)