### PR TITLE
Extend docs-coverage to the test packages

### DIFF
--- a/.rhiza/make.d/test.mk
+++ b/.rhiza/make.d/test.mk
@@ -116,6 +116,12 @@ docs-coverage: install ## check documentation coverage with interrogate
 	if [ -d ".rhiza/utils" ]; then \
 	  docstring_paths="$${docstring_paths} .rhiza/utils"; \
 	fi; \
+	if [ -d "tests" ]; then \
+	  docstring_paths="$${docstring_paths} tests"; \
+	fi; \
+	if [ -d ".rhiza/tests" ]; then \
+	  docstring_paths="$${docstring_paths} .rhiza/tests"; \
+	fi; \
 	if [ -n "$${docstring_paths}" ]; then \
 	  printf "${BLUE}[INFO] Checking documentation coverage in:$${docstring_paths}${RESET}\n"; \
 	  ${UV_BIN} run interrogate -vv --fail-under 100 --ignore-init-method --ignore-magic $${docstring_paths}; \

--- a/.rhiza/tests/utils/test_pip_audit_policy.py
+++ b/.rhiza/tests/utils/test_pip_audit_policy.py
@@ -12,6 +12,7 @@ from test_utils import strip_ansi
 
 
 def _load_module(root: Path):
+    """Import the repo's pip_audit_policy.py utility as a standalone module."""
     module_path = root / ".rhiza" / "utils" / "pip_audit_policy.py"
     spec = importlib.util.spec_from_file_location("pip_audit_policy", module_path)
     assert spec is not None
