### PR TITLE
docs: gate prose-level drift and remove Last Updated stamps

### DIFF
--- a/.rhiza/completions/README.md
+++ b/.rhiza/completions/README.md
@@ -257,7 +257,3 @@ m te<TAB>  # Expands to: m test
 - [Tools Reference](../../docs/reference/TOOLS_REFERENCE.md) - Complete command reference
 - [Quick Reference](../../docs/guides/QUICK_REFERENCE.md) - Quick command reference
 - [Extending Rhiza](../../docs/guides/EXTENDING_RHIZA.md) - How to add custom targets
-
----
-
-*Last updated: 2026-02-15*

--- a/bundles/core/.rhiza/completions/README.md
+++ b/bundles/core/.rhiza/completions/README.md
@@ -257,7 +257,3 @@ m te<TAB>  # Expands to: m test
 - [Tools Reference](../../docs/reference/TOOLS_REFERENCE.md) - Complete command reference
 - [Quick Reference](../../docs/guides/QUICK_REFERENCE.md) - Quick command reference
 - [Extending Rhiza](../../docs/guides/EXTENDING_RHIZA.md) - How to add custom targets
-
----
-
-*Last updated: 2026-02-15*

--- a/docs/guides/EXTENDING_RHIZA.md
+++ b/docs/guides/EXTENDING_RHIZA.md
@@ -1077,7 +1077,3 @@ For more details on customizing the documentation book, see [BOOK.md](BOOK.md).
 - [Tools Reference](../reference/TOOLS_REFERENCE.md) - Comprehensive tool documentation
 - [Makefile Cookbook](../../.rhiza/make.d/README.md) - Make recipes
 - [rhiza-education Lesson 10: Customising Safely](https://github.com/Jebel-Quant/rhiza-education/blob/main/lessons/10-customizing-safely.md) - Tutorial overview of extension mechanisms and the template-managed file rule
-
----
-
-*Last updated: 2026-05-27*

--- a/docs/ops/CHANGELOG_GUIDE.md
+++ b/docs/ops/CHANGELOG_GUIDE.md
@@ -455,8 +455,6 @@ After implementing changelog enhancements:
 
 ---
 
-**Last Updated**: February 2026
-
 For related documentation:
 - `ROADMAP.md` - Project roadmap (create one in your repository root)
 - [CONTRIBUTING.md](../../.rhiza/CONTRIBUTING.md) - Contribution guidelines

--- a/docs/ops/PROJECT_BOARD.md
+++ b/docs/ops/PROJECT_BOARD.md
@@ -287,8 +287,6 @@ For inspiration, see the Rhiza project board:
 
 ---
 
-**Last Updated**: February 2026
-
 For related documentation:
 - `ROADMAP.md` - Project roadmap and planned features (create one in your repository root)
 - [TECHNICAL_DEBT.md](TECHNICAL_DEBT.md) - Known limitations and debt items

--- a/docs/ops/TECHNICAL_DEBT.md
+++ b/docs/ops/TECHNICAL_DEBT.md
@@ -274,7 +274,4 @@ See [CONTRIBUTING.md](../../.rhiza/CONTRIBUTING.md) for general contribution gui
 
 ---
 
-**Last Updated**: February 2026  
-**Next Review**: March 2026
-
 For planned features and improvements, see `ROADMAP.md` (if your project keeps one).

--- a/docs/reference/DEPENDENCIES.md
+++ b/docs/reference/DEPENDENCIES.md
@@ -216,7 +216,3 @@ A: Update the lower bound and document the reason. Run full tests and get PR app
 
 **Q: How do I check for outdated dependencies?**  
 A: Run `uv lock --upgrade` to see available updates. Renovate also creates PRs automatically.
-
----
-
-*Last Updated: 2026-02-15*

--- a/docs/reference/TOOLS_REFERENCE.md
+++ b/docs/reference/TOOLS_REFERENCE.md
@@ -810,7 +810,3 @@ PYTHON_VERSION = 3.12
 - [Extending Rhiza](../guides/EXTENDING_RHIZA.md) - Extending and customizing Rhiza
 - [Contributing Guide](../../.rhiza/CONTRIBUTING.md) - How to contribute
 - [README](../../README.md) - Project overview
-
----
-
-*Last updated: 2026-02-15*

--- a/tests/docs/test_doc_consistency.py
+++ b/tests/docs/test_doc_consistency.py
@@ -152,3 +152,77 @@ class TestBundleDocumentation:
         assert f"`{bundle_name}`" in claude_md, (
             f"bundle '{bundle_name}' is defined in .rhiza/template-bundles.yml but not documented in CLAUDE.md"
         )
+
+
+_MAKE_SOURCES = (
+    "Makefile",
+    ".rhiza/rhiza.mk",
+    *sorted(str(p.relative_to(_ROOT)) for p in (_ROOT / ".rhiza" / "make.d").glob("*.mk")),
+)
+
+_TARGET_DEF_RE = re.compile(r"^([A-Za-z0-9_.-]+(?:\s+[A-Za-z0-9_.-]+)*)\s*::?(?!=)", re.MULTILINE)
+_MAKE_MENTION_RE = re.compile(r"\bmake\s+([a-z][A-Za-z0-9_-]*)")
+_CODE_REGION_RE = re.compile(r"```.*?```|`[^`\n]+`", re.DOTALL)
+
+_BUNDLE_COUNT_RE = re.compile(r"\b\d+\s+(?:\w+\s+){0,2}bundles\b", re.IGNORECASE)
+_STAMP_RE = re.compile(r"^\s*\*{0,2}Last Updated", re.MULTILINE | re.IGNORECASE)
+
+# Markdown files exempt from prose-drift gates: generated or historical records.
+_PROSE_GATE_EXEMPT = {"CHANGELOG.md"}
+
+
+def _defined_make_targets() -> set[str]:
+    """Return every make target defined by the root Makefile and .rhiza make modules."""
+    targets: set[str] = set()
+    for source in _MAKE_SOURCES:
+        text = (_ROOT / source).read_text(encoding="utf-8")
+        for match in _TARGET_DEF_RE.finditer(text):
+            targets.update(name for name in match.group(1).split() if not name.startswith("."))
+    return targets
+
+
+def _make_mention_cases() -> list[tuple[str, str]]:
+    """Collect (label, target) for every `make <target>` mention in CLAUDE.md and README.md code."""
+    cases: list[tuple[str, str]] = []
+    for doc in ("CLAUDE.md", "README.md"):
+        text = (_ROOT / doc).read_text(encoding="utf-8")
+        for region in _CODE_REGION_RE.findall(text):
+            for match in _MAKE_MENTION_RE.finditer(region):
+                cases.append((f"{doc}: make {match.group(1)}", match.group(1)))
+    return sorted(set(cases))
+
+
+class TestProseDrift:
+    """Verify that documentation prose cannot drift from the repository state."""
+
+    @pytest.mark.parametrize(("label", "target"), _make_mention_cases(), ids=[c[0] for c in _make_mention_cases()])
+    def test_mentioned_make_targets_exist(self, label: str, target: str) -> None:
+        """Every `make <target>` mentioned in CLAUDE.md/README.md code must be a real target."""
+        assert target in _defined_make_targets(), (
+            f"{label}: target is not defined in the Makefile or any .rhiza/make.d module"
+        )
+
+    @pytest.mark.parametrize(
+        "md_file",
+        [p for p in _markdown_files() if p.name not in _PROSE_GATE_EXEMPT],
+        ids=lambda p: str(p.relative_to(_ROOT)),
+    )
+    def test_no_hardcoded_bundle_counts(self, md_file: Path) -> None:
+        """Docs must not hard-code the bundle count; template-bundles.yml is authoritative."""
+        hits = _BUNDLE_COUNT_RE.findall(md_file.read_text(encoding="utf-8", errors="replace"))
+        assert not hits, f"hard-coded bundle count {hits} — refer to .rhiza/template-bundles.yml instead"
+
+    @pytest.mark.parametrize(
+        "md_file",
+        [p for p in _markdown_files() if p.name not in _PROSE_GATE_EXEMPT],
+        ids=lambda p: str(p.relative_to(_ROOT)),
+    )
+    def test_no_last_updated_stamps(self, md_file: Path) -> None:
+        """Docs must not carry manual 'Last Updated' stamps; git history answers that question."""
+        assert not _STAMP_RE.search(md_file.read_text(encoding="utf-8", errors="replace")), (
+            "manual 'Last Updated' stamp found — these drift silently; rely on git history instead"
+        )
+
+    def test_make_mentions_were_collected(self) -> None:
+        """Guard against the make-mention scanner silently collecting nothing."""
+        assert len(_make_mention_cases()) > 10, "expected CLAUDE.md/README.md to mention make targets"


### PR DESCRIPTION
## Summary

Closes the gating items of #1150 (quality plan C — Documentation → 10).

Three new prose-drift gates in `tests/docs/test_doc_consistency.py`:

1. **Make-target mentions must be real**: every `make <target>` in CLAUDE.md/README.md code spans and fenced blocks must exist in the `Makefile` or `.rhiza/make.d/*.mk`. Mentions are extracted from code regions only, so prose like "make sure" can't false-positive.
2. **No hard-coded bundle counts** anywhere in the docs (CHANGELOG exempt as a historical record) — the "13 bundles" drift class found in the original review becomes unwritable.
3. **No manual "Last Updated" stamps** — they drift silently; git history answers the question.

All eight existing stamps removed. Notably, the initial grep found only four; **the new gate itself caught the other four** (lowercase "Last updated" variants in TOOLS_REFERENCE.md, EXTENDING_RHIZA.md, and the completions README + its core-bundle copy) — a live demonstration of why the gate beats the sweep.

The `analysis.md` bookkeeping item of #1150 lands separately on the `quality-assessment` branch.

## Test plan

- [x] `uv run pytest tests/ -m "not stress"` — **849 passed** (209 new prose-gate cases)
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)