### PR TITLE
security: raise OpenSSF Scorecard (token-permissions, signed-releases, branch-protection)

### DIFF
--- a/.github/rulesets/main-branch-protection.json
+++ b/.github/rulesets/main-branch-protection.json
@@ -1,0 +1,35 @@
+{
+  "name": "main-branch-protection",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": ["squash", "merge", "rebase"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": []
+      }
+    }
+  ],
+  "bypass_actors": []
+}

--- a/.github/workflows/rhiza_devcontainer.yml
+++ b/.github/workflows/rhiza_devcontainer.yml
@@ -57,12 +57,14 @@ concurrency:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   build:
     name: Build Devcontainer Image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read   # Read-only: logs in to pull cache layers; the image is built with `push: never`
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/.github/workflows/rhiza_docker.yml
+++ b/.github/workflows/rhiza_docker.yml
@@ -19,7 +19,6 @@ concurrency:
 
 permissions:
   contents: read
-  security-events: write
 
 on:
   push:
@@ -31,6 +30,9 @@ on:
 jobs:
   lint_and_build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write   # Needed to upload the Trivy SARIF report to code scanning
 
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/rhiza_paper.yml
+++ b/.github/workflows/rhiza_paper.yml
@@ -32,11 +32,13 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build-pdf:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write   # Needed to push the compiled PDF to the paper branch
 
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -97,16 +97,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+# Least-privilege default: every job below re-declares exactly the write
+# scopes it needs (Scorecard Token-Permissions). Top-level stays read-only.
 permissions:
-  contents: write       # Needed to create releases
-  id-token: write       # Needed for OIDC authentication with PyPI
-  packages: write       # Needed to publish devcontainer image
-  attestations: write   # Needed for SLSA provenance attestations (public repos only)
+  contents: read
 
 jobs:
   tag:
     name: Validate Tag
     runs-on: ubuntu-latest
+    permissions:
+      contents: read   # Validation only: reads tags and release state
     outputs:
       tag: ${{ steps.set_tag.outputs.tag }}
     steps:
@@ -195,6 +196,10 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     needs: tag
+    permissions:
+      contents: read
+      id-token: write       # OIDC for attestation signing
+      attestations: write   # SLSA provenance + SBOM attestations (public repos only)
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -291,10 +296,18 @@ jobs:
             sbom.cdx.xml
 
       - name: Generate SLSA provenance attestations
