### PR TITLE
fix(scorecard): keep id-token/security-events write at job level only

### DIFF
--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -33,15 +33,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# Least privilege: declare exactly the scopes Scorecard needs. A caller invoking
-# this reusable workflow must grant at least these (via its job-level
-# `permissions`), so the top-level set must match the job below rather than
-# over-broadly request `read-all` -- which a least-privilege caller cannot
-# satisfy, and GitHub then rejects with "is requesting '... read', but is only
-# allowed '... none'".
+# Least privilege, with a hard constraint from the Scorecard publish step: the
+# OpenSSF webapp rejects results when `id-token: write` or `security-events:
+# write` are granted at the top (workflow) level -- those write scopes MUST live
+# only on the job below (see scorecard-action#workflow-restrictions). So the top
+# level stays read-only. We still avoid `read-all` (which over-requests scopes a
+# least-privilege reusable-workflow caller cannot satisfy, #1251) and declare
+# exactly the read scopes the job uses; the job expands to the writes it needs.
 permissions:
-  security-events: write   # upload the SARIF results to code scanning
-  id-token: write          # publish results to the OpenSSF REST API (badge)
   contents: read
   actions: read
 


### PR DESCRIPTION
## Problem

The OSSF Scorecard job [failed](https://github.com/Jebel-Quant/rhiza/actions/runs/27617725756/job/81657834669) at the publish step with a 400 from the OpenSSF webapp:

```
workflow verification failed: global perm is set to write:
permission for id-token is set to write
```

The analysis itself ran fine, but publishing the result (which powers the README badge and external score verification) was rejected — failing the job.

## Root cause

Commit 74cefa1 (#1251) hoisted `id-token: write` and `security-events: write` to the workflow's **top level** to satisfy least-privilege reusable-workflow callers. But `scorecard-action`'s publish webapp has a hard [restriction](https://github.com/ossf/scorecard-action#workflow-restrictions): those write scopes must live **only on the job**, never at the top (workflow) level.

## Fix

Set the top-level `permissions` back to read-only (`contents: read`, `actions: read`) while keeping the full write set on the job. This satisfies both constraints at once:

- **webapp publish:** no write scopes at the top level ✅
- **the #1251 concern:** top level still avoids `read-all`, so it does not over-request scopes a least-privilege caller cannot grant ✅

Job-level permissions are allowed to exceed top-level ones at runtime, so the job still gets the writes it needs. The bundle stub (`bundles/github/...`) is unaffected — it only calls the reusable workflow and never runs `scorecard-action` itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)