### PR TITLE
security: harden branch-protection ruleset + prep Code-Review/CII

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Code owners for rhiza.
+#
+# Pull requests that modify matching paths require an approving review from a
+# listed owner. This is enforced by the `require_code_owner_review` rule in
+# .github/rulesets/main-branch-protection.json and feeds the OpenSSF Scorecard
+# Code-Review and Branch-Protection checks.
+#
+# Repository admins can still bypass per that ruleset's `bypass_actors` entry,
+# so a maintainer can self-merge without a second reviewer. Listing multiple
+# owners means any one of them can satisfy the requirement.
+
+# Default owner for everything in the repository.
+*       @tschm @Jebel-Quant/rhiza

--- a/.github/rulesets/main-branch-protection.json
+++ b/.github/rulesets/main-branch-protection.json
@@ -16,10 +16,24 @@
       "parameters": {
         "required_approving_review_count": 1,
         "dismiss_stale_reviews_on_push": true,
-        "require_code_owner_review": false,
-        "require_last_push_approval": false,
+        "require_code_owner_review": true,
+        "require_last_push_approval": true,
         "required_review_thread_resolution": false,
         "allowed_merge_methods": ["squash", "merge", "rebase"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "required_status_checks": [
+          { "context": "Pre-commit hooks" },
+          { "context": "validation" },
+          { "context": "Check dependencies with deptry" },
+          { "context": "docs-coverage" },
+          { "context": "Security scanning" },
+          { "context": "License compliance scan" }
+        ]
       }
     }
   ],

--- a/docs/ops/BRANCH_PROTECTION.md
+++ b/docs/ops/BRANCH_PROTECTION.md
@@ -18,17 +18,24 @@ This directly improves two Scorecard checks that cannot be fixed by workflow fil
 
 ## What the ruleset enforces
 
-- Pull request required, with **1 approving review** and stale-review dismissal on new pushes.
+- Pull request required, with **1 approving review**, **code-owner review** (see
+  [`.github/CODEOWNERS`](../../.github/CODEOWNERS)), **last-push approval**, and stale-review dismissal on new
+  pushes.
+- **Required status checks** — the always-on CI gates must pass before merge: `Pre-commit hooks`, `validation`,
+  `Check dependencies with deptry`, `docs-coverage`, `Security scanning`, `License compliance scan`.
 - **No force-pushes** (`non_fast_forward`) and **no deletion** of the default branch.
 
 Repository **admins can bypass** (`bypass_actors` → `RepositoryRole` id 5, `bypass_mode: always`) so a solo
-maintainer can still self-merge. Drop the `bypass_actors` entry for the strictest posture (admins included), at
-the cost of needing a second approver on every PR.
+maintainer can still self-merge. This is the one remaining gap Scorecard flags (`'branch protection settings
+apply to administrators' is disabled`) and the main reason **Code-Review** stays low while admins self-merge.
+Drop the `bypass_actors` entry for the strictest posture (admins included), at the cost of needing a second
+approver on every PR.
 
-There is intentionally **no `required_status_checks` rule**: the GitHub API rejects an empty check list, and a
-single config can't safely hard-require checks across projects — conditional workflows (book, docker, paper,
-marimo, devcontainer) only run on relevant changes, so requiring them would wedge unrelated PRs that never
-trigger them. Add the checks that run on *every* PR for your repo (see below) when you want red CI to block merges.
+The required status checks are deliberately limited to **single-instance jobs that run on every PR**. The
+matrix jobs (`test (3.x, <os>)`, `Type checking (Python 3.x)`) are intentionally **not** hard-required: their
+context names change whenever the Python/OS matrix changes, which would wedge PRs until the ruleset is edited.
+The conditional overlay workflows (book, docker, paper, marimo, devcontainer) are excluded for the same reason —
+they only run on relevant changes.
 
 ## Apply it
 
@@ -48,32 +55,19 @@ gh api --method PUT repos/Jebel-Quant/rhiza/rulesets/<RULESET_ID> \
   --input .github/rulesets/main-branch-protection.json
 ```
 
-## Adding required status checks
+## Tuning required status checks
 
-Pick checks that run on **every** PR (not the conditional overlay workflows), then add a
-`required_status_checks` rule to the `rules` array and re-apply with the `PUT` command above:
+The ruleset already requires the always-on, single-instance gates (see above). To adjust the list, edit the
+`required_status_checks` rule and re-apply with the `PUT` command above. List context names from a recent PR
+head (PRs exercise the full matrix, unlike `main`):
 
 ```bash
