### PR TITLE
test: migrate class-scoped fixtures to classmethods and guard node pin

### DIFF
--- a/.rhiza/tests/structure/test_pyproject.py
+++ b/.rhiza/tests/structure/test_pyproject.py
@@ -116,8 +116,9 @@ class TestProjectFields:
 class TestProjectUrls:
     """Tests for [project.urls] — Homepage and Repository links."""
 
+    @classmethod
     @pytest.fixture(scope="class")
-    def urls(self, project: dict) -> dict:
+    def urls(cls, project: dict) -> dict:
         """Return the [project.urls] table."""
         table = project.get("urls")
         if not isinstance(table, dict):
@@ -142,8 +143,9 @@ class TestProjectUrls:
 class TestProjectClassifiers:
     """Tests for [project].classifiers — Python version and licence entries."""
 
+    @classmethod
     @pytest.fixture(scope="class")
-    def classifiers(self, project: dict) -> list[str]:
+    def classifiers(cls, project: dict) -> list[str]:
         """Return the classifiers list."""
         cl = project.get("classifiers", [])
         if not cl:
@@ -166,8 +168,9 @@ class TestProjectClassifiers:
 class TestDependencyGroups:
     """Tests for [dependency-groups] — ensures required groups are declared."""
 
+    @classmethod
     @pytest.fixture(scope="class")
-    def dependency_groups(self, pyproject: dict) -> dict:
+    def dependency_groups(cls, pyproject: dict) -> dict:
         """Return the [dependency-groups] table."""
         dg = pyproject.get("dependency-groups")
         if not isinstance(dg, dict):
@@ -193,8 +196,9 @@ class TestDependencyGroups:
 class TestGitTagVersion:
     """Tests for harmony between the latest git tag and pyproject.toml version."""
 
+    @classmethod
     @pytest.fixture(scope="class")
