### PR TITLE
dx: cache shell-completion targets and add a Windows/WSL quick-start

### DIFF
--- a/.rhiza/CONTRIBUTING.md
+++ b/.rhiza/CONTRIBUTING.md
@@ -27,6 +27,36 @@ navigate to its root, and run the following command:
 make install
 ```
 
+### Windows quick-start (WSL)
+
+The Makefile system requires GNU Make and a POSIX shell, so native Windows
+shells (PowerShell, cmd.exe, Git Bash) fail fast with an error. Use the
+Windows Subsystem for Linux instead:
+
+1. Install WSL with an Ubuntu distribution (PowerShell, as administrator):
+
+   ```bash
+   wsl --install -d Ubuntu
+   ```
+
+2. Inside the Ubuntu shell, install the prerequisites that `make doctor` checks
+   for (GNU Make and git; `make install` provisions `uv` itself):
+
+   ```bash
+   sudo apt-get update && sudo apt-get install -y make git curl
+   ```
+
+3. Clone the repository **inside the WSL filesystem** (e.g. `~/projects`), not
+   under `/mnt/c/...` — cross-filesystem I/O is dramatically slower and can
+   break file-permission assumptions:
+
+   ```bash
+   git clone https://github.com/jebel-quant/rhiza.git ~/projects/rhiza
+   cd ~/projects/rhiza && make install
+   ```
+
+4. Run `make doctor` to confirm the toolchain is complete.
+
 ### Optional uv dependency groups
 
 For faster, focused installs you can sync only the dependency groups you need:

--- a/.rhiza/completions/README.md
+++ b/.rhiza/completions/README.md
@@ -244,13 +244,17 @@ m te<TAB>  # Expands to: m test
 1. **Target Discovery**: Parses `make -qp` output to find all targets
 2. **Description Extraction**: Looks for `##` comments after target names
 3. **Variable Detection**: Includes common Makefile variables
-4. **Dynamic Completion**: Regenerates list each time you tab
+4. **Cached Completion**: The target list is cached per directory and refreshed automatically
 
 ### Performance
 
-- Completions are generated on-demand (when you press Tab)
-- For large Makefiles (100+ targets), there may be a small delay
-- Results are not cached to ensure targets are always current
+- The target list is cached under `${XDG_CACHE_HOME:-~/.cache}/rhiza/`, keyed per directory
+- The cache refreshes automatically whenever the `Makefile`, `local.mk`,
+  `.rhiza/rhiza.mk`, or any `.rhiza/make.d/*.mk` file changes
+- Only the first Tab press after a makefile change pays the full `make -qp` parsing cost
+- To force a refresh manually, delete the cache: `rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/rhiza"`
+- If the cache directory cannot be created (e.g. read-only home), completion
+  falls back to direct parsing on every Tab press
 
 ## See Also
 

--- a/.rhiza/completions/rhiza-completion.bash
+++ b/.rhiza/completions/rhiza-completion.bash
@@ -9,8 +9,19 @@
 #     sudo cp .rhiza/completions/rhiza-completion.bash /etc/bash_completion.d/rhiza
 #
 
