### PR TITLE
fix(pre-commit): pin node to 24.12.0 so npm hooks survive odd node releases

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,12 @@
 # This file is part of the jebel-quant/rhiza repository
 # (https://github.com/jebel-quant/rhiza).
 #
+# Pin node so pre-commit provisions a compatible runtime instead of using the
+# system node. Some npm-based hooks (markdownlint-cli) pull transitive deps that
+# reject odd-numbered current node releases (e.g. v25), failing on EBADENGINE.
+default_language_version:
+  node: "24.12.0"
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/bundles/core/.pre-commit-config.yaml
+++ b/bundles/core/.pre-commit-config.yaml
@@ -1,6 +1,12 @@
 # This file is part of the jebel-quant/rhiza repository
 # (https://github.com/jebel-quant/rhiza).
 #
+# Pin node so pre-commit provisions a compatible runtime instead of using the
+# system node. Some npm-based hooks (markdownlint-cli) pull transitive deps that
+# reject odd-numbered current node releases (e.g. v25), failing on EBADENGINE.
+default_language_version:
+  node: "24.12.0"
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0


### PR DESCRIPTION
## Problem

`markdownlint-cli` fails to install under pre-commit on machines running odd-numbered current node releases (e.g. v25). It pulls a transitive dependency (`ava`) whose `engines` field is `^22.20 || ^24.12 || >=26`. v25 falls in the gap between the `24.x` and `>=26` bands, so `npm install` aborts with `EBADENGINE` and the hook never installs — blocking commits.

## Fix

Add `default_language_version.node: "24.12.0"` so pre-commit provisions a compatible node via nodeenv instead of relying on the system runtime. Node 24.12.0 satisfies the `^24.12` band and is LTS.

Applied to both:
- `.pre-commit-config.yaml` (this repo)
- `bundles/core/.pre-commit-config.yaml` (synced template, so downstream projects inherit the fix)

## Verification

`pre-commit clean && pre-commit run markdownlint --all-files` now passes — pre-commit provisions node 24.12.0 and the `npm install` no longer hits `EBADENGINE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)