### PR TITLE
fix(fuzzing): scope security-events:write to job level

### DIFF
--- a/.github/workflows/rhiza_fuzzing.yml
+++ b/.github/workflows/rhiza_fuzzing.yml
@@ -32,7 +32,6 @@ concurrency:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   pr-fuzzing:
@@ -43,6 +42,9 @@ jobs:
     if: ${{ github.event_name == 'pull_request' && vars.FUZZING_ENABLED == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write   # Needed to upload the ClusterFuzzLite SARIF report to code scanning
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4


### PR DESCRIPTION
## Summary

OpenSSF Scorecard's **Token-Permissions** check flagged the top-level `security-events: write` token in `.github/workflows/rhiza_fuzzing.yml` (score 9). This restricts the workflow token to least privilege:

- **Top-level** permissions → `contents: read` only.
- `security-events: write` moved down to the **pr-fuzzing** job — the only job that uploads a SARIF report (`run_fuzzers` with `output-sarif: true`).
- **batch-fuzzing** inherits the read-only top-level permissions; it emits no SARIF, so it needs nothing more.

This matches the job-level scoping already used by `rhiza_docker.yml`, `rhiza_codeql.yml`, and `rhiza_scorecard.yml`.

## Test plan

- [x] `actionlint` passes on the workflow
- [x] pre-commit "Validate GitHub Workflows" + "Lint GitHub Actions workflow files" pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)