### PR TITLE
test(api): coverage-gate API tests tolerate a downstream override

### DIFF
--- a/.rhiza/tests/api/test_make_variable_overrides.py
+++ b/.rhiza/tests/api/test_make_variable_overrides.py
@@ -15,6 +15,7 @@ executed without running them — keeping the suite fast and side-effect-free.
 from __future__ import annotations
 
 import os
+import re
 
 from api.conftest import run_make, strip_ansi
 
@@ -22,11 +23,21 @@ from api.conftest import run_make, strip_ansi
 class TestCoverageFailUnder:
     """COVERAGE_FAIL_UNDER controls the pytest --cov-fail-under threshold."""
 
-    def test_default_threshold_is_90(self, logger) -> None:
-        """Default COVERAGE_FAIL_UNDER value must be 90."""
+    def test_default_threshold_is_at_least_90(self, logger) -> None:
+        """The effective COVERAGE_FAIL_UNDER must be at least 90.
+
+        The template default is 90, but a downstream project may legitimately
+        raise the bar (e.g. to 100) via the documented Makefile override. These
+        API tests run against the consuming project's Makefile, so we assert a
+        floor rather than an exact value: at least 90 passes for both the bare
+        default and any downstream hardening, while still catching a regression
+        that drops the gate below 90.
+        """
         proc = run_make(logger, ["test"])