-    def latest_tag(self, root: Path) -> str:
+    def latest_tag(cls, root: Path) -> str:
         """Return the latest semver git tag, or skip if none exist."""
         result = subprocess.run(  # nosec B603
             [_GIT, "tag", "--list", "v*", "--sort=-version:refname"],

--- a/.rhiza/tests/structure/test_pyproject.py
+++ b/.rhiza/tests/structure/test_pyproject.py
@@ -116,9 +116,8 @@ class TestProjectFields:
 class TestProjectUrls:
     """Tests for [project.urls] — Homepage and Repository links."""
 
-    @classmethod
-    @pytest.fixture(scope="class")
-    def urls(cls, project: dict) -> dict:
+    @pytest.fixture
+    def urls(self, project: dict) -> dict:
         """Return the [project.urls] table."""
         table = project.get("urls")
         if not isinstance(table, dict):
@@ -143,9 +142,8 @@ class TestProjectUrls:
 class TestProjectClassifiers:
     """Tests for [project].classifiers — Python version and licence entries."""
 
-    @classmethod
-    @pytest.fixture(scope="class")
-    def classifiers(cls, project: dict) -> list[str]:
+    @pytest.fixture
+    def classifiers(self, project: dict) -> list[str]:
         """Return the classifiers list."""
         cl = project.get("classifiers", [])
         if not cl:
@@ -168,9 +166,8 @@ class TestProjectClassifiers:
 class TestDependencyGroups:
     """Tests for [dependency-groups] — ensures required groups are declared."""
 
-    @classmethod
-    @pytest.fixture(scope="class")
-    def dependency_groups(cls, pyproject: dict) -> dict:
+    @pytest.fixture
+    def dependency_groups(self, pyproject: dict) -> dict:
         """Return the [dependency-groups] table."""
         dg = pyproject.get("dependency-groups")
         if not isinstance(dg, dict):
@@ -196,9 +193,8 @@ class TestDependencyGroups:
 class TestGitTagVersion:
     """Tests for harmony between the latest git tag and pyproject.toml version."""
 
-    @classmethod
-    @pytest.fixture(scope="class")
-    def latest_tag(cls, root: Path) -> str:
+    @pytest.fixture
+    def latest_tag(self, root: Path) -> str:
         """Return the latest semver git tag, or skip if none exist."""
         result = subprocess.run(  # nosec B603
             [_GIT, "tag", "--list", "v*", "--sort=-version:refname"],

--- a/bundles/tests/.rhiza/tests/structure/test_pyproject.py
+++ b/bundles/tests/.rhiza/tests/structure/test_pyproject.py
@@ -116,8 +116,9 @@ class TestProjectFields:
 class TestProjectUrls:
     """Tests for [project.urls] — Homepage and Repository links."""
 
+    @classmethod
     @pytest.fixture(scope="class")
-    def urls(self, project: dict) -> dict:
+    def urls(cls, project: dict) -> dict:
         """Return the [project.urls] table."""
         table = project.get("urls")
         if not isinstance(table, dict):
@@ -142,8 +143,9 @@ class TestProjectUrls:
 class TestProjectClassifiers:
     """Tests for [project].classifiers — Python version and licence entries."""
 
+    @classmethod
     @pytest.fixture(scope="class")
-    def classifiers(self, project: dict) -> list[str]:
+    def classifiers(cls, project: dict) -> list[str]:
         """Return the classifiers list."""
         cl = project.get("classifiers", [])
         if not cl:
@@ -166,8 +168,9 @@ class TestProjectClassifiers:
 class TestDependencyGroups:
     """Tests for [dependency-groups] — ensures required groups are declared."""
 
+    @classmethod
     @pytest.fixture(scope="class")
-    def dependency_groups(self, pyproject: dict) -> dict:
+    def dependency_groups(cls, pyproject: dict) -> dict:
         """Return the [dependency-groups] table."""
         dg = pyproject.get("dependency-groups")
         if not isinstance(dg, dict):
@@ -193,8 +196,9 @@ class TestDependencyGroups:
 class TestGitTagVersion:
     """Tests for harmony between the latest git tag and pyproject.toml version."""
 
+    @classmethod
     @pytest.fixture(scope="class")
-    def latest_tag(self, root: Path) -> str:
+    def latest_tag(cls, root: Path) -> str:
         """Return the latest semver git tag, or skip if none exist."""
         result = subprocess.run(  # nosec B603
             [_GIT, "tag", "--list", "v*", "--sort=-version:refname"],

--- a/bundles/tests/.rhiza/tests/structure/test_pyproject.py
+++ b/bundles/tests/.rhiza/tests/structure/test_pyproject.py
@@ -116,9 +116,8 @@ class TestProjectFields:
 class TestProjectUrls:
     """Tests for [project.urls] — Homepage and Repository links."""
 
-    @classmethod
-    @pytest.fixture(scope="class")
-    def urls(cls, project: dict) -> dict:
+    @pytest.fixture
+    def urls(self, project: dict) -> dict:
         """Return the [project.urls] table."""
         table = project.get("urls")
         if not isinstance(table, dict):
@@ -143,9 +142,8 @@ class TestProjectUrls:
 class TestProjectClassifiers:
     """Tests for [project].classifiers — Python version and licence entries."""
 
-    @classmethod
-    @pytest.fixture(scope="class")
-    def classifiers(cls, project: dict) -> list[str]:
+    @pytest.fixture
+    def classifiers(self, project: dict) -> list[str]:
         """Return the classifiers list."""
         cl = project.get("classifiers", [])
         if not cl:
@@ -168,9 +166,8 @@ class TestProjectClassifiers:
 class TestDependencyGroups:
     """Tests for [dependency-groups] — ensures required groups are declared."""
 
-    @classmethod
-    @pytest.fixture(scope="class")
-    def dependency_groups(cls, pyproject: dict) -> dict:
+    @pytest.fixture
+    def dependency_groups(self, pyproject: dict) -> dict:
         """Return the [dependency-groups] table."""
         dg = pyproject.get("dependency-groups")
         if not isinstance(dg, dict):
@@ -196,9 +193,8 @@ class TestDependencyGroups:
 class TestGitTagVersion:
     """Tests for harmony between the latest git tag and pyproject.toml version."""
 
-    @classmethod
-    @pytest.fixture(scope="class")
-    def latest_tag(cls, root: Path) -> str:
+    @pytest.fixture
+    def latest_tag(self, root: Path) -> str:
         """Return the latest semver git tag, or skip if none exist."""
         result = subprocess.run(  # nosec B603
             [_GIT, "tag", "--list", "v*", "--sort=-version:refname"],

--- a/bundles/tests/pytest.ini
+++ b/bundles/tests/pytest.ini
@@ -9,6 +9,12 @@ log_cli_date_format = %H:%M:%S
 # Show extra summary info for skipped/failed tests
 addopts = -ra
 timeout = 60
+# Treat pytest's own removal warnings as errors so deprecated patterns
+# (e.g. class-scoped fixtures defined as instance methods) cannot silently
+# regress. Scoped to pytest's removal warnings only — third-party
+# DeprecationWarnings stay non-fatal.
+filterwarnings =
+    error::pytest.PytestRemovedIn10Warning
 # Register custom markers
 markers =
     stress: marks tests as stress tests (deselect with '-m "not stress"')

--- a/bundles/tests/pytest.ini
+++ b/bundles/tests/pytest.ini
@@ -9,12 +9,13 @@ log_cli_date_format = %H:%M:%S
 # Show extra summary info for skipped/failed tests
 addopts = -ra
 timeout = 60
-# Treat pytest's own removal warnings as errors so deprecated patterns
-# (e.g. class-scoped fixtures defined as instance methods) cannot silently
-# regress. Scoped to pytest's removal warnings only — third-party
-# DeprecationWarnings stay non-fatal.
+# Treat the class-scoped-instance-method fixture deprecation as an error so it
+# cannot silently regress. Matched by message rather than by warning category:
+# the category name is version-specific (PytestRemovedIn9Warning vs ...In10Warning)
+# and referencing a missing class breaks `--resolution lowest-direct` runs at
+# parse time. Third-party DeprecationWarnings stay non-fatal.
 filterwarnings =
-    error::pytest.PytestRemovedIn10Warning
+    error:Class-scoped fixture defined as instance method is deprecated
 # Register custom markers
 markers =
     stress: marks tests as stress tests (deselect with '-m "not stress"')

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,6 +9,12 @@ log_cli_date_format = %H:%M:%S
 # Show extra summary info for skipped/failed tests
 addopts = -ra
 timeout = 60
+# Treat pytest's own removal warnings as errors so deprecated patterns
+# (e.g. class-scoped fixtures defined as instance methods) cannot silently
+# regress. Scoped to pytest's removal warnings only — third-party
+# DeprecationWarnings stay non-fatal.
+filterwarnings =
+    error::pytest.PytestRemovedIn10Warning
 # Register custom markers
 markers =
     stress: marks tests as stress tests (deselect with '-m "not stress"')

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,12 +9,13 @@ log_cli_date_format = %H:%M:%S
 # Show extra summary info for skipped/failed tests
 addopts = -ra
 timeout = 60
-# Treat pytest's own removal warnings as errors so deprecated patterns
-# (e.g. class-scoped fixtures defined as instance methods) cannot silently
-# regress. Scoped to pytest's removal warnings only — third-party
-# DeprecationWarnings stay non-fatal.
+# Treat the class-scoped-instance-method fixture deprecation as an error so it
+# cannot silently regress. Matched by message rather than by warning category:
+# the category name is version-specific (PytestRemovedIn9Warning vs ...In10Warning)
+# and referencing a missing class breaks `--resolution lowest-direct` runs at
+# parse time. Third-party DeprecationWarnings stay non-fatal.
 filterwarnings =
-    error::pytest.PytestRemovedIn10Warning
+    error:Class-scoped fixture defined as instance method is deprecated
 # Register custom markers
 markers =
     stress: marks tests as stress tests (deselect with '-m "not stress"')

--- a/tests/api/test_mutation_workflow.py
+++ b/tests/api/test_mutation_workflow.py
@@ -27,8 +27,9 @@ def _step_names(job: dict) -> list[str]:
 class TestMutationWorkflowStructure:
     """Validate badge generation and publishing in rhiza_mutation.yml."""
 
+    @classmethod
     @pytest.fixture(scope="class")
-    def workflow(self, root: Path) -> dict:
+    def workflow(cls, root: Path) -> dict:
         """Return parsed workflow data."""
         return _load_workflow(root)
 

--- a/tests/api/test_mutation_workflow.py
+++ b/tests/api/test_mutation_workflow.py
@@ -27,9 +27,8 @@ def _step_names(job: dict) -> list[str]:
 class TestMutationWorkflowStructure:
     """Validate badge generation and publishing in rhiza_mutation.yml."""
 
-    @classmethod
-    @pytest.fixture(scope="class")
-    def workflow(cls, root: Path) -> dict:
+    @pytest.fixture
+    def workflow(self, root: Path) -> dict:
         """Return parsed workflow data."""
         return _load_workflow(root)
 

--- a/tests/api/test_release_workflow.py
+++ b/tests/api/test_release_workflow.py
@@ -57,9 +57,8 @@ def _step_uses(job: dict) -> list[str]:
 class TestReleaseWorkflowStructure:
     """Validate the static content of rhiza_release.yml."""
 
-    @classmethod
-    @pytest.fixture(scope="class")
-    def workflow(cls, root):
+    @pytest.fixture
+    def workflow(self, root):
         """Load and return the parsed release workflow YAML."""
         return _load_workflow(root)
 

--- a/tests/api/test_release_workflow.py
+++ b/tests/api/test_release_workflow.py
@@ -57,8 +57,9 @@ def _step_uses(job: dict) -> list[str]:
 class TestReleaseWorkflowStructure:
     """Validate the static content of rhiza_release.yml."""
 
+    @classmethod
     @pytest.fixture(scope="class")
-    def workflow(self, root):
+    def workflow(cls, root):
         """Load and return the parsed release workflow YAML."""
         return _load_workflow(root)
 

--- a/tests/api/test_weekly_workflow.py
+++ b/tests/api/test_weekly_workflow.py
@@ -67,9 +67,8 @@ def _step_with_args(job: dict) -> list[dict]:
 class TestWeeklyWorkflowStructure:
     """Validate the static content of rhiza_weekly.yml."""
 
-    @classmethod
-    @pytest.fixture(scope="class")
-    def workflow(cls, root):
+    @pytest.fixture
+    def workflow(self, root):
         """Load and return the parsed weekly workflow YAML."""
         return _load_workflow(root)
 

--- a/tests/api/test_weekly_workflow.py
+++ b/tests/api/test_weekly_workflow.py
@@ -67,8 +67,9 @@ def _step_with_args(job: dict) -> list[dict]:
 class TestWeeklyWorkflowStructure:
     """Validate the static content of rhiza_weekly.yml."""
 
+    @classmethod
     @pytest.fixture(scope="class")
-    def workflow(self, root):
+    def workflow(cls, root):
         """Load and return the parsed weekly workflow YAML."""
         return _load_workflow(root)
 

--- a/tests/bundles/test_bundle_content_validity.py
+++ b/tests/bundles/test_bundle_content_validity.py
@@ -555,3 +555,43 @@ class TestRenovateBundleContent:
         required = {"pep621", "github-actions", "gitlabci"}
         missing = required - set(enabled)
         assert not missing, f"renovate.json 'enabledManagers' is missing required managers: {sorted(missing)}"
+
+
+# ---------------------------------------------------------------------------
+# Core pre-commit configuration
+# ---------------------------------------------------------------------------
+
+
+class TestCorePreCommitConfig:
+    """The core bundle's .pre-commit-config.yaml must pin node for npm-based hooks.
+
+    markdownlint-cli pulls a transitive dependency (ava) whose engines field is
+    ``^22.20 || ^24.12 || >=26``.  Odd-numbered current node releases such as v25
+    fall in the gap between those bands, so ``npm install`` aborts with EBADENGINE
+    and the hook fails to install.  Pinning ``default_language_version.node`` makes
+    pre-commit provision a compatible node via nodeenv instead of relying on the
+    system runtime.  This guard stops the pin from silently disappearing downstream.
+    """
+
+    @pytest.fixture
+    def precommit_config(self, root: Path) -> dict:
+        """Load and return the parsed core-bundle .pre-commit-config.yaml."""
+        cfg = root / "bundles" / "core" / ".pre-commit-config.yaml"
+        if not cfg.exists():
+            pytest.skip("core bundle .pre-commit-config.yaml not present")
+        with cfg.open(encoding="utf-8") as fh:
+            return yaml.safe_load(fh)
+
+    def test_default_language_version_pins_node(self, precommit_config: dict) -> None:
+        """default_language_version.node must be a non-empty pin so npm hooks get a compatible runtime."""
+        versions = precommit_config.get("default_language_version")
+        assert isinstance(versions, dict), (
+            "core .pre-commit-config.yaml must declare a 'default_language_version' table "
+            "pinning node for npm-based hooks (markdownlint-cli)"
+        )
+        node = versions.get("node")
+        assert isinstance(node, str), "'default_language_version.node' must be a version string"
+        assert node.strip(), (
+            "'default_language_version.node' must be a non-empty version string to keep markdownlint-cli "
+            "installable on odd-numbered current node releases (EBADENGINE guard)"
+        )


### PR DESCRIPTION
Closes #1272
Closes #1273

## #1272 — pytest fixture deprecation (cross-version safe)

Class-scoped fixtures defined as instance methods are deprecated in pytest 9.1+ and removed in pytest 10 (`PytestRemovedIn10Warning`): instance attributes set in such fixtures stop being visible to test methods.

The fix had to work across the project's whole supported range (`pytest>=9,<10`), including the `--resolution lowest-direct` CI job which installs **pytest 9.0.x**. The `@classmethod` fixture form is _not_ recognised on 9.0.x (`fixture 'workflow' not found`), so the portable fix is to **drop `scope="class"`** — function-scoped instance-method fixtures are the basic, non-deprecated form supported on every 9.x. These fixtures are cheap readers (parse a YAML/TOML file), so per-test re-evaluation is negligible.

Fixtures converted to function scope:

- `tests/api/test_release_workflow.py` — `workflow`
- `tests/api/test_weekly_workflow.py` — `workflow`
- `tests/api/test_mutation_workflow.py` — `workflow`
- `.rhiza/tests/structure/test_pyproject.py` — `urls`, `classifiers`, `dependency_groups`, `latest_tag` (and the synced `bundles/tests/.rhiza/...` copy, to keep sync-parity)

### Regression guard

Added a **message-based** filter to both `pytest.ini` and `bundles/tests/pytest.ini`:

```ini
filterwarnings =
    error:Class-scoped fixture defined as instance method is deprecated
```

Matched by message rather than by warning category on purpose: the category name is version-specific (`PytestRemovedIn9Warning` vs `...In10Warning`), and referencing a class the installed pytest doesn't expose breaks `--resolution lowest-direct` at parse time. Matching the message errors on exactly this deprecation regardless of pytest version, while third-party `DeprecationWarning`s stay non-fatal.

## #1273 — guard the pre-commit node pin

Added `TestCorePreCommitConfig` to `tests/bundles/test_bundle_content_validity.py`, asserting `bundles/core/.pre-commit-config.yaml` declares a non-empty `default_language_version.node`. This locks in the EBADENGINE node-pin from #1271 so it cannot silently disappear downstream.

## Verification

- `uv run --all-extras --resolution lowest-direct pytest tests --ignore=tests/stress --ignore=tests/benchmarks` → **952 passed, 14 skipped** (the CI `lowest-direct` command — both the parse error and the fixture-not-found errors are gone)
- `make test` (pytest 9.1.1) → **952 passed, 14 skipped** (+1 new node-pin test)
- `make rhiza-test` → **159 passed, 1 skipped**
- Verified the message filter genuinely catches the deprecated pattern (a scratch class-scoped instance-method fixture errors under it)
- `make fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)