### PR TITLE
security: propagate least-privilege workflow permissions to bundle templates

### DIFF
--- a/bundles/gh-aw/.github/workflows/copilot-setup-steps.yml
+++ b/bundles/gh-aw/.github/workflows/copilot-setup-steps.yml
@@ -25,6 +25,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   copilot-setup-steps:
     runs-on: ubuntu-latest

--- a/bundles/github-book/.github/workflows/rhiza_book.yml
+++ b/bundles/github-book/.github/workflows/rhiza_book.yml
@@ -27,6 +27,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   book:
     uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v0.18.9

--- a/bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml
+++ b/bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml
@@ -17,7 +17,6 @@ concurrency:
 
 permissions:
   contents: read
-  packages: write
 
 on:
   push:
@@ -39,4 +38,4 @@ jobs:
     secrets: inherit
     permissions:
       contents: read
-      packages: write
+      packages: read   # Read-only: image is built with `push: never`, login only pulls cache

--- a/bundles/github-docker/.github/workflows/rhiza_docker.yml
+++ b/bundles/github-docker/.github/workflows/rhiza_docker.yml
@@ -17,7 +17,6 @@ concurrency:
 
 permissions:
   contents: read
-  security-events: write
 
 on:
   push:

--- a/bundles/github-paper/.github/workflows/rhiza_paper.yml
+++ b/bundles/github-paper/.github/workflows/rhiza_paper.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write
+  contents: read
 
 on:
   push:

--- a/bundles/github-tests/.github/workflows/rhiza_codeql.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_codeql.yml
@@ -19,9 +19,6 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  security-events: write
-  packages: read
-  actions: read
   contents: read
 
 on:
@@ -36,3 +33,8 @@ jobs:
   codeql:
     uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v0.18.9
     secrets: inherit
+    permissions:
+      security-events: write   # Upload CodeQL results to code scanning
+      packages: read
+      actions: read
+      contents: read

--- a/bundles/github/.github/workflows/rhiza_release.yml
+++ b/bundles/github/.github/workflows/rhiza_release.yml
@@ -108,16 +108,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+# Least-privilege default: every job below re-declares exactly the write
+# scopes it needs (Scorecard Token-Permissions). Top-level stays read-only.
 permissions:
-  contents: write       # Needed to create releases
-  id-token: write       # Needed for OIDC authentication with PyPI
-  packages: write       # Needed to publish devcontainer image
-  attestations: write   # Needed for SLSA provenance attestations (public repos only)
+  contents: read
 
 jobs:
   tag:
     name: Validate Tag
     runs-on: ubuntu-latest
+    permissions:
+      contents: read   # Validation only: reads tags and release state
     outputs:
       tag: ${{ steps.set_tag.outputs.tag }}
     steps:
@@ -201,6 +202,10 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     needs: tag
+    permissions:
+      contents: read
+      id-token: write       # OIDC for attestation signing
+      attestations: write   # SLSA provenance + SBOM attestations (public repos only)
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6.0.2
@@ -292,10 +297,18 @@ jobs:
             sbom.cdx.xml
 
       - name: Generate SLSA provenance attestations