-        assert "--cov-fail-under=90" in proc.stdout, (
-            "Default coverage threshold should be 90; got:\n" + proc.stdout[:500]
+        match = re.search(r"--cov-fail-under=(\d+)", proc.stdout)
+        assert match is not None, "no --cov-fail-under flag found:\n" + proc.stdout[:500]
+        assert int(match.group(1)) >= 90, (
+            f"Coverage threshold should be at least 90; got {match.group(1)}:\n" + proc.stdout[:500]
         )
 
     def test_threshold_override_to_100(self, logger) -> None:

--- a/.rhiza/tests/api/test_makefile_api.py
+++ b/.rhiza/tests/api/test_makefile_api.py
@@ -249,17 +249,18 @@ def test_global_variable_override(logger, setup_api_env):
 
     This tests the pattern documented in CUSTOMIZATION.md:
     Set variables before the include line to override defaults.
-    """
-    # Add variable override to root Makefile (before include line)
-    makefile = setup_api_env / "Makefile"
-    original = makefile.read_text()
-    new_content = (
-        """# Override default coverage threshold (defaults to 90)
-COVERAGE_FAIL_UNDER := 42
-export COVERAGE_FAIL_UNDER
 
-"""
-        + original
+    The Makefile is rebuilt from a pristine root (just the override and the
+    Rhiza include) rather than prepended to the consuming project's own
+    Makefile, so a coverage override the project itself sets cannot shadow the
+    value under test.
+    """
+    makefile = setup_api_env / "Makefile"
+    new_content = (
+        "# Override default coverage threshold (defaults to 90)\n"
+        "COVERAGE_FAIL_UNDER := 42\n"
+        "export COVERAGE_FAIL_UNDER\n\n"
+        "include .rhiza/rhiza.mk\n"
     )
     makefile.write_text(new_content)
 

--- a/bundles/tests/.rhiza/tests/api/test_make_variable_overrides.py
+++ b/bundles/tests/.rhiza/tests/api/test_make_variable_overrides.py
@@ -15,6 +15,7 @@ executed without running them — keeping the suite fast and side-effect-free.
 from __future__ import annotations
 
 import os
+import re
 
 from api.conftest import run_make, strip_ansi
 
@@ -22,11 +23,21 @@ from api.conftest import run_make, strip_ansi
 class TestCoverageFailUnder:
     """COVERAGE_FAIL_UNDER controls the pytest --cov-fail-under threshold."""
 
-    def test_default_threshold_is_90(self, logger) -> None:
-        """Default COVERAGE_FAIL_UNDER value must be 90."""
+    def test_default_threshold_is_at_least_90(self, logger) -> None:
+        """The effective COVERAGE_FAIL_UNDER must be at least 90.
+
+        The template default is 90, but a downstream project may legitimately
+        raise the bar (e.g. to 100) via the documented Makefile override. These
+        API tests run against the consuming project's Makefile, so we assert a
+        floor rather than an exact value: at least 90 passes for both the bare
+        default and any downstream hardening, while still catching a regression
+        that drops the gate below 90.
+        """
         proc = run_make(logger, ["test"])
-        assert "--cov-fail-under=90" in proc.stdout, (
-            "Default coverage threshold should be 90; got:\n" + proc.stdout[:500]
+        match = re.search(r"--cov-fail-under=(\d+)", proc.stdout)
+        assert match is not None, "no --cov-fail-under flag found:\n" + proc.stdout[:500]
+        assert int(match.group(1)) >= 90, (
+            f"Coverage threshold should be at least 90; got {match.group(1)}:\n" + proc.stdout[:500]
         )
 
     def test_threshold_override_to_100(self, logger) -> None:

--- a/bundles/tests/.rhiza/tests/api/test_makefile_api.py
+++ b/bundles/tests/.rhiza/tests/api/test_makefile_api.py
@@ -249,17 +249,18 @@ def test_global_variable_override(logger, setup_api_env):
 
     This tests the pattern documented in CUSTOMIZATION.md:
     Set variables before the include line to override defaults.
-    """
-    # Add variable override to root Makefile (before include line)
-    makefile = setup_api_env / "Makefile"
-    original = makefile.read_text()
-    new_content = (
-        """# Override default coverage threshold (defaults to 90)
-COVERAGE_FAIL_UNDER := 42
-export COVERAGE_FAIL_UNDER
 
-"""
-        + original
+    The Makefile is rebuilt from a pristine root (just the override and the
+    Rhiza include) rather than prepended to the consuming project's own
+    Makefile, so a coverage override the project itself sets cannot shadow the
+    value under test.
+    """
+    makefile = setup_api_env / "Makefile"
+    new_content = (
+        "# Override default coverage threshold (defaults to 90)\n"
+        "COVERAGE_FAIL_UNDER := 42\n"
+        "export COVERAGE_FAIL_UNDER\n\n"
+        "include .rhiza/rhiza.mk\n"
     )
     makefile.write_text(new_content)
 


### PR DESCRIPTION
## Problem

The Makefile API tests build their sandbox from the **consuming project's** `Makefile` (`setup_tmp_makefile` / `setup_api_env` copy `root/Makefile`), then assert the coverage gate is *exactly* 90 and that a freshly-prepended `:= 42` override wins. Both assumptions break for any downstream repo that uses the override documented in `CUSTOMIZATION.md` (set `COVERAGE_FAIL_UNDER` before the `include`) to **raise** the gate — e.g. a project that sustains 100% coverage and sets `COVERAGE_FAIL_UNDER = 100`:

- `test_default_threshold_is_90` sees 100, not 90.
- `test_global_variable_override`'s `:= 42` is shadowed by the project's own later `= 100`.

So Rhiza documents the override pattern but ships self-tests that fail when a consumer actually uses it (surfaced by `make validate` in a downstream repo).

## Fix

- **`test_default_threshold_is_90` → `test_default_threshold_is_at_least_90`**: parse `--cov-fail-under=N` and assert `N >= 90`. A floor passes for the bare default *and* any downstream hardening, while still catching a regression that drops the gate below 90.
- **`test_global_variable_override`**: rebuild a pristine root Makefile (the override plus the Rhiza include) instead of prepending to the project's own Makefile, so a coverage override the project sets cannot shadow the value under test.

Both the dev copy (`.rhiza/tests/`) and the distributed bundle (`bundles/tests/.rhiza/tests/`) are updated in sync.

## Verification

Both files pass (29 tests) against **both** Rhiza's default-90 Makefile and a simulated downstream `COVERAGE_FAIL_UNDER = 100` override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)