### PR TITLE
security: add gitleaks, remove piped installers, widen shellcheck

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,7 +68,12 @@ repos:
     rev: v0.11.0.1
     hooks:
       - id: shellcheck
-        files: '\.rhiza/utils/.*\.sh$'
+        files: '\.sh$'
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
 
   - repo: https://github.com/astral-sh/uv-pre-commit
     rev: 0.11.16

--- a/.rhiza/make.d/agentic.mk
+++ b/.rhiza/make.d/agentic.mk
@@ -31,13 +31,18 @@ install-copilot:  ## checks for copilot and prompts to install
 	elif [ -x "${INSTALL_DIR}/copilot" ]; then \
 	  printf "${SUCCESS}[INFO] copilot already installed in ${INSTALL_DIR}, skipping install.${RESET}\n"; \
 	else \
-		printf "${YELLOW}[WARN] GitHub Copilot CLI not found in ${INSTALL_DIR}.${RESET}\n"; \
-		printf "${BLUE}Do you want to install GitHub Copilot CLI? [y/N] ${RESET}"; \
+		printf "${YELLOW}[WARN] GitHub Copilot CLI not found.${RESET}\n"; \
+		if ! command -v npm >/dev/null 2>&1; then \
+			printf "${RED}[ERROR] npm not found. Please install Node.js and npm first.${RESET}\n"; \
+			printf "${BLUE}  See: https://nodejs.org/${RESET}\n"; \
+			printf "${BLUE}  Then run: npm install -g @github/copilot${RESET}\n"; \
+			exit 1; \
+		fi; \
+		printf "${BLUE}Do you want to install GitHub Copilot CLI via npm? [y/N] ${RESET}"; \
 		read -r response; \
 		if [ "$$response" = "y" ] || [ "$$response" = "Y" ]; then \
-			printf "${BLUE}[INFO] Installing GitHub Copilot CLI to ${INSTALL_DIR}...${RESET}\n"; \
-			mkdir -p "${INSTALL_DIR}"; \
-			if curl -fsSL https://gh.io/copilot-install | PREFIX="." bash; then \
+			printf "${BLUE}[INFO] Installing GitHub Copilot CLI (npm install -g @github/copilot)...${RESET}\n"; \
+			if npm install -g @github/copilot; then \
 				printf "${GREEN}[INFO] GitHub Copilot CLI installed successfully.${RESET}\n"; \
 			else \
 				printf "${RED}[ERROR] Failed to install GitHub Copilot CLI.${RESET}\n"; \
@@ -53,11 +58,17 @@ install-claude:  ## checks for claude and prompts to install
 	  printf "${GREEN}[INFO] claude already installed in PATH, skipping install.${RESET}\n"; \
 	else \
 		printf "${YELLOW}[WARN] Claude Code CLI not found in PATH.${RESET}\n"; \
-		printf "${BLUE}Do you want to install Claude Code CLI? [y/N] ${RESET}"; \
+		if ! command -v npm >/dev/null 2>&1; then \
+			printf "${RED}[ERROR] npm not found. Please install Node.js and npm first.${RESET}\n"; \
+			printf "${BLUE}  See: https://nodejs.org/${RESET}\n"; \
+			printf "${BLUE}  Then run: npm install -g @anthropic-ai/claude-code${RESET}\n"; \
+			exit 1; \
+		fi; \
+		printf "${BLUE}Do you want to install Claude Code CLI via npm? [y/N] ${RESET}"; \
 		read -r response; \
 		if [ "$$response" = "y" ] || [ "$$response" = "Y" ]; then \
-			printf "${BLUE}[INFO] Installing Claude Code CLI to default location (~/.local/bin/claude)...${RESET}\n"; \
-			if curl -fsSL https://claude.ai/install.sh | bash; then \
+			printf "${BLUE}[INFO] Installing Claude Code CLI (npm install -g @anthropic-ai/claude-code)...${RESET}\n"; \
+			if npm install -g @anthropic-ai/claude-code; then \
 				printf "${GREEN}[INFO] Claude Code CLI installed successfully.${RESET}\n"; \
 			else \
 				printf "${RED}[ERROR] Failed to install Claude Code CLI.${RESET}\n"; \

