### PR TITLE
Remove make validate from the /rhiza command

### DIFF
--- a/.claude/commands/rhiza.md
+++ b/.claude/commands/rhiza.md
@@ -1,5 +1,5 @@
 ---
-description: Run the full code-quality gate (format, lint, types, tests, deps, docs, security, rhiza-test, validate)
+description: Run the full code-quality gate (format, lint, types, tests, deps, docs, security, rhiza-test)
 ---
 
 Run the project's quality gates in order and report results. These mirror the
@@ -21,7 +21,6 @@ Run each of the following, in order:
 5. `make test` — full test suite (runs **without** a coverage gate here, since there is no `src/` to measure with `--cov`)
 6. `make security` — pip-audit + bandit scans
 7. `make rhiza-test` — rhiza's own suite under `.rhiza/tests/` (the templates, Makefile-target, sync, and `.rhiza/utils/` tests that travel downstream), distinct from the root `tests/` suite collected by `make test`
-8. `make validate` — validate project structure against the template repository defined in `.rhiza/template.yml`
 
 Guidelines:
 
@@ -38,12 +37,8 @@ Expected skips are not failures. While `make typecheck` and `make docs-coverage`
 are being repointed from `src` to `.rhiza/utils`, they may still print a
 `[WARN] Source folder src not found, skipping…` and exit clean; once repointed
 they run against `.rhiza/utils`. `make test` runs without a coverage gate (there
-is no `src/` to measure with `--cov`). `make validate` **skips its
-structure-validation step by design in this repo** — the mother repo ships no
-`.rhiza/template.yml`, so it prints `[INFO] Skipping validate in rhiza repository
-(no template.yml by design)` and exits clean; note that `validate` depends on
-`rhiza-test`, so it re-runs that suite as a prerequisite. Report any of these as
-**SKIP (by design)** — do not score them as failures or gaps.
+is no `src/` to measure with `--cov`). Report any of these as **SKIP (by design)**
+— do not score them as failures or gaps.
 
 Test depth (replaces line-coverage scoring). Since there is no runtime source,
 there is no line-coverage percentage to hit. Judge the test suite by **behavioural


### PR DESCRIPTION
## Summary

`make validate` was added to the `/rhiza` command in #1236, but in the mother repo it adds no signal: it always skips its structure-validation step (no `.rhiza/template.yml` by design → `[INFO] Skipping validate in rhiza repository`) and its only real action is re-running `rhiza-test`, which is already step 7. Running it as a separate gate just executes `rhiza-test` twice and reports a guaranteed SKIP.

## Changes

- Remove step 8 (`make validate`) from the gate list.
- Remove the validate by-design-skip note from the "Expected skips" section.
- Update the frontmatter `description` to drop `validate`.

`make rhiza-test` (step 7) is unchanged. Documentation-only change to a repo-local command file. `make fmt` (markdownlint) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)