+        id: provenance
         if: steps.buildable.outputs.buildable == 'true' && github.event.repository.private == false
         uses: actions/attest-build-provenance@v4.1.0
         with:
           subject-path: dist/*
+
+      - name: Stage provenance bundle for the GitHub release
+        # Attach the SLSA provenance bundle to the release as a recognised
+        # signature asset (*.intoto.jsonl) so consumers — and OpenSSF
+        # Scorecard's Signed-Releases check — can verify the artifacts.
+        if: steps.buildable.outputs.buildable == 'true' && github.event.repository.private == false
+        run: cp "${{ steps.provenance.outputs.bundle-path }}" dist/provenance.intoto.jsonl
 
       - name: Upload dist artifact
         if: steps.buildable.outputs.buildable == 'true'
@@ -309,6 +322,8 @@ jobs:
     name: Draft GitHub Release
     runs-on: ubuntu-latest
     needs: [tag, build]
+    permissions:
+      contents: write   # Needed to create the GitHub release and upload artifacts
 
     steps:
       - name: Checkout Code
@@ -330,6 +345,15 @@ jobs:
           path: sbom
         continue-on-error: true
 
+      - name: Download dist artifact
+        # Brings in provenance.intoto.jsonl (and the built distributions) staged
+        # by the build job, so the SLSA provenance ships as a release asset.
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: dist
+          path: dist
+        continue-on-error: true
+
       - name: Create GitHub Release with artifacts
         uses: ncipollo/release-action@v1.21.0
         with:
@@ -338,12 +362,14 @@ jobs:
           bodyFile: RELEASE_NOTES.md
           draft: true
           allowUpdates: true
-          artifacts: "sbom/*"
+          artifacts: "sbom/*,dist/provenance.intoto.jsonl"
 
   update-changelog:
     name: Update CHANGELOG.md
     runs-on: ubuntu-latest
     needs: [tag, draft-release]
+    permissions:
+      contents: write   # Needed to commit and push the regenerated CHANGELOG.md
     steps:
       - name: Checkout Default Branch
         uses: actions/checkout@v6.0.2
@@ -374,6 +400,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     needs: [tag, build, draft-release]
+    permissions:
+      contents: read
+      id-token: write   # OIDC Trusted Publishing to PyPI (no stored credentials)
     outputs:
       should_publish: ${{ steps.check_dist.outputs.should_publish }}
 
@@ -422,6 +451,8 @@ jobs:
     name: Generate Conda Recipe
     runs-on: ubuntu-latest
     needs: [tag, pypi]
+    permissions:
+      contents: read   # Generates a recipe and uploads it as a workflow artifact only
     outputs:
       should_generate: ${{ steps.check_conda.outputs.should_generate }}
 
@@ -484,6 +515,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     needs: [tag, build, draft-release]
+    permissions:
+      contents: read
+      packages: write   # Needed to push the devcontainer image to the registry
     outputs:
       should_publish: ${{ steps.check_publish.outputs.should_publish }}
       image_name: ${{ steps.image_name.outputs.image_name }}
@@ -572,6 +606,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [tag, pypi, conda, devcontainer]
     if: needs.pypi.result == 'success' || needs.conda.result == 'success' || needs.devcontainer.result == 'success'
+    permissions:
+      contents: write   # Needed to undraft/publish the GitHub release
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6.0.2

--- a/bundles/github/.github/workflows/rhiza_sync.yml
+++ b/bundles/github/.github/workflows/rhiza_sync.yml
@@ -21,8 +21,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 on:
   push:
@@ -47,3 +46,6 @@ jobs:
       direct: ${{ github.event_name == 'push' }}
       create-pr: ${{ github.event_name != 'push' && (github.event_name == 'schedule' || inputs.create-pr == true) }}
     secrets: inherit
+    permissions:
+      contents: write         # Commit/push synced files (direct mode)
+      pull-requests: write    # Open the sync PR (scheduled/dispatch mode)


### PR DESCRIPTION
## Why

Follow-up to #1172, which hardened **rhiza's own** workflows. That improves rhiza's score but not downstream projects that adopt the bundles. This applies the same Token-Permissions least-privilege treatment to the shipped **bundle templates** so adopters inherit good OpenSSF Scorecard posture too.

After this, **every** bundle workflow is read-only at the top level.

## Changes

**Stubs** (delegate via `jobs.<id>.uses:`) — top-level → read-only; write scopes move to the calling job's `permissions:` (passed through to the reusable workflow):

| Template | Calling-job permission |
|---|---|
| `github-docker/rhiza_docker` | `security-events: write` (Trivy SARIF) |
| `github-devcontainer/rhiza_devcontainer` | `packages: **read**` (built with `push: never`) |
| `github-paper/rhiza_paper` | `contents: write` (push PDF) |
| `github-tests/rhiza_codeql` | `security-events: write` + `actions/packages: read` |
| `github/rhiza_sync` | `contents` + `pull-requests: write` |

**Missing top-level blocks** added (read-only): `github-book/rhiza_book` (stub), `gh-aw/copilot-setup-steps`.

**`github/rhiza_release`** (full template, synced directly downstream — can't be a stub due to PyPI OIDC identity): per-job scoping across all 8 jobs **and** the SLSA provenance bundle attached to the release as `dist/provenance.intoto.jsonl`, mirroring the root workflow from #1172.

## Verification

- `make fmt` clean (actionlint, markdownlint)
- 892 tests pass (workflow hygiene covers `bundles/*/.github/workflows/` too)
- Concurrency/queue semantics untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)