### PR TITLE
chore(deps): combined renovate dependency updates

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -2,7 +2,7 @@
 # Uses the OSS-Fuzz Python base image, which provides Atheris and
 # the compile_python_fuzzer helper.
 # Pinned by SHA256 so the build image only changes through reviewed updates.
-FROM gcr.io/oss-fuzz-base/base-builder-python@sha256:9c97273c8de83d22a40462fdda4371d1ff16eac065c72ee03bef7fdb1aaaf458
+FROM gcr.io/oss-fuzz-base/base-builder-python@sha256:99c714c91ec30778a3ce3ae5b37491a81fc043808bc8f2955159c2f608f80116
 
 COPY . $SRC/rhiza
 WORKDIR $SRC/rhiza

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,7 +99,7 @@ repos:
         files: ^(src/|\.rhiza/utils/)
 
   - repo: https://github.com/Jebel-Quant/rhiza-hooks
-    rev: v0.6.2  # Use the latest release
+    rev: v0.6.3  # Use the latest release
     hooks:
       # Migrated from rhiza
       - id: check-rhiza-workflow-names

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.48.0
+    rev: v0.49.0
     hooks:
       - id: markdownlint
         args: ["--disable", "MD013"]

--- a/bundles/core/.pre-commit-config.yaml
+++ b/bundles/core/.pre-commit-config.yaml
@@ -88,7 +88,7 @@ repos:
         files: ^src/
 
   - repo: https://github.com/Jebel-Quant/rhiza-hooks
-    rev: v0.6.2  # Use the latest release
+    rev: v0.6.3  # Use the latest release
     hooks:
       # Migrated from rhiza
       - id: check-rhiza-workflow-names

--- a/bundles/core/.pre-commit-config.yaml
+++ b/bundles/core/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.48.0
+    rev: v0.49.0
     hooks:
       - id: markdownlint
         args: ["--disable", "MD013"]


### PR DESCRIPTION
Combines the three open Renovate PRs into a single branch so they can be reviewed/merged together.

## Updates
- **#1262** — `gcr.io/oss-fuzz-base/base-builder-python` digest → `99c714c…` (`.clusterfuzzlite/Dockerfile`)
- **#1263** — pre-commit hook `jebel-quant/rhiza-hooks` → `v0.6.3` (`.pre-commit-config.yaml`, `bundles/core/.pre-commit-config.yaml`)
- **#1264** — pre-commit hook `igorshubovych/markdownlint-cli` → `v0.49.0` (`.pre-commit-config.yaml`, `bundles/core/.pre-commit-config.yaml`)

Branched off `main`; all three merged with no conflicts. Net change: 3 files.

Supersedes #1262, #1263, #1264 if merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)