### PR TITLE
Fix: strip SLSA provenance from dist/ before PyPI publish

### DIFF
--- a/bundles/github/.github/workflows/rhiza_release.yml
+++ b/bundles/github/.github/workflows/rhiza_release.yml
@@ -419,6 +419,13 @@ jobs:
           fi
           cat "$GITHUB_OUTPUT"
 
+      - name: Remove non-distribution files before publish
+        # The dist artifact also carries the SLSA provenance bundle (staged for
+        # the GitHub release). twine/pypi-publish rejects it as an unknown
+        # distribution format, so strip it here before publishing.
+        if: ${{ steps.check_dist.outputs.should_publish == 'true' }}
+        run: rm -f dist/*.intoto.jsonl
+
       # this should not take place, as "Private :: Do Not Upload" set in pyproject.toml
       # repository-url and password only used for custom feeds, not for PyPI with OIDC
       - name: Publish to PyPI


### PR DESCRIPTION
## Problem

Release runs fail `twine check` during the PyPI publish step:

```
Checking dist/provenance.intoto.jsonl: ERROR  InvalidDistribution: Unknown distribution format: 'provenance.intoto.jsonl'
```

The build job stages the SLSA provenance bundle into `dist/provenance.intoto.jsonl` (so it ships as a GitHub Release asset) and uploads the whole `dist/` dir as the `dist` artifact. The `pypi` job points `pypa/gh-action-pypi-publish` at `packages-dir: dist/`, so `twine` walks every file in `dist/` and rejects the provenance bundle.

## Fix

Add a step in the `pypi` job (`bundles/github/.github/workflows/rhiza_release.yml`) that removes `dist/*.intoto.jsonl` before publishing. The `dist` artifact remains intact for `draft-release`; only PyPI sees real distributions.

The GitLab bundle never stages a provenance file into `dist/`, so no equivalent change is needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)