### PR TITLE
Add /quality slash command for running quality gates

### DIFF
--- a/.claude/commands/quality.md
+++ b/.claude/commands/quality.md
@@ -1,0 +1,27 @@
+---
+description: Run the full code-quality gate (format, lint, types, tests, deps, docs, security)
+---
+
+Run the project's quality gates in order and report results. These mirror the
+requirements in `CLAUDE.md`. Follow the command-execution policy: always prefer
+`make <target>`; never invoke `.venv/bin/...` directly.
+
+Run each of the following, in order:
+
+1. `make fmt` — pre-commit hooks (ruff format/check, markdownlint, bandit, actionlint, interrogate, jsonschema, uv-lock)
+2. `make typecheck` — static type checking with `ty`
+3. `make deptry` — unused/missing dependency check
+4. `make docs-coverage` — docstring coverage (100% required)
+5. `make test` — full test suite with coverage (90% minimum)
+6. `make security` — pip-audit + bandit scans
+
+Guidelines:
+
+- Run the gates and let earlier failures inform the later ones, but run all of
+  them so the user sees the complete picture rather than stopping at the first
+  failure.
+- If something fails, show the relevant output, diagnose the root cause, and
+  propose (or apply, if clearly correct and low-risk) a fix.
+- If `$ARGUMENTS` is non-empty, treat it as a scope hint (e.g. a subset of gates
+  to run, or specific files/paths to focus the checks on) and adjust accordingly.
+- End with a concise PASS/FAIL summary per gate.


### PR DESCRIPTION
## Summary

Adds the `/quality` slash command (`.claude/commands/quality.md`) that runs the project's quality gates in order, mirroring the requirements in `CLAUDE.md`:

1. `make fmt` — pre-commit hooks (ruff, markdownlint, bandit, actionlint, jsonschema, uv-lock)
2. `make typecheck` — static type checking with `ty`
3. `make deptry` — unused/missing dependency check
4. `make docs-coverage` — docstring coverage (100% required)
5. `make test` — full test suite with coverage (90% minimum)
6. `make security` — pip-audit + bandit scans

The command runs all gates (letting earlier failures inform later ones), shows relevant output on failure, and ends with a per-gate PASS/FAIL summary.

## Test plan

All gates pass on `main`:
- `make fmt` ✅
- `make typecheck` ✅ (skipped — no `src/`)
- `make deptry` ✅
- `make docs-coverage` ✅ (skipped — no `src/`)
- `make test` ✅ 929 passed
- `make security` ✅ pip-audit clean, bandit no targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)