--- a/.rhiza/tests/shell/test_scripts.sh
+++ b/.rhiza/tests/shell/test_scripts.sh
@@ -65,6 +65,7 @@ assert_contains() {
     fi
 }
 
+# shellcheck disable=SC2329  # helper kept for tests that assert on exit codes
 assert_exit_code() {
     local expected_code="$1"
     local actual_code="$2"

--- a/bundles/core/.pre-commit-config.yaml
+++ b/bundles/core/.pre-commit-config.yaml
@@ -64,6 +64,11 @@ repos:
       - id: bandit
         args: ["--ini", ".bandit", "--exclude", ".venv,tests,.rhiza/tests,.git,.pytest_cache"]
 
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+
   - repo: https://github.com/astral-sh/uv-pre-commit
     rev: 0.11.16
     hooks:

--- a/bundles/devcontainer/.devcontainer/bootstrap.sh
+++ b/bundles/devcontainer/.devcontainer/bootstrap.sh
@@ -16,7 +16,8 @@ error_with_recovery() {
 
 # Read Python version from .python-version (single source of truth)
 if [ -f ".python-version" ]; then
-    export PYTHON_VERSION=$(cat .python-version | tr -d '[:space:]')
+    PYTHON_VERSION=$(tr -d '[:space:]' < .python-version)
+    export PYTHON_VERSION
     echo "✓ Using Python version from .python-version: $PYTHON_VERSION"
 else
     error_with_recovery \
@@ -42,9 +43,11 @@ export UV_VENV_CLEAR=1
 export UV_LINK_MODE=copy
 
 # Make UV environment variables persistent for all sessions
-echo "export UV_LINK_MODE=copy" >> ~/.bashrc
-echo "export UV_VENV_CLEAR=1" >> ~/.bashrc
-echo "export PATH=\"$INSTALL_DIR:\$PATH\"" >> ~/.bashrc
+{
+    echo "export UV_LINK_MODE=copy"
+    echo "export UV_VENV_CLEAR=1"
+    echo "export PATH=\"$INSTALL_DIR:\$PATH\""
+} >> ~/.bashrc
 
 # Add to current PATH so subsequent commands can find uv
 export PATH="$INSTALL_DIR:$PATH"

--- a/bundles/gh-aw/.rhiza/make.d/agentic.mk
+++ b/bundles/gh-aw/.rhiza/make.d/agentic.mk
@@ -31,13 +31,18 @@ install-copilot:  ## checks for copilot and prompts to install
 	elif [ -x "${INSTALL_DIR}/copilot" ]; then \
 	  printf "${SUCCESS}[INFO] copilot already installed in ${INSTALL_DIR}, skipping install.${RESET}\n"; \
 	else \
-		printf "${YELLOW}[WARN] GitHub Copilot CLI not found in ${INSTALL_DIR}.${RESET}\n"; \
-		printf "${BLUE}Do you want to install GitHub Copilot CLI? [y/N] ${RESET}"; \
+		printf "${YELLOW}[WARN] GitHub Copilot CLI not found.${RESET}\n"; \
+		if ! command -v npm >/dev/null 2>&1; then \
+			printf "${RED}[ERROR] npm not found. Please install Node.js and npm first.${RESET}\n"; \
+			printf "${BLUE}  See: https://nodejs.org/${RESET}\n"; \
+			printf "${BLUE}  Then run: npm install -g @github/copilot${RESET}\n"; \
+			exit 1; \
+		fi; \
+		printf "${BLUE}Do you want to install GitHub Copilot CLI via npm? [y/N] ${RESET}"; \
 		read -r response; \
 		if [ "$$response" = "y" ] || [ "$$response" = "Y" ]; then \
-			printf "${BLUE}[INFO] Installing GitHub Copilot CLI to ${INSTALL_DIR}...${RESET}\n"; \
-			mkdir -p "${INSTALL_DIR}"; \
-			if curl -fsSL https://gh.io/copilot-install | PREFIX="." bash; then \
+			printf "${BLUE}[INFO] Installing GitHub Copilot CLI (npm install -g @github/copilot)...${RESET}\n"; \
+			if npm install -g @github/copilot; then \
 				printf "${GREEN}[INFO] GitHub Copilot CLI installed successfully.${RESET}\n"; \
 			else \
 				printf "${RED}[ERROR] Failed to install GitHub Copilot CLI.${RESET}\n"; \
@@ -53,11 +58,17 @@ install-claude:  ## checks for claude and prompts to install
 	  printf "${GREEN}[INFO] claude already installed in PATH, skipping install.${RESET}\n"; \
 	else \
 		printf "${YELLOW}[WARN] Claude Code CLI not found in PATH.${RESET}\n"; \
-		printf "${BLUE}Do you want to install Claude Code CLI? [y/N] ${RESET}"; \
+		if ! command -v npm >/dev/null 2>&1; then \
+			printf "${RED}[ERROR] npm not found. Please install Node.js and npm first.${RESET}\n"; \
+			printf "${BLUE}  See: https://nodejs.org/${RESET}\n"; \
+			printf "${BLUE}  Then run: npm install -g @anthropic-ai/claude-code${RESET}\n"; \
+			exit 1; \
+		fi; \
+		printf "${BLUE}Do you want to install Claude Code CLI via npm? [y/N] ${RESET}"; \
 		read -r response; \
 		if [ "$$response" = "y" ] || [ "$$response" = "Y" ]; then \
-			printf "${BLUE}[INFO] Installing Claude Code CLI to default location (~/.local/bin/claude)...${RESET}\n"; \
-			if curl -fsSL https://claude.ai/install.sh | bash; then \
+			printf "${BLUE}[INFO] Installing Claude Code CLI (npm install -g @anthropic-ai/claude-code)...${RESET}\n"; \
+			if npm install -g @anthropic-ai/claude-code; then \
 				printf "${GREEN}[INFO] Claude Code CLI installed successfully.${RESET}\n"; \
 			else \
 				printf "${RED}[ERROR] Failed to install Claude Code CLI.${RESET}\n"; \

--- a/bundles/tests/.rhiza/tests/shell/test_scripts.sh
+++ b/bundles/tests/.rhiza/tests/shell/test_scripts.sh
@@ -65,6 +65,7 @@ assert_contains() {
     fi
 }
 
+# shellcheck disable=SC2329  # helper kept for tests that assert on exit codes
 assert_exit_code() {
     local expected_code="$1"
     local actual_code="$2"

--- a/tests/security/test_security_patterns.py
+++ b/tests/security/test_security_patterns.py
@@ -285,3 +285,55 @@ class TestGithubBundleActive:
             "repository: Jebel-Quant/rhiza\nref: main\ntemplates:\n# core bundles\n- core\n- github\n"
         )
         assert _github_bundle_active(tmp_path) is True
+
+
+# Lines allowed to pipe a downloaded script into a shell. The uv installer is
+# the documented bootstrap path and runs before any package manager exists;
+# every other installer must use a verifiable package manager (npm, uv, ...).
+_PIPED_INSTALLER_ALLOWLIST = ("astral.sh/uv/install.sh",)
+
+_PIPED_INSTALLER_RE = re.compile(
+    r"(?:curl|wget)[^|\n]*\|\s*(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*(?:env\s+)?(?:ba|da|z)?sh\b"
+)
+
+_SCANNED_SUFFIXES = {".mk", ".sh"}
+_SCAN_EXCLUDED_DIRS = {".git", ".venv", ".idea", ".pytest_cache", ".ruff_cache", "__pycache__", "node_modules"}
+
+
+def _shell_and_make_sources(repo_root: pathlib.Path) -> list[pathlib.Path]:
+    """Return all Makefile, *.mk, and *.sh sources outside excluded directories."""
+    return sorted(
+        path
+        for path in repo_root.rglob("*")
+        if path.is_file()
+        and (path.suffix in _SCANNED_SUFFIXES or path.name == "Makefile")
+        and not _SCAN_EXCLUDED_DIRS.intersection(path.relative_to(repo_root).parts)
+    )
+
+
+class TestPipedInstallers:
+    """No make target or shell script may pipe a downloaded script into a shell.
+
+    curl|bash executes unverified remote content; installers must go through a
+    package manager instead (see the allowlist for the single bootstrap
+    exception).
+    """
+
+    def test_no_piped_installers_outside_allowlist(self) -> None:
+        """Every curl/wget-piped-to-shell line must be on the explicit allowlist."""
+        repo_root = pathlib.Path(__file__).parent.parent.parent
+        violations = []
+        for source in _shell_and_make_sources(repo_root):
+            for line_number, line in enumerate(source.read_text(encoding="utf-8", errors="replace").splitlines(), 1):
+                if line.lstrip().startswith("#"):
+                    continue
+                if _PIPED_INSTALLER_RE.search(line) and not any(a in line for a in _PIPED_INSTALLER_ALLOWLIST):
+                    violations.append(f"{source.relative_to(repo_root)}:{line_number}: {line.strip()}")
+        assert not violations, "piped remote-script execution found (use a package manager instead):\n" + "\n".join(
+            violations
+        )
+
+    def test_scanner_finds_sources(self) -> None:
+        """Guard against the scanner silently matching nothing."""
+        repo_root = pathlib.Path(__file__).parent.parent.parent
+        assert len(_shell_and_make_sources(repo_root)) > 10, "expected to scan make and shell sources"


### PR DESCRIPTION
## Summary

Plan item **B** of the 10-across-the-board plan (Security 8 → 10). Each fix lands with its gate.

### B1 — Client-side secret scanning

Adds the `gitleaks` hook (v8.30.1) to `.pre-commit-config.yaml` **and** the core bundle's copy, so every downstream project gets commit-time secret scanning too — previously only GitHub's server-side scanning applied. The full-repo baseline scan is clean. This also makes the quality-assessment branch's "Gitleaks active" claim true instead of drifted.

### B2 — No more `curl | bash`

Both interactive installers in `agentic.mk` piped unverified remote scripts into a shell:

- `curl -fsSL https://gh.io/copilot-install | PREFIX="." bash` → `npm install -g @github/copilot`
- `curl -fsSL https://claude.ai/install.sh | bash` → `npm install -g @anthropic-ai/claude-code`

Same UX as before (y/N prompt, clear failure messages), now with an npm presence check matching the Marp pattern in `presentation.mk`. **Gate:** `TestPipedInstallers` in `tests/security/` scans every `Makefile`, `*.mk`, and `*.sh` source and rejects any curl/wget piped into a shell. The single allowlisted line is the official astral.sh uv installer in `bootstrap.mk` — it provisions the toolchain before any package manager exists, so it's the one structurally unavoidable exception, and it's documented as such in the test.

### B3 — Shellcheck everything

The hook previously covered only `.rhiza/utils/*.sh` — which matched **zero** of the repo's 7 shell scripts. Scope widened to all `*.sh`, and the three findings it surfaced are fixed: SC2155 (masked return value) and SC2129 (grouped redirects) in the devcontainer `bootstrap.sh`, plus a documented SC2329 suppression for the kept-for-future-use assert helper in `test_scripts.sh`.

Bundle-owned copies (`bundles/gh-aw/.rhiza/make.d/agentic.mk`, `bundles/tests/.rhiza/tests/shell/test_scripts.sh`) updated in lockstep — byte-identity is enforced by `test_bundle_rhiza_sync.py`.

## Test plan

- [x] `uv run pytest tests/ -m "not stress"` — **640 passed**
- [x] `pre-commit run gitleaks --all-files` — clean baseline
- [x] `pre-commit run shellcheck --all-files` — clean with widened scope
- [x] `make -n install-claude` / `make -n install-copilot` — recipes parse
- [x] All other pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)