+# Return 0 (stale) when the cache file is missing or any makefile source
+# changed since it was written.
+_rhiza_make_cache_stale() {
+    local cache_file="$1" src
+    [[ -f "$cache_file" ]] || return 0
+    for src in Makefile local.mk .rhiza/rhiza.mk .rhiza/make.d/*.mk; do
+        [[ -f "$src" && "$src" -nt "$cache_file" ]] && return 0
+    done
+    return 1
+}
+
 _rhiza_make_completion() {
-    local cur prev opts
+    local cur prev opts cache_dir cache_file
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
@@ -20,12 +31,29 @@ _rhiza_make_completion() {
         return 0
     fi
 
-    # Extract make targets from Makefile and all included .mk files
-    # Looks for lines like: target: ## description
-    opts=$(make -qp 2>/dev/null | \
-           awk -F':' '/^[a-zA-Z0-9][^$#\/\t=]*:([^=]|$)/ {split($1,A,/ /);for(i in A)print A[i]}' | \
-           grep -v '^Makefile$' | \
-           sort -u)
+    # Target extraction parses the full make database (make -qp), which is
+    # slow on large Makefiles - cache the result per directory and refresh
+    # only when a makefile source changes.
+    cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/rhiza"
+    cache_file="$cache_dir/targets-$(pwd | cksum | cut -d' ' -f1)"
+
+    if _rhiza_make_cache_stale "$cache_file" && mkdir -p "$cache_dir" 2>/dev/null; then
+        # Extract make targets from Makefile and all included .mk files
+        make -qp 2>/dev/null | \
+            awk -F':' '/^[a-zA-Z0-9][^$#\/\t=]*:([^=]|$)/ {split($1,A,/ /);for(i in A)print A[i]}' | \
+            grep -v '^Makefile$' | \
+            sort -u > "$cache_file"
+    fi
+
+    if [[ -r "$cache_file" ]]; then
+        opts=$(cat "$cache_file")
+    else
+        # Cache unavailable (e.g. unwritable HOME): fall back to direct parsing
+        opts=$(make -qp 2>/dev/null | \
+               awk -F':' '/^[a-zA-Z0-9][^$#\/\t=]*:([^=]|$)/ {split($1,A,/ /);for(i in A)print A[i]}' | \
+               grep -v '^Makefile$' | \
+               sort -u)
+    fi
 
     # Add common make variables that can be overridden
     local vars="DRY_RUN=1 BUMP=patch BUMP=minor BUMP=major ENV=dev ENV=staging ENV=prod"

--- a/.rhiza/completions/rhiza-completion.zsh
+++ b/.rhiza/completions/rhiza-completion.zsh
@@ -19,17 +19,34 @@
 #     sudo cp .rhiza/completions/rhiza-completion.zsh /usr/local/share/zsh/site-functions/_make
 #
 
+# Return 0 (stale) when the cache file is missing or any makefile source
+# changed since it was written.
+_rhiza_make_cache_stale() {
+    local cache_file="$1" src
+    [[ -f "$cache_file" ]] || return 0
+    for src in Makefile local.mk .rhiza/rhiza.mk .rhiza/make.d/*.mk(N); do
+        [[ -f "$src" && "$src" -nt "$cache_file" ]] && return 0
+    done
+    return 1
+}
+
 _rhiza_make() {
     local -a targets variables
-    
+    local cache_dir cache_file
+
     # Check if we're in a directory with a Makefile
     if [[ ! -f "Makefile" ]]; then
         return 0
     fi
 
-    # Extract make targets with descriptions
-    # Format: target:description
-    targets=(${(f)"$(
+    # Target extraction parses the full make database (make -qp) twice, which
+    # is slow on large Makefiles - cache both lists per directory and refresh
+    # only when a makefile source changes.
+    cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/rhiza"
+    cache_file="$cache_dir/targets-$(pwd | cksum | cut -d' ' -f1)"
+
+    if _rhiza_make_cache_stale "$cache_file.desc" && mkdir -p "$cache_dir" 2>/dev/null; then
+        # Extract make targets with descriptions (format: target:description)
         make -qp 2>/dev/null | \
         awk -F':' '
             /^# Files/,/^# Finished Make data base/ {
@@ -43,20 +60,34 @@ _rhiza_make() {
             }
         ' | \
         grep -v '^Makefile:' | \
-        sort -u
-    )"})
+        sort -u > "$cache_file.desc"
 
-    # Also get targets without descriptions
-    local -a plain_targets
-    plain_targets=(${(f)"$(
+        # Also get targets without descriptions
         make -qp 2>/dev/null | \
         awk -F':' '/^[a-zA-Z0-9_-]+:([^=]|$)/ {
             split($1,A,/ /)
             for(i in A) print A[i]
         }' | \
         grep -v '^Makefile$' | \
-        sort -u
-    )"})
+        sort -u > "$cache_file.plain"
+    fi
+
+    local -a plain_targets
+    if [[ -r "$cache_file.desc" ]]; then
+        targets=(${(f)"$(cat "$cache_file.desc")"})
+        plain_targets=(${(f)"$(cat "$cache_file.plain" 2>/dev/null)"})
+    else
+        # Cache unavailable (e.g. unwritable HOME): fall back to direct parsing
+        plain_targets=(${(f)"$(
+            make -qp 2>/dev/null | \
+            awk -F':' '/^[a-zA-Z0-9_-]+:([^=]|$)/ {
+                split($1,A,/ /)
+                for(i in A) print A[i]
+            }' | \
+            grep -v '^Makefile$' | \
+            sort -u
+        )"})
+    fi
 
     # Common make variables
     variables=(

--- a/bundles/core/.rhiza/completions/README.md
+++ b/bundles/core/.rhiza/completions/README.md
@@ -244,13 +244,17 @@ m te<TAB>  # Expands to: m test
 1. **Target Discovery**: Parses `make -qp` output to find all targets
 2. **Description Extraction**: Looks for `##` comments after target names
 3. **Variable Detection**: Includes common Makefile variables
-4. **Dynamic Completion**: Regenerates list each time you tab
+4. **Cached Completion**: The target list is cached per directory and refreshed automatically
 
 ### Performance
 
-- Completions are generated on-demand (when you press Tab)
-- For large Makefiles (100+ targets), there may be a small delay
-- Results are not cached to ensure targets are always current
+- The target list is cached under `${XDG_CACHE_HOME:-~/.cache}/rhiza/`, keyed per directory
+- The cache refreshes automatically whenever the `Makefile`, `local.mk`,
+  `.rhiza/rhiza.mk`, or any `.rhiza/make.d/*.mk` file changes
+- Only the first Tab press after a makefile change pays the full `make -qp` parsing cost
+- To force a refresh manually, delete the cache: `rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/rhiza"`
+- If the cache directory cannot be created (e.g. read-only home), completion
+  falls back to direct parsing on every Tab press
 
 ## See Also
 

--- a/bundles/core/.rhiza/completions/rhiza-completion.bash
+++ b/bundles/core/.rhiza/completions/rhiza-completion.bash
@@ -9,8 +9,19 @@
 #     sudo cp .rhiza/completions/rhiza-completion.bash /etc/bash_completion.d/rhiza
 #
 
+# Return 0 (stale) when the cache file is missing or any makefile source
+# changed since it was written.
+_rhiza_make_cache_stale() {
+    local cache_file="$1" src
+    [[ -f "$cache_file" ]] || return 0
+    for src in Makefile local.mk .rhiza/rhiza.mk .rhiza/make.d/*.mk; do
+        [[ -f "$src" && "$src" -nt "$cache_file" ]] && return 0
+    done
+    return 1
+}
+
 _rhiza_make_completion() {
-    local cur prev opts
+    local cur prev opts cache_dir cache_file
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
@@ -20,12 +31,29 @@ _rhiza_make_completion() {
         return 0
     fi
 
-    # Extract make targets from Makefile and all included .mk files
-    # Looks for lines like: target: ## description
-    opts=$(make -qp 2>/dev/null | \
-           awk -F':' '/^[a-zA-Z0-9][^$#\/\t=]*:([^=]|$)/ {split($1,A,/ /);for(i in A)print A[i]}' | \
-           grep -v '^Makefile$' | \
-           sort -u)
+    # Target extraction parses the full make database (make -qp), which is
+    # slow on large Makefiles - cache the result per directory and refresh
+    # only when a makefile source changes.
+    cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/rhiza"
+    cache_file="$cache_dir/targets-$(pwd | cksum | cut -d' ' -f1)"
+
+    if _rhiza_make_cache_stale "$cache_file" && mkdir -p "$cache_dir" 2>/dev/null; then
+        # Extract make targets from Makefile and all included .mk files
+        make -qp 2>/dev/null | \
+            awk -F':' '/^[a-zA-Z0-9][^$#\/\t=]*:([^=]|$)/ {split($1,A,/ /);for(i in A)print A[i]}' | \
+            grep -v '^Makefile$' | \
+            sort -u > "$cache_file"
+    fi
+
+    if [[ -r "$cache_file" ]]; then
+        opts=$(cat "$cache_file")
+    else
+        # Cache unavailable (e.g. unwritable HOME): fall back to direct parsing
+        opts=$(make -qp 2>/dev/null | \
+               awk -F':' '/^[a-zA-Z0-9][^$#\/\t=]*:([^=]|$)/ {split($1,A,/ /);for(i in A)print A[i]}' | \
+               grep -v '^Makefile$' | \
+               sort -u)
+    fi
 
     # Add common make variables that can be overridden
     local vars="DRY_RUN=1 BUMP=patch BUMP=minor BUMP=major ENV=dev ENV=staging ENV=prod"

--- a/bundles/core/.rhiza/completions/rhiza-completion.zsh
+++ b/bundles/core/.rhiza/completions/rhiza-completion.zsh
@@ -19,17 +19,34 @@
 #     sudo cp .rhiza/completions/rhiza-completion.zsh /usr/local/share/zsh/site-functions/_make
 #
 
+# Return 0 (stale) when the cache file is missing or any makefile source
+# changed since it was written.
+_rhiza_make_cache_stale() {
+    local cache_file="$1" src
+    [[ -f "$cache_file" ]] || return 0
+    for src in Makefile local.mk .rhiza/rhiza.mk .rhiza/make.d/*.mk(N); do
+        [[ -f "$src" && "$src" -nt "$cache_file" ]] && return 0
+    done
+    return 1
+}
+
 _rhiza_make() {
     local -a targets variables
-    
+    local cache_dir cache_file
+
     # Check if we're in a directory with a Makefile
     if [[ ! -f "Makefile" ]]; then
         return 0
     fi
 
-    # Extract make targets with descriptions
-    # Format: target:description
-    targets=(${(f)"$(
+    # Target extraction parses the full make database (make -qp) twice, which
+    # is slow on large Makefiles - cache both lists per directory and refresh
+    # only when a makefile source changes.
+    cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/rhiza"
+    cache_file="$cache_dir/targets-$(pwd | cksum | cut -d' ' -f1)"
+
+    if _rhiza_make_cache_stale "$cache_file.desc" && mkdir -p "$cache_dir" 2>/dev/null; then
+        # Extract make targets with descriptions (format: target:description)
         make -qp 2>/dev/null | \
         awk -F':' '
             /^# Files/,/^# Finished Make data base/ {
@@ -43,20 +60,34 @@ _rhiza_make() {
             }
         ' | \
         grep -v '^Makefile:' | \
-        sort -u
-    )"})
+        sort -u > "$cache_file.desc"
 
-    # Also get targets without descriptions
-    local -a plain_targets
-    plain_targets=(${(f)"$(
+        # Also get targets without descriptions
         make -qp 2>/dev/null | \
         awk -F':' '/^[a-zA-Z0-9_-]+:([^=]|$)/ {
             split($1,A,/ /)
             for(i in A) print A[i]
         }' | \
         grep -v '^Makefile$' | \
-        sort -u
-    )"})
+        sort -u > "$cache_file.plain"
+    fi
+
+    local -a plain_targets
+    if [[ -r "$cache_file.desc" ]]; then
+        targets=(${(f)"$(cat "$cache_file.desc")"})
+        plain_targets=(${(f)"$(cat "$cache_file.plain" 2>/dev/null)"})
+    else
+        # Cache unavailable (e.g. unwritable HOME): fall back to direct parsing
+        plain_targets=(${(f)"$(
+            make -qp 2>/dev/null | \
+            awk -F':' '/^[a-zA-Z0-9_-]+:([^=]|$)/ {
+                split($1,A,/ /)
+                for(i in A) print A[i]
+            }' | \
+            grep -v '^Makefile$' | \
+            sort -u
+        )"})
+    fi
 
     # Common make variables
     variables=(

--- a/bundles/legal/.rhiza/CONTRIBUTING.md
+++ b/bundles/legal/.rhiza/CONTRIBUTING.md
@@ -27,6 +27,36 @@ navigate to its root, and run the following command:
 make install
 ```
 
+### Windows quick-start (WSL)
+
+The Makefile system requires GNU Make and a POSIX shell, so native Windows
+shells (PowerShell, cmd.exe, Git Bash) fail fast with an error. Use the
+Windows Subsystem for Linux instead:
+
+1. Install WSL with an Ubuntu distribution (PowerShell, as administrator):
+
+   ```bash
+   wsl --install -d Ubuntu
+   ```
+
+2. Inside the Ubuntu shell, install the prerequisites that `make doctor` checks
+   for (GNU Make and git; `make install` provisions `uv` itself):
+
+   ```bash
+   sudo apt-get update && sudo apt-get install -y make git curl
+   ```
+
+3. Clone the repository **inside the WSL filesystem** (e.g. `~/projects`), not
+   under `/mnt/c/...` — cross-filesystem I/O is dramatically slower and can
+   break file-permission assumptions:
+
+   ```bash
+   git clone https://github.com/jebel-quant/rhiza.git ~/projects/rhiza
+   cd ~/projects/rhiza && make install
+   ```
+
+4. Run `make doctor` to confirm the toolchain is complete.
+
 ### Optional uv dependency groups
 
 For faster, focused installs you can sync only the dependency groups you need:

--- a/tests/utils/test_completions.py
+++ b/tests/utils/test_completions.py
@@ -1,0 +1,76 @@
+"""Tests for the shell completion scripts in .rhiza/completions/.
+
+Gates two invariants:
+
+1. Both completion scripts are syntactically valid for their target shell
+   (bash -n / zsh -n), so a broken edit cannot ship.
+2. The bash completion's cache helper behaves correctly: stale when the cache
+   file is missing, fresh after writing, stale again after a makefile source
+   changes.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess  # nosec B404 - invoking known shells on repo-controlled files
+import time
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+_COMPLETIONS = _ROOT / ".rhiza" / "completions"
+
+
+def _run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    """Run a command, capturing output."""
+    return subprocess.run(cmd, capture_output=True, text=True, check=False, **kwargs)  # nosec B603
+
+
+class TestCompletionScripts:
+    """Syntax and cache behaviour of the shell completion scripts."""
+
+    @pytest.mark.parametrize(
+        ("shell", "script"),
+        [("bash", "rhiza-completion.bash"), ("zsh", "rhiza-completion.zsh")],
+    )
+    def test_script_syntax_is_valid(self, shell: str, script: str) -> None:
+        """Each completion script must pass its shell's no-exec syntax check."""
+        if shutil.which(shell) is None:
+            pytest.skip(f"{shell} not available")
+        result = _run([shell, "-n", str(_COMPLETIONS / script)])
+        assert result.returncode == 0, f"{script} failed {shell} -n: {result.stderr}"
+
+    def test_bash_cache_staleness_lifecycle(self, tmp_path: Path) -> None:
+        """The cache helper reports stale on miss, fresh after write, stale after edit."""
+        if shutil.which("bash") is None:
+            pytest.skip("bash not available")
+        (tmp_path / "Makefile").write_text("all:\n\ttrue\n")
+        script = f"""
+        source "{_COMPLETIONS / "rhiza-completion.bash"}"
+        cd "{tmp_path}"
+        cache="{tmp_path}/cache-file"
+        _rhiza_make_cache_stale "$cache" && echo "miss:stale" || echo "miss:fresh"
+        echo targets > "$cache"
+        _rhiza_make_cache_stale "$cache" && echo "written:stale" || echo "written:fresh"
+        """
+        result = _run(["bash", "-c", script])
+        assert "miss:stale" in result.stdout
+        assert "written:fresh" in result.stdout
+
+        # A makefile edit after the cache write must invalidate it. mtimes are
+        # second-granular under macOS bash, so push the Makefile clearly ahead.
+        cache = tmp_path / "cache-file"
+        cache.write_text("targets\n")
+        future = time.time() + 5
+        os.utime(tmp_path / "Makefile", (future, future))
+        result = _run(
+            [
+                "bash",
+                "-c",
+                f'source "{_COMPLETIONS / "rhiza-completion.bash"}"; cd "{tmp_path}"; '
+                f'_rhiza_make_cache_stale "{cache}" && echo "edited:stale" || echo "edited:fresh"',
+            ],
+        )
+        assert "edited:stale" in result.stdout

--- a/tests/utils/test_completions.py
+++ b/tests/utils/test_completions.py
@@ -28,6 +28,29 @@ def _run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
     return subprocess.run(cmd, capture_output=True, text=True, check=False, **kwargs)  # nosec B603
 
 
+def _usable_shell(shell: str) -> str | None:
+    """Resolve *shell* to an executable that actually runs, or None.
+
+    On Windows, ``shutil.which("bash")`` can resolve to the System32 WSL
+    launcher, which exits non-zero when no WSL distribution is installed.
+    Prefer Git Bash there, and verify each candidate by running a trivial
+    command before trusting it.
+    """
+    candidates: list[str] = []
+    if shell == "bash" and os.name == "nt":
+        for env_var in ("ProgramFiles", "ProgramFiles(x86)"):
+            base = os.environ.get(env_var)
+            if base:
+                candidates.append(str(Path(base) / "Git" / "bin" / "bash.exe"))
+    which = shutil.which(shell)
+    if which:
+        candidates.append(which)
+    for candidate in candidates:
+        if Path(candidate).is_file() and _run([candidate, "-c", "echo ok"]).stdout.strip() == "ok":
+            return candidate
+    return None
+
+
 class TestCompletionScripts:
     """Syntax and cache behaviour of the shell completion scripts."""
 
@@ -37,25 +60,27 @@ class TestCompletionScripts:
     )
     def test_script_syntax_is_valid(self, shell: str, script: str) -> None:
         """Each completion script must pass its shell's no-exec syntax check."""
-        if shutil.which(shell) is None:
+        shell_exe = _usable_shell(shell)
+        if shell_exe is None:
             pytest.skip(f"{shell} not available")
-        result = _run([shell, "-n", str(_COMPLETIONS / script)])
+        result = _run([shell_exe, "-n", str(_COMPLETIONS / script)])
         assert result.returncode == 0, f"{script} failed {shell} -n: {result.stderr}"
 
     def test_bash_cache_staleness_lifecycle(self, tmp_path: Path) -> None:
         """The cache helper reports stale on miss, fresh after write, stale after edit."""
-        if shutil.which("bash") is None:
+        bash_exe = _usable_shell("bash")
+        if bash_exe is None:
             pytest.skip("bash not available")
         (tmp_path / "Makefile").write_text("all:\n\ttrue\n")
         script = f"""
-        source "{_COMPLETIONS / "rhiza-completion.bash"}"
-        cd "{tmp_path}"
-        cache="{tmp_path}/cache-file"
+        source "{(_COMPLETIONS / "rhiza-completion.bash").as_posix()}"
+        cd "{tmp_path.as_posix()}"
+        cache="{tmp_path.as_posix()}/cache-file"
         _rhiza_make_cache_stale "$cache" && echo "miss:stale" || echo "miss:fresh"
         echo targets > "$cache"
         _rhiza_make_cache_stale "$cache" && echo "written:stale" || echo "written:fresh"
         """
-        result = _run(["bash", "-c", script])
+        result = _run([bash_exe, "-c", script])
         assert "miss:stale" in result.stdout
         assert "written:fresh" in result.stdout
 
@@ -67,10 +92,10 @@ class TestCompletionScripts:
         os.utime(tmp_path / "Makefile", (future, future))
         result = _run(
             [
-                "bash",
+                bash_exe,
                 "-c",
-                f'source "{_COMPLETIONS / "rhiza-completion.bash"}"; cd "{tmp_path}"; '
-                f'_rhiza_make_cache_stale "{cache}" && echo "edited:stale" || echo "edited:fresh"',
+                f'source "{(_COMPLETIONS / "rhiza-completion.bash").as_posix()}"; cd "{tmp_path.as_posix()}"; '
+                f'_rhiza_make_cache_stale "{cache.as_posix()}" && echo "edited:stale" || echo "edited:fresh"',
             ],
         )
         assert "edited:stale" in result.stdout


### PR DESCRIPTION
## Summary

Closes #1151 (quality plan D — Developer Experience → 10).

### Completion caching

Both completion scripts ran `make -qp` — a full make-database dump — on **every Tab press**; the zsh script ran it twice. The target list is now cached per directory under `${XDG_CACHE_HOME:-~/.cache}/rhiza/` and refreshed automatically whenever a makefile source (`Makefile`, `local.mk`, `.rhiza/rhiza.mk`, `.rhiza/make.d/*.mk`) changes. If the cache directory can't be created (read-only home), completion falls back to direct parsing rather than going silent.

Measured on this repo (small Makefile, warm machine): cold 74ms → warm 35ms, with identical candidate lists; the win grows with Makefile size, which is exactly the case the README used to apologise for. Invalidation verified end-to-end: edit `Makefile` → next Tab regenerates (confirmed via nanosecond mtimes; macOS bash's `-nt` is second-granular, which the gate test accounts for).

### Windows/WSL quick-start

#1146 made native Windows shells fail fast — the error tells users *that* they need WSL, but nothing said *how*. New section in `.rhiza/CONTRIBUTING.md`: WSL install, the exact prerequisites `make doctor` checks for, and the clone-inside-the-WSL-filesystem caveat (`/mnt/c` I/O cost).

### Gate

`tests/utils/test_completions.py`: both scripts must pass their shell's no-exec syntax check (`bash -n` / `zsh -n`), and the cache helper's lifecycle is exercised (stale on miss → fresh after write → stale after a makefile edit).

Bundle copies in lockstep: completions ship via **core**, CONTRIBUTING via **legal** (the byte-identity test caught the legal copy when I initially missed it).

## Test plan

- [x] `uv run pytest tests/ -m "not stress"` — **643 passed**
- [x] Functional verification of cold/warm/invalidate cycles in bash and zsh
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)