### PR TITLE
security: add OSSF Scorecard workflow and README badge

### DIFF
--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -1,0 +1,78 @@
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
+#
+# Workflow: OSSF Scorecard
+#
+# Purpose: Run the OpenSSF Scorecard supply-chain security analysis and upload
+#          the results to GitHub code scanning. On public repositories the
+#          results are also published to the OpenSSF REST API, which powers
+#          the README badge and lets adopters verify the score independently.
+#          Set the SCORECARD_ENABLED repository variable to 'true' to
+#          force-enable on private repos, 'false' to disable, or leave unset
+#          for auto-detect (public repositories only).
+#
+# Trigger: Weekly schedule, pushes to main, branch-protection changes, and
+#          manual dispatch.
+
+name: "(RHIZA) SCORECARD"
+
+on:
+  # Re-evaluate when branch protection rules change (Scorecard's
+  # Branch-Protection check reads them).
+  branch_protection_rule:
+  schedule:
+    - cron: '34 2 * * 2'
+  push:
+    branches: [ "main", "master" ]
+  workflow_dispatch:
+
+# Cancel superseded in-progress runs of this workflow for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Least privilege by default; the job grants itself only what Scorecard needs.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    # Publishing results and the public score only work on public repositories.
+    if: |
+      vars.SCORECARD_ENABLED == 'true' ||
+      (vars.SCORECARD_ENABLED != 'false' && github.event.repository.visibility == 'public')
+    permissions:
+      # Needed to upload the SARIF results to code scanning.
+      security-events: write
+      # Needed to publish results to the OpenSSF REST API (badge support).
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish to the OpenSSF REST API so the score is externally
+          # verifiable and the README badge stays current (public repos only).
+          publish_results: true
+
+      - name: Upload Scorecard results artifact
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload results to code scanning
+        uses: github/codeql-action/upload-sarif@v4.36.0
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-000000.svg?logo=ruff)](https://github.com/astral-sh/ruff)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![CodeFactor](https://www.codefactor.io/repository/github/jebel-quant/rhiza/badge)](https://www.codefactor.io/repository/github/jebel-quant/rhiza)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/Jebel-Quant/rhiza/badge)](https://scorecard.dev/viewer/?uri=github.com/Jebel-Quant/rhiza)
 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/jebel-quant/rhiza)
 

--- a/bundles/github/.github/workflows/rhiza_scorecard.yml
+++ b/bundles/github/.github/workflows/rhiza_scorecard.yml
@@ -1,0 +1,78 @@
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
+#
+# Workflow: OSSF Scorecard
+#
+# Purpose: Run the OpenSSF Scorecard supply-chain security analysis and upload
+#          the results to GitHub code scanning. On public repositories the
+#          results are also published to the OpenSSF REST API, which powers
+#          the README badge and lets adopters verify the score independently.
+#          Set the SCORECARD_ENABLED repository variable to 'true' to
+#          force-enable on private repos, 'false' to disable, or leave unset
+#          for auto-detect (public repositories only).
+#
+# Trigger: Weekly schedule, pushes to main, branch-protection changes, and
+#          manual dispatch.
+
+name: "(RHIZA) SCORECARD"
+
+on:
+  # Re-evaluate when branch protection rules change (Scorecard's
+  # Branch-Protection check reads them).
+  branch_protection_rule:
+  schedule:
+    - cron: '34 2 * * 2'
+  push:
+    branches: [ "main", "master" ]
+  workflow_dispatch:
+
+# Cancel superseded in-progress runs of this workflow for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Least privilege by default; the job grants itself only what Scorecard needs.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    # Publishing results and the public score only work on public repositories.
+    if: |
+      vars.SCORECARD_ENABLED == 'true' ||
+      (vars.SCORECARD_ENABLED != 'false' && github.event.repository.visibility == 'public')
+    permissions:
+      # Needed to upload the SARIF results to code scanning.
+      security-events: write
+      # Needed to publish results to the OpenSSF REST API (badge support).
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish to the OpenSSF REST API so the score is externally
+          # verifiable and the README badge stays current (public repos only).
+          publish_results: true
+
+      - name: Upload Scorecard results artifact
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload results to code scanning
+        uses: github/codeql-action/upload-sarif@v4.36.0
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
Closes #1159.

## What changed

- **`.github/workflows/rhiza_scorecard.yml`** (+ lockstep copy in the `github` bundle so downstream adopters inherit it): runs `ossf/scorecard-action@v2.4.3` on a weekly schedule, pushes to main, `branch_protection_rule` changes, and manual dispatch. Results go to GitHub code scanning (SARIF) and are published to the OpenSSF REST API, making the score externally verifiable.
- **README badge** linking to the public scorecard viewer.

## Conventions

Follows the gates in `tests/api/test_workflow_hygiene.py`: top-level concurrency group with `cancel-in-progress: true`, exact action pinning (`v2.4.3`, `v6.0.2`, `v7.0.1`, `v4.36.0` — tag pins matching the hand-written-workflow convention), and least-privilege permissions (`read-all` at the workflow level; `security-events: write` + `id-token: write` only on the job). Public-repo auto-detection mirrors the CodeQL workflow's pattern, overridable via a `SCORECARD_ENABLED` repository variable.

## Notes

- `publish_results: true` requires the workflow to run from the default branch of a public repository — the badge will populate after the first post-merge run.
- The badge URL uses the `api.scorecard.dev` endpoint; the score reflects whatever the latest published run found, so expect it to surface actionable findings (e.g. token permissions in other workflows) over time.

## Verification

- Full suite: 875 passed; `make fmt` green (actionlint, workflow schema validation, workflow-name hook all pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)