### PR TITLE
security: cherry-pick safe StepSecurity hardening from #1167

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -25,12 +25,20 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   copilot-setup-steps:
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@v6.0.2
         with:

--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -34,6 +34,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@v6.0.2
         with:
           lfs: true

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -28,6 +28,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   book:
     if: ${{ !github.event.repository.fork }}

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -27,6 +27,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/rhiza_gh-aw-validate.yml
+++ b/.github/workflows/rhiza_gh-aw-validate.yml
@@ -37,6 +37,11 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@v6.0.2
 
       - name: Install gh-aw extension

--- a/.github/workflows/rhiza_paper.yml
+++ b/.github/workflows/rhiza_paper.yml
@@ -39,6 +39,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: Checkout repository
         uses: actions/checkout@v6.0.2
 


### PR DESCRIPTION
## Why

[#1167](https://github.com/Jebel-Quant/rhiza/pull/1167) (StepSecurity Bot) bundled genuinely useful workflow hardening with several changes that **break Rhiza's own gates** (all of its CI checks fail). This PR applies only the safe subset, authored to pass CI, so #1167 can be closed.

## What's included

| File | Change |
|---|---|
| `copilot-setup-steps.yml` | top-level `permissions: contents: read` + `harden-runner` (egress audit) |
| `rhiza_book.yml` | top-level `permissions: contents: read` |
| `rhiza_codeql.yml` | top-level `permissions: contents: read` |
| `rhiza_benchmark.yml` | `harden-runner` step |
| `rhiza_gh-aw-validate.yml` | `harden-runner` step |
| `rhiza_paper.yml` | `harden-runner` step |

`harden-runner` is SHA-pinned (`9af89fc…` # v2.19.4) to satisfy the precise-pin hygiene test. Job-level permissions still override the top-level default where needed (e.g. CodeQL's `security-events: write`).

## Deliberately excluded from #1167 (these are what fail its CI)

- **`harden-runner` edits to `*.lock.yml` and `agentics-maintenance.yml`** — these are gh-aw-compiled (DO-NOT-EDIT); hand-edits break the `gh-aw-validate` job. Hardening there must come from the `.md` sources via `make gh-aw-compile`.
- **`dependency-review.yml`** — fails 4 workflow-contract tests (no `jebel-quant/rhiza` delegation, no `concurrency` block) and the dependency-review job itself (Dependency Graph not enabled on the repo).
- **`pylint` pre-commit hook** — crashes under Python 3.12 (`pkgutil.ImpImporter` removed); Rhiza lints with ruff.
- **`end-of-file-fixer` / `trailing-whitespace` hooks** — caused 50+ files of unrelated churn and rewrote gh-aw-generated files.
- **dependabot docker entry** — `directory: /bundles/docker` is rhiza-specific, and the github bundle's `dependabot.yml` is a downstream template kept byte-identical to the root copy (see #1152), so the path can't ship downstream.

## Verification

- `make fmt` — clean
- 127 tests pass: workflow hygiene, workflow stubs, agentic-workflow dependabot lockstep, security patterns
- No compiled file touched, so the `validate` job that fails on #1167 passes here

## Follow-ups (dropped value worth doing separately)

- harden-runner in the gh-aw workflows belongs in the `.md` sources → `make gh-aw-compile`
- dependency-review needs Dependency Graph enabled **and** a stub authored to the contract (delegate to `jebel-quant/rhiza` + concurrency block)

Closes the need for #1167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)