@@ -37,6 +38,7 @@ def test_main_returns_zero_and_forwards_args_when_audit_passes(root, monkeypatch
     seen: dict[str, list[str]] = {}
 
     def _fake_run(cmd: list[str], *, capture_output: bool, text: bool):
+        """Record the invoked command and return a passing (returncode 0) pip-audit result."""
         seen["cmd"] = cmd
         assert capture_output is True
         assert text is True
@@ -56,6 +58,7 @@ def test_main_echoes_raw_output_when_json_parsing_fails(root, monkeypatch, capsy
     module = _load_module(root)
 
     def _fake_run(*args, **kwargs):
+        """Return a failing pip-audit result with non-JSON stdout to exercise the passthrough path."""
         return SimpleNamespace(returncode=2, stdout="oops\n", stderr="bad\n")
 
     monkeypatch.setattr(module.subprocess, "run", _fake_run)

--- a/.rhiza/tests/utils/test_suppression_audit.py
+++ b/.rhiza/tests/utils/test_suppression_audit.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 
 
 def _load_module(root: Path):
+    """Import the repo's suppression_audit.py utility as a standalone module."""
     module_path = root / ".rhiza" / "utils" / "suppression_audit.py"
     spec = importlib.util.spec_from_file_location("suppression_audit", module_path)
     assert spec is not None

--- a/bundles/tests/.rhiza/make.d/test.mk
+++ b/bundles/tests/.rhiza/make.d/test.mk
@@ -116,6 +116,12 @@ docs-coverage: install ## check documentation coverage with interrogate
 	if [ -d ".rhiza/utils" ]; then \
 	  docstring_paths="$${docstring_paths} .rhiza/utils"; \
 	fi; \
+	if [ -d "tests" ]; then \
+	  docstring_paths="$${docstring_paths} tests"; \
+	fi; \
+	if [ -d ".rhiza/tests" ]; then \
+	  docstring_paths="$${docstring_paths} .rhiza/tests"; \
+	fi; \
 	if [ -n "$${docstring_paths}" ]; then \
 	  printf "${BLUE}[INFO] Checking documentation coverage in:$${docstring_paths}${RESET}\n"; \
 	  ${UV_BIN} run interrogate -vv --fail-under 100 --ignore-init-method --ignore-magic $${docstring_paths}; \

--- a/bundles/tests/.rhiza/tests/utils/test_pip_audit_policy.py
+++ b/bundles/tests/.rhiza/tests/utils/test_pip_audit_policy.py
@@ -12,6 +12,7 @@ from test_utils import strip_ansi
 
 
 def _load_module(root: Path):
+    """Import the repo's pip_audit_policy.py utility as a standalone module."""
     module_path = root / ".rhiza" / "utils" / "pip_audit_policy.py"
     spec = importlib.util.spec_from_file_location("pip_audit_policy", module_path)
     assert spec is not None
@@ -37,6 +38,7 @@ def test_main_returns_zero_and_forwards_args_when_audit_passes(root, monkeypatch
     seen: dict[str, list[str]] = {}
 
     def _fake_run(cmd: list[str], *, capture_output: bool, text: bool):
+        """Record the invoked command and return a passing (returncode 0) pip-audit result."""
         seen["cmd"] = cmd
         assert capture_output is True
         assert text is True
@@ -56,6 +58,7 @@ def test_main_echoes_raw_output_when_json_parsing_fails(root, monkeypatch, capsy
     module = _load_module(root)
 
     def _fake_run(*args, **kwargs):
+        """Return a failing pip-audit result with non-JSON stdout to exercise the passthrough path."""
         return SimpleNamespace(returncode=2, stdout="oops\n", stderr="bad\n")
 
     monkeypatch.setattr(module.subprocess, "run", _fake_run)

--- a/bundles/tests/.rhiza/tests/utils/test_suppression_audit.py
+++ b/bundles/tests/.rhiza/tests/utils/test_suppression_audit.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 
 
 def _load_module(root: Path):
+    """Import the repo's suppression_audit.py utility as a standalone module."""
     module_path = root / ".rhiza" / "utils" / "suppression_audit.py"
     spec = importlib.util.spec_from_file_location("suppression_audit", module_path)
     assert spec is not None

--- a/tests/bundles/test_template_bundles.py
+++ b/tests/bundles/test_template_bundles.py
@@ -349,6 +349,7 @@ class TestTemplateBundles:
         bundles = bundles_data["bundles"]
 
         def full_closure(seeds: list) -> tuple:
+            """Resolve the transitive bundle closure for the seeds, returning (closure, missing)."""
             closure: set = set()
             missing: list = []
             queue = list(seeds)

--- a/tests/utils/test_explain_bundles.py
+++ b/tests/utils/test_explain_bundles.py
@@ -14,6 +14,7 @@ from tests.util import strip_ansi
 
 
 def _load_module(root: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, yaml_text: str):
+    """Load explain_bundles.py against a temp project whose template-bundles.yml holds yaml_text."""
     module_path = root / ".rhiza" / "utils" / "explain_bundles.py"
     config_dir = tmp_path / ".rhiza"
     config_dir.mkdir()
@@ -124,6 +125,7 @@ def test_import_exits_with_install_hint_when_pyyaml_is_missing(root, monkeypatch
     original_import = builtins.__import__
 
     def _fake_import(name: str, *args, **kwargs):
+        """Stand in for __import__, raising ImportError for ``yaml`` to simulate the missing dep."""
         if name == "yaml":
             raise ImportError
         return original_import(name, *args, **kwargs)


### PR DESCRIPTION
## Recommendation #3 (from `/rhiza`): Documentation 9→10

> Point interrogate at `tests/` and `.rhiza/tests/` so the 100% figure reflects more than three files.

## Problem

`make docs-coverage` only scanned `SOURCE_FOLDER` and `.rhiza/utils`, so the headline "100%" reflected just **3 utility scripts (23 definitions)**. ruff's pydocstyle (`D`) rules already require docstrings on top-level test code, but interrogate also counts **nested helpers** that `D` does not — a real blind spot in the test suite's documentation.

## Change

- Point the `docs-coverage` target at `tests/` and `.rhiza/tests/` in addition to the existing folders.
- Add the **7 missing docstrings** interrogate surfaced — all nested helpers / `_load_module` fixtures:
  - `tests/bundles/test_template_bundles.py` → `full_closure`
  - `tests/utils/test_explain_bundles.py` → `_load_module`, `_fake_import`
  - `tests/utils/test_pip_audit_policy.py` → `_load_module`, two `_fake_run`
  - `tests/utils/test_suppression_audit.py` → `_load_module`
- Applied to both the shipped bundle source (`bundles/tests/.rhiza/make.d/test.mk`) and rhiza's synced copy (`.rhiza/make.d/test.mk`).

This is consistent with rhiza's existing opinionated stance — the shipped `ruff.toml` already enforces docstrings on test code; this closes the gap between what ruff enforces and what the metric reports.

## Verification

```
make docs-coverage  →  RESULT: PASSED (minimum: 100.0%, actual: 100.0%)  over 758 definitions (was 23)
make fmt            →  clean
make test           →  959 passed
```

Acceptance criterion met: `make docs-coverage` reports 100% over a surface that includes the test packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)