-# List context names from a recent PR head (PRs exercise the full matrix, unlike main)
 gh api repos/Jebel-Quant/rhiza/commits/<PR_HEAD_SHA>/check-runs --jq '.check_runs[].name' | sort -u
 ```
 
-```jsonc
-{
-  "type": "required_status_checks",
-  "parameters": {
-    "strict_required_status_checks_policy": true,
-    "do_not_enforce_on_create": false,
-    "required_status_checks": [
-      { "context": "test (3.13, ubuntu-latest)" },
-      { "context": "Type checking (Python 3.13)" },
-      { "context": "Pre-commit hooks" }
-    ]
-  }
-}
-```
-
-The list must be non-empty — the API returns `422` for `"required_status_checks": []`.
+Prefer **stable single-instance contexts**. Avoid matrix contexts such as `test (3.13, ubuntu-latest)` or
+`Type checking (Python 3.13)`: their names change with the matrix and would wedge PRs until the ruleset is
+edited. The list must be non-empty — the API returns `422` for `"required_status_checks": []`.
 
 ## Notes
 

--- a/docs/ops/CII_BEST_PRACTICES.md
+++ b/docs/ops/CII_BEST_PRACTICES.md
@@ -1,0 +1,52 @@
+# OpenSSF Best Practices Badge (CII)
+
+The OpenSSF Scorecard **CII-Best-Practices** check reads the project's badge level from the OpenSSF Best
+Practices BadgeApp. Rhiza currently sits at `InProgress` (Scorecard score 2/10). Reaching **passing** raises the
+check to its full score.
+
+Unlike the other Scorecard checks, this one **cannot be fixed from the repository** — it requires a maintainer
+to complete the questionnaire on the external BadgeApp. This document records the steps and maps each criterion
+to the evidence that already exists in rhiza, so the questionnaire is mostly copy-paste.
+
+## Steps (maintainer, ~30–60 min, one-time)
+
+1. Go to <https://www.bestpractices.dev> → **Get Your Badge!** → sign in with GitHub.
+2. Add (or claim) the project for `https://github.com/Jebel-Quant/rhiza`. Scorecard already detects an
+   in-progress badge, so an entry likely exists — note its numeric **project id** from the URL
+   (`https://www.bestpractices.dev/projects/<ID>`).
+3. Work through the criteria using the evidence table below. Most are already satisfied.
+4. Reach **passing** (all `MUST` criteria met).
+5. Add the badge to `README.md` (ready-to-paste, fill in `<ID>`):
+
+   ```markdown
+   [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/<ID>/badge)](https://www.bestpractices.dev/projects/<ID>)
+   ```
+
+6. The Scorecard check re-reads the badge on its next run — trigger **Actions → "(RHIZA) SCORECARD" → Run
+   workflow**, or wait for the weekly schedule.
+
+## Evidence map (passing criteria → existing artifacts)
+
+| Criterion | Evidence in rhiza |
+| --- | --- |
+| Project homepage / description | `README.md` |
+| Free/open-source license (OSI) | `LICENSE` (MIT) |
+| Version-controlled source, public | This GitHub repository |
+| Release notes / changelog | `CHANGELOG.md`, GitHub Releases |
+| Bug-reporting process | GitHub Issues; `SECURITY.md` for vulnerabilities |
+| Vulnerability report process (private) | `SECURITY.md` |
+| Build + automated test suite | `make test` (909 tests, 90% coverage gate), `rhiza_ci.yml` |
+| Tests added with new functionality | Enforced via coverage gate + CI |
+| Coding style / static analysis | `ruff`, `ty`, `bandit`, `interrogate` (`make fmt`) |
+| Secured delivery (HTTPS) | GitHub + PyPI over HTTPS |
+| Crypto / no hardcoded secrets | `detect-secrets` pre-commit hook |
+| Dynamic / fuzz analysis | ClusterFuzzLite + Atheris (`fuzz/`, `rhiza_fuzzing.yml`) |
+| Dependency vulnerability monitoring | Dependabot + Renovate + `pip-audit` (`make security`) |
+| Contribution guide | `CONTRIBUTING.md` |
+| Code review of changes | Branch-protection ruleset (`docs/ops/BRANCH_PROTECTION.md`) |
+| Continuous integration | GitHub Actions + GitLab CI |
+| Supply-chain hardening | SHA-pinned actions, OpenSSF Scorecard workflow |
+
+## Related
+
+- [`BRANCH_PROTECTION.md`](BRANCH_PROTECTION.md) — covers the Code-Review and Branch-Protection checks.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,8 @@ nav:
     - Technical Debt: ops/TECHNICAL_DEBT.md
   - Security:
     - Security Testing: security/SECURITY_TESTING.md
+    - Branch Protection: ops/BRANCH_PROTECTION.md
+    - OpenSSF Best Practices Badge: ops/CII_BEST_PRACTICES.md
   - Architecture Decision Records:
     - Overview: adr/README.md
     - ADR-0001 Use Architecture Decision Records: adr/0001-use-architecture-decision-records.md


### PR DESCRIPTION
Addresses the three OpenSSF Scorecard findings that can't be fixed by workflow files alone. **This PR does not apply the ruleset** — after merge, a maintainer runs the `PUT` below.

## Branch-Protection (5/10) + Code-Review (0/10)
- **`.github/CODEOWNERS`** — `* @tschm @Jebel-Quant/rhiza` (any one owner satisfies review).
- **Ruleset** (`.github/rulesets/main-branch-protection.json`):
  - `require_code_owner_review: true`, `require_last_push_approval: true`
  - new `required_status_checks` rule scoped to the **always-on single-instance** CI gates: `Pre-commit hooks`, `validation`, `Check dependencies with deptry`, `docs-coverage`, `Security scanning`, `License compliance scan`.
  - Matrix `test (3.x, <os>)` / `Type checking (Python 3.x)` are **excluded** — their context names change with the matrix and would wedge PRs.
- **Admin bypass is retained** so a solo maintainer can still self-merge. That bypass is the remaining reason Code-Review stays low; removing the `bypass_actors` entry is the optional strictest step (costs a second approver on every PR). Code-Review also climbs only as new PRs land *with* approvals.

## CII-Best-Practices (2/10)
Can't be automated — it's an external BadgeApp questionnaire. Added **`docs/ops/CII_BEST_PRACTICES.md`** with the maintainer steps + an evidence map to rhiza's existing artifacts, and the ready-to-paste README badge.

## Docs
- `BRANCH_PROTECTION.md` updated to match the new ruleset (and to recommend stable contexts over matrix ones).
- Registered both Scorecard docs in the MkDocs **Security** nav.

## Apply after merge
```bash
gh api --method PUT repos/Jebel-Quant/rhiza/rulesets/17605978 \
  --input .github/rulesets/main-branch-protection.json
```
Then trigger **Actions → "(RHIZA) SCORECARD" → Run workflow** to refresh the score.

## Verification
- `make fmt` — all hooks pass; ruleset JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)