### PR TITLE
fix(make): skip worktree/current branches in clean branch-prune

### DIFF
--- a/.rhiza/make.d/bootstrap.mk
+++ b/.rhiza/make.d/bootstrap.mk
@@ -111,4 +111,4 @@ clean: ## Clean project artifacts and stale local branches
 
 	@git fetch --prune
 
-	@git branch -vv | awk '/: gone]/{print $$1}' | xargs -r git branch -D
+	@git branch -vv | awk '/: gone]/ && $$1 != "*" && $$1 != "+" {print $$1}' | xargs -r git branch -D

--- a/bundles/core/.rhiza/make.d/bootstrap.mk
+++ b/bundles/core/.rhiza/make.d/bootstrap.mk
@@ -111,4 +111,4 @@ clean: ## Clean project artifacts and stale local branches
 
 	@git fetch --prune
 
-	@git branch -vv | awk '/: gone]/{print $$1}' | xargs -r git branch -D
+	@git branch -vv | awk '/: gone]/ && $$1 != "*" && $$1 != "+" {print $$1}' | xargs -r git branch -D


### PR DESCRIPTION
## Problem

The `clean` target prunes branches whose upstream is gone:

```make
@git branch -vv | awk '/: gone]/{print $$1}' | xargs -r git branch -D
```

`git branch -vv` prefixes a branch checked out in a **linked worktree** with `+` (just as the current branch gets `*`). When such a branch's upstream has been pruned, the line looks like:

```
+ my-branch abc123 [origin/my-branch: gone] ...
```

`awk '{print $1}'` then captures the `+` marker instead of the branch name, so the command becomes `git branch -D +`:

```
error: branch '+' not found
make: *** [clean] Error 1
```

This breaks `make clean` for anyone using git worktrees. (And even if the name were parsed correctly, a worktree-checked-out branch cannot be deleted with `git branch -D`.)

## Fix

Filter out the `*` (current) and `+` (worktree) marker lines so only genuinely unused gone-branches are deleted:

```make
@git branch -vv | awk '/: gone]/ && $$1 != "*" && $$1 != "+" {print $$1}' | xargs -r git branch -D
```

Applied to both the canonical template (`bundles/core/.rhiza/make.d/bootstrap.mk`) and the repo's self-applied copy (`.rhiza/make.d/bootstrap.mk`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)