### PR TITLE
ci: install all extras in the lowest-deps compatibility job

### DIFF
--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -178,7 +178,7 @@ jobs:
         env:
           UV_EXTRA_INDEX_URL: ${{ secrets.UV_EXTRA_INDEX_URL }}
         run: |
-          uv sync --resolution lowest-direct
+          uv sync --all-extras --resolution lowest-direct
           for req in .rhiza/requirements/*.txt; do
             uv pip install --resolution lowest-direct -r "$req"
           done
@@ -186,7 +186,7 @@ jobs:
       - name: Run tests with lowest-direct resolution
         env:
           UV_EXTRA_INDEX_URL: ${{ secrets.UV_EXTRA_INDEX_URL }}
-        run: uv run --resolution lowest-direct pytest tests -q --ignore=tests/stress --ignore=tests/benchmarks
+        run: uv run --all-extras --resolution lowest-direct pytest tests -q --ignore=tests/stress --ignore=tests/benchmarks
 
   typecheck:
     name: Type checking (Python ${{ matrix.python-version }})


### PR DESCRIPTION
## Problem
The **Lowest-direct dependency compatibility** job runs:

```yaml
uv sync --resolution lowest-direct
# ...
uv run --resolution lowest-direct pytest tests ...
```

`uv sync`/`uv run` install only the project's core dependencies plus the default group — **optional extras are excluded**. For a project that puts part of its public API (and the matching tests) behind an optional extra, test collection fails in this job with `ModuleNotFoundError` on the extra's packages, even though the package and its full test suite are correct.

Concrete case: `tschm/TinyCTA` moved its Optuna/hyperopt stack into a `hyper` extra; the lowest-deps job then failed to import `tinycta.hyper` (`No module named 'optuna'`).

## Change
Add `--all-extras` to both steps of the `lowest-deps` job, so the floor-version compatibility check also resolves and installs extras. This matches the main test job, which already installs everything (`make test` → `uv sync --all-extras --all-groups`).

```diff
- uv sync --resolution lowest-direct
+ uv sync --all-extras --resolution lowest-direct
...
- run: uv run --resolution lowest-direct pytest tests -q ...
+ run: uv run --all-extras --resolution lowest-direct pytest tests -q ...
```

Both lines are needed: `uv run` re-syncs the environment to the default groups, which would otherwise drop extras installed by the preceding `uv sync`.

## Impact
- Projects with no extras: no behavioural change (`--all-extras` is a no-op).
- Projects with extras: the lowest-direct job now exercises them at their floor versions — strictly more coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)