### PR TITLE
Remove 'github-actions' from Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,6 @@
   "enabledManagers": [
     "pep621",
     "pre-commit",
-    "github-actions",
     "gitlabci",
     "devcontainer",
     "dockerfile",


### PR DESCRIPTION
Removed 'github-actions' from enabled managers list.

## Summary

<!-- One or two sentences describing what this PR does and why. -->

Closes #<!-- issue number -->

## Changes

<!-- Bullet list of what changed. -->

-

## Testing

- [ ] `make test` passes locally
- [ ] `make fmt` has been run
- [ ] New tests added (or explain why not needed)

## Checklist

- [ ] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] `CHANGELOG.md` entry added (or not needed for this change)
- [ ] Documentation updated if behaviour changed
- [ ] `make deptry` passes (no unused or missing dependencies)
