### PR TITLE
Silence deptry "Assuming module name" warnings via package_module_name_map

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,4 +57,24 @@ Repository = "https://github.com/jebel-quant/rhiza"
 Issues = "https://github.com/jebel-quant/rhiza/issues"
 
 [tool.deptry.package_module_name_map]
+# uvx runs deptry without the project deps installed, so it cannot read each
+# package's metadata to resolve the import module name. Declaring the mappings
+# explicitly silences the "Assuming the corresponding module name ..." warnings.
 pyyaml = "yaml"
+ruff = "ruff"
+interrogate = "interrogate"
+pre-commit = "pre_commit"
+pytest = "pytest"
+pytest-cov = "pytest_cov"
+hypothesis = "hypothesis"
+pytest-timeout = "pytest_timeout"
+pytest-xdist = "xdist"
+pytest-html = "pytest_html"
+python-dotenv = "dotenv"
+defusedxml = "defusedxml"
+mutmut = "mutmut"
+marimo = "marimo"
+numpy = "numpy"
+plotly = "plotly"
+pandas = "pandas"
+mkdocs-material = "mkdocs_material"


### PR DESCRIPTION
## Problem

`make deptry` printed an `Assuming the corresponding module name of package '<x>' is '<y>'. Install the package or configure a package_module_name_map entry to override this behaviour.` warning for nearly every dependency.

The target runs `uvx deptry` in an **isolated environment without the project deps installed**, so deptry cannot read each package's metadata to resolve its import module name and falls back to guessing — one warning per dependency.

## Fix

Declare the mappings explicitly in `[tool.deptry.package_module_name_map]`, exactly as deptry's own message suggests. Used the correct import module names where they differ from deptry's guesses:

- `pytest-xdist → xdist` (deptry guessed `pytest_xdist`)
- `python-dotenv → dotenv` (deptry guessed `python_dotenv`)

## Verification

`make deptry` now runs clean:

```
Scanning 1 file...
Success! No dependency issues found.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)