+        id: provenance
         if: steps.buildable.outputs.buildable == 'true' && github.event.repository.private == false
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: dist/*
+
+      - name: Stage provenance bundle for the GitHub release
+        # Attach the SLSA provenance bundle to the release as a recognised
+        # signature asset (*.intoto.jsonl) so consumers — and OpenSSF
+        # Scorecard's Signed-Releases check — can verify the artifacts.
+        if: steps.buildable.outputs.buildable == 'true' && github.event.repository.private == false
+        run: cp "${{ steps.provenance.outputs.bundle-path }}" dist/provenance.intoto.jsonl
 
       - name: Upload dist artifact
         if: steps.buildable.outputs.buildable == 'true'
@@ -308,6 +321,8 @@ jobs:
     name: Draft GitHub Release
     runs-on: ubuntu-latest
     needs: [tag, build]
+    permissions:
+      contents: write   # Needed to create the GitHub release and upload artifacts
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -334,6 +349,15 @@ jobs:
           path: sbom
         continue-on-error: true
 
+      - name: Download dist artifact
+        # Brings in provenance.intoto.jsonl (and the built distributions) staged
+        # by the build job, so the SLSA provenance ships as a release asset.
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist
+        continue-on-error: true
+
       - name: Create GitHub Release with artifacts
         uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
@@ -342,12 +366,14 @@ jobs:
           bodyFile: RELEASE_NOTES.md
           draft: true
           allowUpdates: true
-          artifacts: "sbom/*"
+          artifacts: "sbom/*,dist/provenance.intoto.jsonl"
 
   update-changelog:
     name: Update CHANGELOG.md
     runs-on: ubuntu-latest
     needs: [tag, draft-release]
+    permissions:
+      contents: write   # Needed to commit and push the regenerated CHANGELOG.md
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -383,6 +409,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     needs: [tag, build, draft-release]
+    permissions:
+      contents: read
+      id-token: write   # OIDC Trusted Publishing to PyPI (no stored credentials)
     outputs:
       should_publish: ${{ steps.check_dist.outputs.should_publish }}
 
@@ -436,6 +465,8 @@ jobs:
     name: Generate Conda Recipe
     runs-on: ubuntu-latest
     needs: [tag, pypi]
+    permissions:
+      contents: read   # Generates a recipe and uploads it as a workflow artifact only
     outputs:
       should_generate: ${{ steps.check_conda.outputs.should_generate }}
 
@@ -503,6 +534,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     needs: [tag, build, draft-release]
+    permissions:
+      contents: read
+      packages: write   # Needed to push the devcontainer image to the registry
     outputs:
       should_publish: ${{ steps.check_publish.outputs.should_publish }}
       image_name: ${{ steps.image_name.outputs.image_name }}
@@ -596,6 +630,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [tag, pypi, conda, devcontainer]
     if: needs.pypi.result == 'success' || needs.conda.result == 'success' || needs.devcontainer.result == 'success'
+    permissions:
+      contents: write   # Needed to undraft/publish the GitHub release
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/.github/workflows/rhiza_sync.yml
+++ b/.github/workflows/rhiza_sync.yml
@@ -21,8 +21,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 on:
   push:
@@ -58,6 +57,8 @@ jobs:
     name: Sync and commit (Renovate)
     if: (github.event_name == 'push' || inputs.direct == true) && github.repository != 'jebel-quant/rhiza'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write   # Needed to commit and push synced changes to the branch
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -135,6 +136,9 @@ jobs:
     name: Sync and open PR (scheduled/manual)
     if: github.event_name != 'push' && inputs.direct != true && github.repository != 'jebel-quant/rhiza'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write         # Needed to push the sync branch
+      pull-requests: write    # Needed to open the sync PR
 
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/docs/ops/BRANCH_PROTECTION.md
+++ b/docs/ops/BRANCH_PROTECTION.md
@@ -1,0 +1,72 @@
+# Branch Protection as Code
+
+This document explains how Rhiza manages branch protection for the default branch as a version-controlled
+GitHub ruleset, and how that maps to OpenSSF Scorecard.
+
+## Why a ruleset (and not the Settings UI)
+
+GitHub does not read branch protection from a file in the repository by default. Clicking through
+**Settings → Rules** leaves no audit trail and drifts over time. Instead, the protection lives in
+[`.github/rulesets/main-branch-protection.json`](../../.github/rulesets/main-branch-protection.json) and is
+applied with a single `gh api` call, so changes are reviewed like any other diff.
+
+This directly improves two Scorecard checks that cannot be fixed by workflow files alone:
+
+- **Code-Review** — requires every change to land via a pull request with at least one approving review.
+- **Branch-Protection** — blocks force-pushes and branch deletion on the default branch and requires status
+  checks to pass before merge.
+
+## What the ruleset enforces
+
+- Pull request required, with **1 approving review** and stale-review dismissal on new pushes.
+- **No force-pushes** (`non_fast_forward`) and **no deletion** of the default branch.
+- **Required status checks** must pass before merge (strict — the branch must be up to date).
+
+The `required_status_checks` list ships **empty** on purpose: check names ("contexts") differ per project and
+change as workflows evolve. Populate it for this repo once (see below) so superseded merges are blocked on red CI.
+
+## Apply it
+
+Requires admin on the repository and a token with the `repo`/`administration` scope (`gh auth login` is enough
+for a maintainer).
+
+```bash
+# Create the ruleset (first time)
+gh api --method POST repos/Jebel-Quant/rhiza/rulesets \
+  --input .github/rulesets/main-branch-protection.json
+
+# List rulesets to find the id
+gh api repos/Jebel-Quant/rhiza/rulesets --jq '.[] | "\(.id)\t\(.name)"'
+
+# Update an existing ruleset after editing the JSON
+gh api --method PUT repos/Jebel-Quant/rhiza/rulesets/<RULESET_ID> \
+  --input .github/rulesets/main-branch-protection.json
+```
+
+## Adding required status checks
+
+Find the exact check names from a recent run on `main`, then add them under `required_status_checks`:
+
+```bash
+# List check/context names from the latest main commit
+gh api repos/Jebel-Quant/rhiza/commits/main/check-runs --jq '.check_runs[].name' | sort -u
+```
+
+```jsonc
+"required_status_checks": [
+  { "context": "test (3.13, ubuntu-latest)" },
+  { "context": "Type checking (Python 3.13)" },
+  { "context": "Pre-commit hooks" }
+]
+```
+
+Re-apply with the `PUT` command above.
+
+## Notes
+
+- The score updates on the **next** Scorecard run after the ruleset is active — trigger it via
+  **Actions → "(RHIZA) SCORECARD" → Run workflow**, or wait for the weekly schedule.
+- **Code-Review** also looks back at recently merged PRs, so its score climbs as new PRs land with approvals;
+  historical self-merges still count against it until they age out of the window.
+- Scorecard's Branch-Protection check needs a token with admin read to inspect settings. The Scorecard action
+  reads this via its `repo_token`; without it the check reports an internal error rather than a real score.

--- a/tests/api/test_release_workflow.py
+++ b/tests/api/test_release_workflow.py
@@ -72,10 +72,21 @@ class TestReleaseWorkflowStructure:
         tags = push.get("tags", [])
         assert any("v*" in tag for tag in tags), "Workflow must trigger on v* tags"
 
-    def test_workflow_has_contents_write_permission(self, workflow):
-        """Workflow must have contents: write permission to push CHANGELOG.md."""
+    def test_workflow_top_level_permissions_are_read_only(self, workflow):
+        """Top-level permissions must stay least-privilege (read-only).
+
+        Write scopes are granted per-job (Scorecard Token-Permissions); the
+        workflow must not hand every job write access by default.
+        """
         permissions = workflow.get("permissions", {})
-        assert permissions.get("contents") == "write", "Workflow must have contents: write permission"
+        assert permissions.get("contents") == "read", "Top-level contents permission must be read"
+        assert "write" not in permissions.values(), f"Top-level permissions must be read-only, got {permissions}"
+
+    def test_changelog_job_has_contents_write_permission(self, workflow):
+        """The update-changelog job must have contents: write to push CHANGELOG.md."""
+        job = workflow["jobs"]["update-changelog"]
+        permissions = job.get("permissions", {})
+        assert permissions.get("contents") == "write", "update-changelog job must have contents: write"
 
     def test_workflow_contains_expected_jobs(self, workflow):
         """Workflow should keep the expected release job structure."""


### PR DESCRIPTION
## Why

Live Scorecard is **6.8**. This targets the lowest checks with file-based fixes. (The score was already stale before this — #1170's SHA-pinning lifts Pinned-Dependencies on the next run.)

## 1. Token-Permissions (was 0) — least-privilege per job

Five workflows declared **write at the top level**, granting it to every job. Moved each write down to the job that needs it; top-level is now read-only:

| Workflow | Job-level write granted |
|---|---|
| `rhiza_paper` | `build-pdf` → `contents:write` (pushes PDF to paper branch) |
| `rhiza_docker` | `lint_and_build` → `security-events:write` (Trivy SARIF upload) |
| `rhiza_devcontainer` | `build` → `packages:**read**` — it logs in only to pull cache and builds with `push: never`, so the old `packages:write` was unnecessary |
| `rhiza_sync` | `sync-direct` → `contents:write`; `sync-pr` → `contents`+`pull-requests:write` |
| `rhiza_release` | per-job across all 8: `tag`/`conda` read-only; `build` → `id-token`+`attestations:write`; `pypi` → `id-token:write`; `devcontainer` → `packages:write`; `draft-release`/`update-changelog`/`finalise-release` → `contents:write` |

## 2. Signed-Releases (was 0) — attach provenance to the release

`rhiza_release` already generates SLSA provenance (`attest-build-provenance`), but it only lived in the attestations API — the GitHub release carried no recognised signature asset. Now the provenance bundle is staged as `dist/provenance.intoto.jsonl` and attached to the release. **Takes effect on the next release** (Scorecard reads release assets retrospectively).

## 3 & 4. Branch-Protection + Code-Review (was 0 / errored) — ruleset as code

Added [`.github/rulesets/main-branch-protection.json`](.github/rulesets/main-branch-protection.json) (require PR + 1 approving review, block force-push & deletion, strict required status checks) and [`docs/ops/BRANCH_PROTECTION.md`](docs/ops/BRANCH_PROTECTION.md) with the `gh api` apply/update commands.

> These are **repo settings**, not workflow files — GitHub won't read them from the repo automatically. The ruleset is version-controlled and applied with one `gh api` call. **Action required (admin):** run the apply command in the doc, then add this repo's status-check contexts. Code-Review also climbs as new reviewed PRs land.

## Not done — Dockerfile digest pin (intentional)

Both `FROM` stages interpolate `${PYTHON_VERSION}` into the tag. A digest pins one specific image (= one Python version), which would break the per-project parameterised-Python design (`.python-version` is the single source of truth). Left as tags by design — Pinned-Dependencies is near its practical ceiling for a template repo that ships tag-pinned bundles for downstream updatability.

## Verification

- `make fmt` clean (actionlint, markdownlint, jsonschema)
- **892 tests pass**
- Updated `test_release_workflow` to assert top-level perms are read-only and the `update-changelog` job holds `contents:write`

## Follow-ups

- Propagate the per-job permissions to the bundle templates (`bundles/*/.github/workflows/`) so downstream projects score well too.
- Enable Dependency Graph (Settings → Code security) to unblock a future `dependency-review` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)