### PR TITLE
fix(scorecard): match reusable workflow top-level permissions to its job (unblock least-privilege callers)

### DIFF
--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -33,8 +33,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# Least privilege by default; the job grants itself only what Scorecard needs.
-permissions: read-all
+# Least privilege: declare exactly the scopes Scorecard needs. A caller invoking
+# this reusable workflow must grant at least these (via its job-level
+# `permissions`), so the top-level set must match the job below rather than
+# over-broadly request `read-all` -- which a least-privilege caller cannot
+# satisfy, and GitHub then rejects with "is requesting '... read', but is only
+# allowed '... none'".
+permissions:
+  security-events: write   # upload the SARIF results to code scanning
+  id-token: write          # publish results to the OpenSSF REST API (badge)
+  contents: read
+  actions: read
 
 jobs:
   analysis:


### PR DESCRIPTION
## Problem

The reusable `rhiza_scorecard.yml` declares top-level `permissions: read-all`,
but its only job — and the `github-scorecard` caller stub — deliberately grant a
narrow least-privilege set (`security-events: write`, `id-token: write`,
`contents: read`, `actions: read`). When a downstream repo's caller stub invokes
this reusable workflow, GitHub compares the workflow's *requested* permissions
(the top-level `read-all`) against what the caller *grants* (the narrow job set)
and rejects the run as invalid:

```
Error calling workflow 'jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v0.19.1'.
The workflow is requesting 'artifact-metadata: read, attestations: read, checks: read,
code-quality: read, ... statuses: read', but is only allowed 'artifact-metadata: none, ...'.
```

The job-level block already overrode `read-all` at runtime, so the top-level line
was cosmetic — but it breaks workflow validation for any least-privilege caller
(and contradicts the file's own "least privilege" comment).

(Surfaced downstream in `cvxgrp/cvxcla` after adopting the synced workflows.)

## Fix

Set the reusable workflow's top-level `permissions` to exactly the scopes the job
uses (and the caller grants). No runtime behaviour change — the job already ran
with this set.

## Validation
- `yaml.safe_load` parses the file
- `actionlint` passes
- Present on `main` and `v0.19.1`; not previously fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)