### PR TITLE
feat(github): stub remaining rhiza_* workflows and auto-pin stub versions

### DIFF
--- a/.github/workflows/rhiza_fuzzing.yml
+++ b/.github/workflows/rhiza_fuzzing.yml
@@ -17,6 +17,8 @@ on:
   schedule:
     - cron: '17 3 * * 6'
   workflow_dispatch:
+  # Callable as a reusable workflow by the github-bundle stub in downstream repos.
+  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/rhiza_mutation.yml
+++ b/.github/workflows/rhiza_mutation.yml
@@ -1,0 +1,66 @@
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
+#
+# Workflow: Mutation Testing (reusable)
+#
+# Purpose: Measure test *assertion strength* with mutmut. 100% line/branch
+#          coverage proves code is executed, not that a wrong result would be
+#          caught; surviving mutants reveal assertions that are too weak.
+#
+#          `make mutation` exits non-zero on any surviving mutant
+#          (genuinely-equivalent ones are marked `# pragma: no mutate`), so the
+#          job is a blocking gate when enabled. The HTML report is uploaded as
+#          an artifact for inspection.
+#
+#          Opt-in: set the MUTATION_ENABLED repository variable to 'true' to
+#          run the gate. It is skipped otherwise, so adopting this bundle never
+#          breaks a repo that has not yet reached a 100% mutation score.
+#
+#          This is the canonical reusable workflow; downstream repos call it
+#          via the thin stub shipped in the github-tests bundle.
+#
+# Trigger: workflow_call (from the bundle stub), plus a weekly schedule and
+#          manual dispatch for rhiza's own repository. Mutation runs are slow,
+#          so it does NOT run per-PR.
+
+name: "(RHIZA) MUTATION"
+
+# Cancel superseded in-progress runs of this workflow for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+on:
+  schedule:
+    - cron: "0 9 * * 1"  # Monday 09:00 UTC (after the rhiza weekly job at 08:00)
+  workflow_dispatch:
+  # Callable as a reusable workflow by the github-tests bundle stub in downstream repos.
+  workflow_call:
+
+jobs:
+  mutation:
+    runs-on: ubuntu-latest
+    # Opt-in gate: only run where the repo has explicitly enabled mutation testing.
+    if: vars.MUTATION_ENABLED == 'true'
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      # `make mutation` bootstraps uv, creates the venv, installs deps, then runs
+      # mutmut. It exits non-zero when any mutant survives, failing the job.
+      - name: Run mutation tests
+        run: make mutation
+
+      - name: Upload mutation report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mutation-report
+          path: _tests/mutation/html
+          if-no-files-found: warn

--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -25,6 +25,8 @@ on:
   push:
     branches: [ "main", "master" ]
   workflow_dispatch:
+  # Callable as a reusable workflow by the github-bundle stub in downstream repos.
+  workflow_call:
 
 # Cancel superseded in-progress runs of this workflow for the same ref.
 concurrency:

--- a/.rhiza/.cfg.toml
+++ b/.rhiza/.cfg.toml
@@ -32,3 +32,19 @@ values = [
 filename = "pyproject.toml"
 search = 'version = "{current_version}"'
 replace = 'version = "{new_version}"'
+
+# Keep the reusable-workflow stubs in the bundles pinned to the current release.
+# These stubs are synced into downstream repos and must reference an existing tag.
+# The search is a regex anchored to the `jebel-quant/rhiza/...` path so it rewrites
+# the pin from ANY prior version (not just {current_version}) — this prevents silent
+# drift if a stub was left behind — while leaving third-party action pins
+# (actions/checkout@vX, astral-sh/setup-uv@vX, ...) in the same files untouched.
+# This block ships verbatim in the synced downstream .cfg.toml; there it is a
+# harmless no-op because a downstream repo has no bundles/ tree (the glob matches
+# nothing and bump-my-version skips it).
+[[tool.bumpversion.files]]
+glob = "bundles/**/.github/workflows/*.yml"
+regex = true
+search = "(jebel-quant/rhiza/[^@\\s]+)@v\\d+\\.\\d+\\.\\d+"
+replace = "\\1@v{new_version}"
+ignore_missing_version = true

--- a/bundles/core/.rhiza/.cfg.toml
+++ b/bundles/core/.rhiza/.cfg.toml
@@ -32,3 +32,19 @@ values = [
 filename = "pyproject.toml"
 search = 'version = "{current_version}"'
 replace = 'version = "{new_version}"'
+
+# Keep the reusable-workflow stubs in the bundles pinned to the current release.
+# These stubs are synced into downstream repos and must reference an existing tag.
+# The search is a regex anchored to the `jebel-quant/rhiza/...` path so it rewrites
+# the pin from ANY prior version (not just {current_version}) — this prevents silent
+# drift if a stub was left behind — while leaving third-party action pins
+# (actions/checkout@vX, astral-sh/setup-uv@vX, ...) in the same files untouched.
+# This block ships verbatim in the synced downstream .cfg.toml; there it is a
+# harmless no-op because a downstream repo has no bundles/ tree (the glob matches
+# nothing and bump-my-version skips it).
+[[tool.bumpversion.files]]
+glob = "bundles/**/.github/workflows/*.yml"
+regex = true
+search = "(jebel-quant/rhiza/[^@\\s]+)@v\\d+\\.\\d+\\.\\d+"
+replace = "\\1@v{new_version}"
+ignore_missing_version = true

--- a/bundles/gh-aw/.github/workflows/copilot-setup-steps.yml
+++ b/bundles/gh-aw/.github/workflows/copilot-setup-steps.yml
@@ -45,7 +45,7 @@ jobs:
           version: "0.11.16"
 
       - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v0.18.9
+        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v0.18.10
         with:
           token: ${{ secrets.GH_PAT }}
 

--- a/bundles/gh-aw/.github/workflows/rhiza_gh-aw-validate.yml
+++ b/bundles/gh-aw/.github/workflows/rhiza_gh-aw-validate.yml
@@ -8,18 +8,13 @@
 #          running `gh aw compile`. Skips gracefully when the gh-aw extension
 #          is not yet available.
 #
+#          Thin stub: the validation logic lives in the reusable workflow in
+#          jebel-quant/rhiza; this file only wires up the triggers.
+#
 # Trigger: On pull requests and pushes to main when .github/workflows/*.md or
 #          *.lock.yml files change.
 
 name: "(RHIZA) VALIDATE AGENTIC WORKFLOWS"
-
-# Cancel superseded in-progress runs of this workflow for the same ref.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
-permissions:
-  contents: read
 
 on:
   pull_request:
@@ -32,41 +27,17 @@ on:
       - ".github/workflows/*.md"
       - ".github/workflows/*.lock.yml"
 
+# Cancel superseded in-progress runs of this workflow for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   validate:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6.0.2
-
-      - name: Install gh-aw extension
-        id: install-gh-aw
-        continue-on-error: true
-        run: |
-          if output=$(gh extension install github/gh-aw 2>&1); then
-            echo "available=true" >> "$GITHUB_OUTPUT"
-          elif echo "$output" | grep -q "HTTP 403\|not found"; then
-            echo "gh-aw extension not available (expected for public repos)"
-            echo "available=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "Failed to install gh-aw: $output"
-            echo "available=false" >> "$GITHUB_OUTPUT"
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Validate lock files are up-to-date
-        if: steps.install-gh-aw.outputs.available == 'true'
-        run: |
-          gh aw compile
-          if ! git diff --quiet .github/workflows/*.lock.yml; then
-            echo "::error::Agentic workflow lock files are out of date. Run 'gh aw compile' and commit the changes."
-            git diff .github/workflows/*.lock.yml
-            exit 1
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Skip validation (gh-aw not available)
-        if: steps.install-gh-aw.outputs.available != 'true'
-        run: |
-          echo "::notice::Skipping validation - gh-aw extension not available. This is expected until gh-aw is publicly released."
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_gh-aw-validate.yml@v0.18.10
+    secrets: inherit
+    permissions:
+      contents: read

--- a/bundles/github-book/.github/workflows/rhiza_book.yml
+++ b/bundles/github-book/.github/workflows/rhiza_book.yml
@@ -32,7 +32,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v0.18.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v0.18.10
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml
+++ b/bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml
@@ -34,7 +34,7 @@ on:
 
 jobs:
   devcontainer:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v0.18.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v0.18.10
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-docker/.github/workflows/rhiza_docker.yml
+++ b/bundles/github-docker/.github/workflows/rhiza_docker.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   docker:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v0.18.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v0.18.10
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-marimo/.github/workflows/rhiza_marimo.yml
+++ b/bundles/github-marimo/.github/workflows/rhiza_marimo.yml
@@ -33,5 +33,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v0.18.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v0.18.10
     secrets: inherit

--- a/bundles/github-paper/.github/workflows/rhiza_paper.yml
+++ b/bundles/github-paper/.github/workflows/rhiza_paper.yml
@@ -33,7 +33,7 @@ on:
 
 jobs:
   paper:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v0.18.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v0.18.10
     secrets: inherit
     permissions:
       contents: write

--- a/bundles/github-tests/.github/workflows/rhiza_benchmark.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_benchmark.yml
@@ -25,5 +25,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v0.18.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v0.18.10
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_ci.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_ci.yml
@@ -31,5 +31,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v0.18.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v0.18.10
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_codeql.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_codeql.yml
@@ -31,7 +31,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v0.18.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v0.18.10
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/bundles/github-tests/.github/workflows/rhiza_mutation.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_mutation.yml
@@ -7,14 +7,13 @@
 #          coverage proves code is executed, not that a wrong result would be
 #          caught; surviving mutants reveal assertions that are too weak.
 #
-#          `make mutation` exits non-zero on any surviving mutant
-#          (genuinely-equivalent ones are marked `# pragma: no mutate`), so the
-#          job is a blocking gate when enabled. The HTML report is uploaded as
-#          an artifact for inspection.
-#
 #          Opt-in: set the MUTATION_ENABLED repository variable to 'true' to
 #          run the gate. It is skipped otherwise, so adopting this bundle never
 #          breaks a repo that has not yet reached a 100% mutation score.
+#
+#          Thin stub: the mutation logic and the opt-in gate live in the
+#          reusable workflow in jebel-quant/rhiza; this file only wires up the
+#          triggers.
 #
 # Trigger: Weekly schedule (mutation runs are slow) and manual dispatch — it
 #          does NOT run per-PR, to avoid adding minutes to every pull request.
@@ -36,25 +35,7 @@ on:
 
 jobs:
   mutation:
-    runs-on: ubuntu-latest
-    # Opt-in gate: only run where the repo has explicitly enabled mutation testing.
-    if: vars.MUTATION_ENABLED == 'true'
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.12"
-
-      # `make mutation` bootstraps uv, creates the venv, installs deps, then runs
-      # mutmut. It exits non-zero when any mutant survives, failing the job.
-      - name: Run mutation tests
-        run: make mutation
-
-      - name: Upload mutation report
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: mutation-report
-          path: _tests/mutation/html
-          if-no-files-found: warn
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v0.18.10
+    secrets: inherit
+    permissions:
+      contents: read

--- a/bundles/github/.github/workflows/rhiza_fuzzing.yml
+++ b/bundles/github/.github/workflows/rhiza_fuzzing.yml
@@ -6,6 +6,12 @@
 # Purpose: Run coverage-guided fuzzing for the repository's Python security
 #          parsing utilities. Pull requests run short code-change fuzzing,
 #          while main-branch pushes and the weekly schedule run batch fuzzing.
+#
+#          Thin stub: the fuzzing logic lives in the reusable workflow in
+#          jebel-quant/rhiza; this file only wires up the triggers.
+#
+# Trigger: Pull requests, pushes to main/master, weekly schedule, and manual
+#          dispatch.
 
 name: "(RHIZA) FUZZING"
 
@@ -18,64 +24,18 @@ on:
     - cron: '17 3 * * 6'
   workflow_dispatch:
 
+# Cancel superseded in-progress runs of this workflow for the same ref.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
-  pr-fuzzing:
-    name: ClusterFuzzLite PR fuzzing
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Build fuzzers
-        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
-        with:
-          language: python
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          sanitizer: address
-
-      - name: Run fuzzers
-        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          fuzz-seconds: 300
-          mode: "code-change"
-          output-sarif: true
-          sanitizer: address
-
-  batch-fuzzing:
-    name: ClusterFuzzLite batch fuzzing
-    if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Build fuzzers
-        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
-        with:
-          language: python
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          sanitizer: address
-
-      - name: Run fuzzers
-        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          fuzz-seconds: ${{ github.event_name == 'schedule' && '1800' || '300' }}
-          mode: "batch"
-          sanitizer: address
+  fuzzing:
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v0.18.10
+    secrets: inherit
+    permissions:
+      contents: read
+      security-events: write   # Upload fuzzing SARIF to code scanning

--- a/bundles/github/.github/workflows/rhiza_release.yml
+++ b/bundles/github/.github/workflows/rhiza_release.yml
@@ -218,7 +218,7 @@ jobs:
           version: "0.11.16"
 
       - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v0.18.9
+        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v0.18.10
         with:
           token: ${{ secrets.GH_PAT }}
 

--- a/bundles/github/.github/workflows/rhiza_scorecard.yml
+++ b/bundles/github/.github/workflows/rhiza_scorecard.yml
@@ -11,6 +11,10 @@
 #          force-enable on private repos, 'false' to disable, or leave unset
 #          for auto-detect (public repositories only).
 #
+#          Thin stub: the analysis logic and its enablement/visibility gate
+#          live in the reusable workflow in jebel-quant/rhiza; this file only
+#          wires up the triggers and grants the token scopes Scorecard needs.
+#
 # Trigger: Weekly schedule, pushes to main, branch-protection changes, and
 #          manual dispatch.
 
@@ -31,48 +35,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# Least privilege by default; the job grants itself only what Scorecard needs.
+# Least privilege by default; the called workflow grants its job only what
+# Scorecard needs (see the job-level permissions below).
 permissions: read-all
 
 jobs:
-  analysis:
-    name: Scorecard analysis
-    runs-on: ubuntu-latest
-    # Publishing results and the public score only work on public repositories.
-    if: |
-      vars.SCORECARD_ENABLED == 'true' ||
-      (vars.SCORECARD_ENABLED != 'false' && github.event.repository.visibility == 'public')
+  scorecard:
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v0.18.10
+    secrets: inherit
     permissions:
-      # Needed to upload the SARIF results to code scanning.
-      security-events: write
-      # Needed to publish results to the OpenSSF REST API (badge support).
-      id-token: write
+      security-events: write   # Upload the SARIF results to code scanning
+      id-token: write          # Publish results to the OpenSSF REST API (badge)
       contents: read
       actions: read
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Run Scorecard analysis
-        uses: ossf/scorecard-action@v2.4.3
-        with:
-          results_file: results.sarif
-          results_format: sarif
-          # Publish to the OpenSSF REST API so the score is externally
-          # verifiable and the README badge stays current (public repos only).
-          publish_results: true
-
-      - name: Upload Scorecard results artifact
-        uses: actions/upload-artifact@v7.0.1
-        with:
-          name: scorecard-results
-          path: results.sarif
-          retention-days: 5
-
-      - name: Upload results to code scanning
-        uses: github/codeql-action/upload-sarif@v4.36.0
-        with:
-          sarif_file: results.sarif

--- a/bundles/github/.github/workflows/rhiza_sync.yml
+++ b/bundles/github/.github/workflows/rhiza_sync.yml
@@ -41,7 +41,7 @@ on:
 
 jobs:
   sync:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_sync.yml@v0.18.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_sync.yml@v0.18.10
     with:
       direct: ${{ github.event_name == 'push' }}
       create-pr: ${{ github.event_name != 'push' && (github.event_name == 'schedule' || inputs.create-pr == true) }}

--- a/bundles/github/.github/workflows/rhiza_weekly.yml
+++ b/bundles/github/.github/workflows/rhiza_weekly.yml
@@ -33,5 +33,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v0.18.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v0.18.10
     secrets: inherit

--- a/tests/bundles/test_bundle_content_validity.py
+++ b/tests/bundles/test_bundle_content_validity.py
@@ -210,24 +210,44 @@ class TestBundleDocumentation:
 # ---------------------------------------------------------------------------
 
 
-class TestGithubWorkflowStubs:
-    """Workflow files injected by github-* overlay bundles must delegate correctly."""
+# Prefix every reusable-workflow stub must call to delegate to this repository.
+_REUSABLE_WORKFLOW_PREFIX = "jebel-quant/rhiza/.github/workflows/"
 
-    def _github_overlay_bundles(self, bundle_names: list[str]) -> list[str]:
-        """Return bundle names that are github-* overlays."""
-        return [n for n in bundle_names if n.startswith("github-")]
+# rhiza_*.yml workflows that are intentionally NOT thin stubs.  rhiza_release.yml
+# is a full release-automation workflow that runs many first-party steps itself
+# rather than delegating to a reusable workflow.
+_NON_STUB_RHIZA_WORKFLOWS = {"rhiza_release.yml"}
+
+
+def _load_workflow_doc(path: Path) -> object:
+    """Parse a workflow YAML file and return the loaded document."""
+    with path.open(encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+class TestGithubWorkflowStubs:
+    """Bundle-shipped GitHub workflows must delegate to jebel-quant/rhiza reusables.
+
+    Covers every bundle that ships a .github/workflows/ directory — not just the
+    github-* overlays, but also the `github` and `gh-aw` bundles.  Documented full
+    workflows (rhiza_release.yml) are excepted from the thin-stub requirement.
+    """
+
+    def _bundles_with_github_workflows(self, root: Path, bundle_names: list[str]) -> list[tuple[str, Path]]:
+        """Return (bundle_name, workflows_dir) for every bundle shipping GitHub workflows."""
+        result: list[tuple[str, Path]] = []
+        for bundle_name in bundle_names:
+            workflows_dir = root / "bundles" / bundle_name / ".github" / "workflows"
+            if workflows_dir.is_dir():
+                result.append((bundle_name, workflows_dir))
+        return result
 
     def test_workflow_stubs_have_name_field(self, root: Path, bundle_names: list[str]) -> None:
         """Every GitHub workflow YAML file has a top-level 'name' field."""
         errors: list[str] = []
-        for bundle_name in self._github_overlay_bundles(bundle_names):
-            bundle_dir = root / "bundles" / bundle_name
-            workflows_dir = bundle_dir / ".github" / "workflows"
-            if not workflows_dir.is_dir():
-                continue
+        for bundle_name, workflows_dir in self._bundles_with_github_workflows(root, bundle_names):
             for wf in workflows_dir.glob("*.yml"):
-                with wf.open(encoding="utf-8") as fh:
-                    doc = yaml.safe_load(fh)
+                doc = _load_workflow_doc(wf)
                 if not isinstance(doc, dict) or "name" not in doc:
                     errors.append(f"  [{bundle_name}] {wf.name}: missing 'name' field")
         if errors:
@@ -241,14 +261,9 @@ class TestGithubWorkflowStubs:
         handle both parsed and raw representations.
         """
         errors: list[str] = []
-        for bundle_name in self._github_overlay_bundles(bundle_names):
-            bundle_dir = root / "bundles" / bundle_name
-            workflows_dir = bundle_dir / ".github" / "workflows"
-            if not workflows_dir.is_dir():
-                continue
+        for bundle_name, workflows_dir in self._bundles_with_github_workflows(root, bundle_names):
             for wf in workflows_dir.glob("*.yml"):
-                with wf.open(encoding="utf-8") as fh:
-                    doc = yaml.safe_load(fh)
+                doc = _load_workflow_doc(wf)
                 if not isinstance(doc, dict):
                     errors.append(f"  [{bundle_name}] {wf.name}: not a YAML mapping")
                     continue
@@ -262,14 +277,9 @@ class TestGithubWorkflowStubs:
     def test_workflow_stubs_have_jobs(self, root: Path, bundle_names: list[str]) -> None:
         """Every GitHub workflow YAML file has a non-empty 'jobs' section."""
         errors: list[str] = []
-        for bundle_name in self._github_overlay_bundles(bundle_names):
-            bundle_dir = root / "bundles" / bundle_name
-            workflows_dir = bundle_dir / ".github" / "workflows"
-            if not workflows_dir.is_dir():
-                continue
+        for bundle_name, workflows_dir in self._bundles_with_github_workflows(root, bundle_names):
             for wf in workflows_dir.glob("*.yml"):
-                with wf.open(encoding="utf-8") as fh:
-                    doc = yaml.safe_load(fh)
+                doc = _load_workflow_doc(wf)
                 if not isinstance(doc, dict):
                     continue
                 jobs = doc.get("jobs")
@@ -278,25 +288,68 @@ class TestGithubWorkflowStubs:
         if errors:
             pytest.fail("Workflow stubs without 'jobs':\n" + "\n".join(errors))
 
-    def test_workflow_stubs_delegate_to_jebel_quant_rhiza(self, root: Path, bundle_names: list[str]) -> None:
-        """Workflow stubs that contain a 'uses:' job reference the jebel-quant/rhiza repo."""
+    def test_reusable_calls_target_rhiza_workflows(self, root: Path, bundle_names: list[str]) -> None:
+        """Every job that calls a reusable workflow must target a jebel-quant/rhiza one.
+
+        This inspects the parsed job-level ``uses:`` reference rather than doing a
+        substring search of the file, so it is not satisfied by the jebel-quant/rhiza
+        URL in the boilerplate header comment.  Step-level ``uses:`` (third-party
+        actions) are intentionally ignored.
+        """
         errors: list[str] = []
-        for bundle_name in self._github_overlay_bundles(bundle_names):
-            bundle_dir = root / "bundles" / bundle_name
-            workflows_dir = bundle_dir / ".github" / "workflows"
-            if not workflows_dir.is_dir():
-                continue
+        for bundle_name, workflows_dir in self._bundles_with_github_workflows(root, bundle_names):
             for wf in workflows_dir.glob("*.yml"):
-                content = wf.read_text(encoding="utf-8")
-                # Only check workflows that use the reusable workflow pattern
-                if "uses:" not in content:
+                doc = _load_workflow_doc(wf)
+                if not isinstance(doc, dict):
                     continue
-                if "jebel-quant/rhiza" not in content:
-                    errors.append(
-                        f"  [{bundle_name}] {wf.name}: 'uses:' present but does not reference jebel-quant/rhiza"
-                    )
+                for job_name, job in (doc.get("jobs") or {}).items():
+                    if not isinstance(job, dict):
+                        continue
+                    uses = job.get("uses")
+                    if uses is None:
+                        continue  # not a reusable-workflow call
+                    if not (isinstance(uses, str) and uses.startswith(_REUSABLE_WORKFLOW_PREFIX)):
+                        errors.append(
+                            f"  [{bundle_name}] {wf.name}: job '{job_name}' calls '{uses}', "
+                            f"not a {_REUSABLE_WORKFLOW_PREFIX}* reusable workflow"
+                        )
         if errors:
-            pytest.fail("Workflow stubs with non-rhiza 'uses:' references:\n" + "\n".join(errors))
+            pytest.fail("Reusable-workflow calls not targeting jebel-quant/rhiza:\n" + "\n".join(errors))
+
+    def test_rhiza_workflows_are_thin_stubs(self, root: Path, bundle_names: list[str]) -> None:
+        """Every rhiza_*.yml bundle workflow is a thin stub (except documented exceptions).
+
+        A thin stub delegates entirely to a jebel-quant/rhiza reusable workflow: each
+        of its jobs has a ``uses:`` pointing at that repo and defines no inline
+        ``steps:``.  rhiza_release.yml is exempt (it is a full release workflow).
+        """
+        errors: list[str] = []
+        for bundle_name, workflows_dir in self._bundles_with_github_workflows(root, bundle_names):
+            for wf in workflows_dir.glob("*.yml"):
+                if not wf.name.startswith("rhiza_") or wf.name in _NON_STUB_RHIZA_WORKFLOWS:
+                    continue
+                doc = _load_workflow_doc(wf)
+                jobs = doc.get("jobs") if isinstance(doc, dict) else None
+                if not jobs:
+                    errors.append(f"  [{bundle_name}] {wf.name}: no jobs to delegate")
+                    continue
+                for job_name, job in jobs.items():
+                    if not isinstance(job, dict):
+                        errors.append(f"  [{bundle_name}] {wf.name}: job '{job_name}' is malformed")
+                        continue
+                    uses = job.get("uses")
+                    if not (isinstance(uses, str) and uses.startswith(_REUSABLE_WORKFLOW_PREFIX)):
+                        errors.append(
+                            f"  [{bundle_name}] {wf.name}: job '{job_name}' does not delegate to a "
+                            f"{_REUSABLE_WORKFLOW_PREFIX}* reusable workflow"
+                        )
+                    if "steps" in job:
+                        errors.append(
+                            f"  [{bundle_name}] {wf.name}: job '{job_name}' defines inline steps; "
+                            f"rhiza_* workflows must be thin stubs (add it to the reusable workflow instead)"
+                        )
+        if errors:
+            pytest.fail("rhiza_* bundle workflows that are not thin stubs:\n" + "\n".join(errors))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Completes the reusable-workflow-stub migration and wires up automatic version pinning for the stubs.

### Stub conversions
Converts the last full bundle workflows into thin reusable-workflow stubs — **all `rhiza_*` except `rhiza_release`**:
- `bundles/github/rhiza_fuzzing.yml`, `rhiza_scorecard.yml`
- `bundles/gh-aw/rhiza_gh-aw-validate.yml`
- `bundles/github-tests/rhiza_mutation.yml`

`rhiza_mutation` had no reusable counterpart, so this adds a canonical **`.github/workflows/rhiza_mutation.yml`** (`workflow_call`-enabled) that the stub delegates to. `rhiza_fuzzing`/`rhiza_scorecard` root workflows gain `workflow_call` so their stubs can delegate.

### Auto-pinning the stub versions (`.rhiza/.cfg.toml`)
Adds a bump-my-version glob block that keeps every `jebel-quant/rhiza/...@vX.Y.Z` pin in lockstep with the release on each `make bump`. The search is a **regex anchored to the `jebel-quant/rhiza` path**, so it rewrites the pin from *any* prior version (no silent drift) while leaving third-party action pins (`actions/checkout@…`, etc.) untouched. It ships verbatim in the synced downstream `.cfg.toml` (byte-identical, per `test_bundle_rhiza_sync.py`), where it is a harmless no-op — a downstream repo has no `bundles/` tree for the glob to match. All stubs re-pinned to the current release.

> Why not `{{ version }}`? Rhiza syncs files **verbatim** (no Jinja — see `WHY_NOT_COPIER_CRUFT.md`), the stub also runs in Rhiza's own CI, and GitHub requires reusable-workflow `uses:` refs to be literal. The literal-pin + bump-regex is the idiomatic fit.

### Strengthened tests (`tests/bundles/test_bundle_content_validity.py`)
- Coverage broadened from `github-*` overlays to **every** bundle shipping GitHub workflows (now includes `bundles/github/` and `bundles/gh-aw/`).
- Replaced the weak substring delegation check (which the boilerplate header satisfied) with one that inspects the **parsed job-level `uses:` target**.
- Added `test_rhiza_workflows_are_thin_stubs` asserting every `rhiza_*.yml` bundle workflow is a thin stub except `rhiza_release.yml` (verified it fails when a stub is fattened).

## Release ordering note
`fuzzing`/`scorecard`/`mutation` only become `workflow_call`-able as of this branch, so the `@v0.18.10` pins are only fully consistent once the **next release (`0.18.11`)** runs `make bump` and repoints them to a tag that contains both the callable reusables and the repointed stubs.

## Test plan
- [x] `tests/api/` + `tests/bundles/` — 509 passed
- [x] `make fmt` clean (ruff, actionlint, secrets, etc.)
- [x] Negative-tested the new thin-stub assertion (fails on a fattened stub)
- [x] Verified the bump regex rewrites only rhiza pins, leaving third-party action pins untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)