### PR TITLE
docs(utils): enrich .rhiza/utils docstrings with args/returns/examples (#1279)

### DIFF
--- a/.rhiza/utils/explain_bundles.py
+++ b/.rhiza/utils/explain_bundles.py
@@ -1,4 +1,19 @@
-"""Print all Rhiza bundles and profiles with descriptions and dependencies."""
+"""Print all Rhiza bundles and profiles with descriptions and dependencies.
+
+Run as a script from a project root that contains ``.rhiza/template-bundles.yml``.
+It reads that file, groups every bundle into the base, GitHub, and GitLab families,
+and prints a colourised summary of each bundle (with its ``requires``/``recommends``
+dependencies) followed by the profiles and the bundles they expand to.
+
+Example:
+    Invoke through the Makefile target (the supported entry point)::
+
+        $ make explain-bundles
+
+    or run the module directly from the repository root::
+
+        $ python .rhiza/utils/explain_bundles.py
+"""
 
 import sys
 
@@ -22,17 +37,39 @@ profiles = data.get("profiles", {})
 
 
 def _is_github(name: str) -> bool:
-    """Return True when a bundle belongs to the GitHub family."""
+    """Return True when a bundle belongs to the GitHub family.
+
+    Args:
+        name: The bundle name (e.g. ``github-tests`` or ``gh-aw``).
+
+    Returns:
+        True if the bundle is GitHub-specific, False otherwise.
+    """
     return name.startswith("github-") or name in {"github", "gh-aw"}
 
 
 def _is_gitlab(name: str) -> bool:
-    """Return True when a bundle belongs to the GitLab family."""
+    """Return True when a bundle belongs to the GitLab family.
+
+    Args:
+        name: The bundle name (e.g. ``gitlab-tests`` or ``gitlab``).
+
+    Returns:
+        True if the bundle is GitLab-specific, False otherwise.
+    """
     return name.startswith("gitlab-") or name == "gitlab"
 
 
 def _bundle_group(name: str) -> str:
-    """Map a bundle name to its display group."""
+    """Map a bundle name to its display group.
+
+    Args:
+        name: The bundle name to classify.
+
+    Returns:
+        One of ``"github"``, ``"gitlab"``, or ``"base"`` — the section
+        heading the bundle is printed under.
+    """
     if _is_github(name):
         return "github"
     if _is_gitlab(name):
@@ -41,7 +78,17 @@ def _bundle_group(name: str) -> str:
 
 
 def _print_bundle(name: str, info: dict) -> None:  # type: ignore[type-arg]
-    """Print one bundle entry with dependency metadata."""
+    """Print one bundle entry with dependency metadata.
+
+    Args:
+        name: The bundle name, used as the row label.
+        info: The bundle's mapping from ``template-bundles.yml``. Recognised
+            keys are ``description``, ``requires``, ``recommends``, and
+            ``standalone``; all are optional and default sensibly.
+
+    Returns:
+        None. The formatted entry is written to standard output.
+    """
     desc = info.get("description", "").strip().splitlines()[0]
     requires = info.get("requires") or []
     recommends = info.get("recommends") or []

--- a/.rhiza/utils/pip_audit_policy.py
+++ b/.rhiza/utils/pip_audit_policy.py
@@ -22,13 +22,43 @@ _TOOLING: frozenset[str] = frozenset({"pip", "setuptools", "wheel", "distribute"
 
 
 def _vuln_ids(vuln: dict) -> str:  # type: ignore[type-arg]
-    """Return a human-readable string of all IDs for a vulnerability entry."""
+    """Return a human-readable string of all IDs for a vulnerability entry.
+
+    Args:
+        vuln: A single vulnerability object from pip-audit's JSON output. Must
+            contain an ``id`` key and may contain an ``aliases`` list.
+
+    Returns:
+        A comma-separated string starting with the primary ``id`` followed by any
+        distinct aliases (e.g. ``"PYSEC-2024-1, CVE-2024-1234"``).
+    """
     ids = [vuln["id"]] + [a for a in vuln.get("aliases", []) if a != vuln["id"]]
     return ", ".join(ids)
 
 
 def main() -> int:
-    """Run pip-audit and apply tiered vulnerability policy."""
+    """Run pip-audit and apply the tiered vulnerability policy.
+
+    Invokes ``uvx pip-audit`` with JSON output, forwarding any extra
+    command-line arguments. Vulnerabilities in build tooling (see ``_TOOLING``)
+    are reported as warnings; vulnerabilities in any other (runtime) dependency
+    are reported as failures.
+
+    Returns:
+        A process exit code: ``0`` when no vulnerabilities affect runtime
+        dependencies (clean run, tooling-only findings, or unparseable output is
+        passed through with pip-audit's own code), or ``1`` when at least one
+        runtime dependency is vulnerable.
+
+    Example:
+        Run via the Makefile (the supported entry point)::
+
+            $ make security
+
+        or call pip-audit through this policy directly, forwarding flags::
+
+            $ python .rhiza/utils/pip_audit_policy.py --ignore-vuln CVE-2024-1234
+    """
     uvx = shutil.which("uvx") or "uvx"
     cmd = [uvx, "pip-audit", "--format", "json", *sys.argv[1:]]
     proc = subprocess.run(cmd, capture_output=True, text=True)  # noqa: S603  # nosec B603

--- a/.rhiza/utils/suppression_audit.py
+++ b/.rhiza/utils/suppression_audit.py
@@ -64,7 +64,17 @@ _SKIP_DIRS = {".venv", ".git", "node_modules", ".tox", "build", "dist", "__pycac
 
 @dataclass
 class Suppression:
-    """Represents a single suppression comment found in the codebase."""
+    """A single suppression comment found in the codebase.
+
+    Attributes:
+        file: Path to the file containing the suppression.
+        line_no: 1-based line number of the comment.
+        kind: Suppression family label (e.g. ``"noqa"``, ``"nosec"``,
+            ``"type:ignore"``, ``"no cover"``, ``"noinspection"``).
+        codes: The specific rule codes named in the comment, if any
+            (e.g. ``["E501", "F401"]``); empty for blanket suppressions.
+        raw: The verbatim comment text, used for downstream CVE extraction.
+    """
 
     file: str
     line_no: int
@@ -99,6 +109,13 @@ def scan_file(path: Path) -> list[Suppression]:
     Uses Python's ``tokenize`` module so that only actual comment tokens are
     inspected — patterns that appear inside string literals or docstrings are
     correctly ignored.
+
+    Args:
+        path: Path to the Python file to scan.
+
+    Returns:
+        A list of :class:`Suppression` records, one per matching comment line, in
+        source order. Empty if the file cannot be read or fails to tokenize.
     """
     suppressions: list[Suppression] = []
     try:
@@ -134,7 +151,15 @@ def scan_file(path: Path) -> list[Suppression]:
 
 
 def count_non_empty_lines(path: Path) -> int:
-    """Count non-empty lines in a file."""
+    """Count non-empty lines in a file.
+
+    Args:
+        path: Path to the file to measure.
+
+    Returns:
+        The number of lines that contain non-whitespace characters, or ``0`` if
+        the file cannot be read. Used as the denominator for suppression density.
+    """
     try:
         return sum(1 for line in path.read_text(encoding="utf-8", errors="replace").splitlines() if line.strip())
     except OSError:
@@ -156,7 +181,15 @@ _GRADE_THRESHOLDS: list[tuple[float, str]] = [
 
 
 def compute_grade(density: float) -> str:
-    """Return a letter grade based on suppression density (count per 100 lines)."""
+    """Return a letter grade based on suppression density.
+
+    Args:
+        density: Number of suppressions per 100 non-empty lines of code.
+
+    Returns:
+        A letter grade from ``"A+"`` (zero suppressions) down to ``"F"``,
+        derived from :data:`_GRADE_THRESHOLDS`.
+    """
     grade = "F"
     for threshold, letter in _GRADE_THRESHOLDS:
         if density <= threshold:
@@ -347,7 +380,31 @@ def _check_stale_nosec_cves(suppressions: list[Suppression], pip_audit_args: lis
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Run the suppression audit and print a structured report."""
+    """Run the suppression audit and print a structured report.
+
+    Scans the working directory tree for inline suppression comments, prints a
+    per-file report, a histogram by code, and an overall density grade. With
+    ``--fail-stale-nosec-cve`` it additionally cross-checks CVE-tagged ``# nosec``
+    comments against live pip-audit findings and fails on stale ones.
+
+    Args:
+        argv: Argument list to parse (excluding the program name). Defaults to
+            ``None``, in which case ``sys.argv[1:]`` is used by the module entry
+            point. Unrecognised arguments are forwarded to pip-audit.
+
+    Returns:
+        A process exit code: ``0`` on success, ``1`` when stale CVE-tagged
+        ``# nosec`` suppressions are found, or ``2`` when pip-audit fails to run.
+
+    Example:
+        Run via the Makefile (the supported entry point)::
+
+            $ make suppression-audit
+
+        or invoke the module directly, enabling the stale-CVE gate::
+
+            $ python .rhiza/utils/suppression_audit.py --fail-stale-nosec-cve
+    """
     parser = argparse.ArgumentParser(add_help=True)
     parser.add_argument(
         "--fail-stale-nosec-cve",

--- a/bundles/core/.rhiza/utils/pip_audit_policy.py
+++ b/bundles/core/.rhiza/utils/pip_audit_policy.py
@@ -22,13 +22,43 @@ _TOOLING: frozenset[str] = frozenset({"pip", "setuptools", "wheel", "distribute"
 
 
 def _vuln_ids(vuln: dict) -> str:  # type: ignore[type-arg]
-    """Return a human-readable string of all IDs for a vulnerability entry."""
+    """Return a human-readable string of all IDs for a vulnerability entry.
+
+    Args:
+        vuln: A single vulnerability object from pip-audit's JSON output. Must
+            contain an ``id`` key and may contain an ``aliases`` list.
+
+    Returns:
+        A comma-separated string starting with the primary ``id`` followed by any
+        distinct aliases (e.g. ``"PYSEC-2024-1, CVE-2024-1234"``).
+    """
     ids = [vuln["id"]] + [a for a in vuln.get("aliases", []) if a != vuln["id"]]
     return ", ".join(ids)
 
 
 def main() -> int:
-    """Run pip-audit and apply tiered vulnerability policy."""
+    """Run pip-audit and apply the tiered vulnerability policy.
+
+    Invokes ``uvx pip-audit`` with JSON output, forwarding any extra
+    command-line arguments. Vulnerabilities in build tooling (see ``_TOOLING``)
+    are reported as warnings; vulnerabilities in any other (runtime) dependency
+    are reported as failures.
+
+    Returns:
+        A process exit code: ``0`` when no vulnerabilities affect runtime
+        dependencies (clean run, tooling-only findings, or unparseable output is
+        passed through with pip-audit's own code), or ``1`` when at least one
+        runtime dependency is vulnerable.
+
+    Example:
+        Run via the Makefile (the supported entry point)::
+
+            $ make security
+
+        or call pip-audit through this policy directly, forwarding flags::
+
+            $ python .rhiza/utils/pip_audit_policy.py --ignore-vuln CVE-2024-1234
+    """
     uvx = shutil.which("uvx") or "uvx"
     cmd = [uvx, "pip-audit", "--format", "json", *sys.argv[1:]]
     proc = subprocess.run(cmd, capture_output=True, text=True)  # noqa: S603  # nosec B603

--- a/bundles/core/.rhiza/utils/suppression_audit.py
+++ b/bundles/core/.rhiza/utils/suppression_audit.py
@@ -64,7 +64,17 @@ _SKIP_DIRS = {".venv", ".git", "node_modules", ".tox", "build", "dist", "__pycac
 
 @dataclass
 class Suppression:
-    """Represents a single suppression comment found in the codebase."""
+    """A single suppression comment found in the codebase.
+
+    Attributes:
+        file: Path to the file containing the suppression.
+        line_no: 1-based line number of the comment.
+        kind: Suppression family label (e.g. ``"noqa"``, ``"nosec"``,
+            ``"type:ignore"``, ``"no cover"``, ``"noinspection"``).
+        codes: The specific rule codes named in the comment, if any
+            (e.g. ``["E501", "F401"]``); empty for blanket suppressions.
+        raw: The verbatim comment text, used for downstream CVE extraction.
+    """
 
     file: str
     line_no: int
@@ -99,6 +109,13 @@ def scan_file(path: Path) -> list[Suppression]:
     Uses Python's ``tokenize`` module so that only actual comment tokens are
     inspected — patterns that appear inside string literals or docstrings are
     correctly ignored.
+
+    Args:
+        path: Path to the Python file to scan.
+
+    Returns:
+        A list of :class:`Suppression` records, one per matching comment line, in
+        source order. Empty if the file cannot be read or fails to tokenize.
     """
     suppressions: list[Suppression] = []
     try:
@@ -134,7 +151,15 @@ def scan_file(path: Path) -> list[Suppression]:
 
 
 def count_non_empty_lines(path: Path) -> int:
-    """Count non-empty lines in a file."""
+    """Count non-empty lines in a file.
+
+    Args:
+        path: Path to the file to measure.
+
+    Returns:
+        The number of lines that contain non-whitespace characters, or ``0`` if
+        the file cannot be read. Used as the denominator for suppression density.
+    """
     try:
         return sum(1 for line in path.read_text(encoding="utf-8", errors="replace").splitlines() if line.strip())
     except OSError:
@@ -156,7 +181,15 @@ _GRADE_THRESHOLDS: list[tuple[float, str]] = [
 
 
 def compute_grade(density: float) -> str:
-    """Return a letter grade based on suppression density (count per 100 lines)."""
+    """Return a letter grade based on suppression density.
+
+    Args:
+        density: Number of suppressions per 100 non-empty lines of code.
+
+    Returns:
+        A letter grade from ``"A+"`` (zero suppressions) down to ``"F"``,
+        derived from :data:`_GRADE_THRESHOLDS`.
+    """
     grade = "F"
     for threshold, letter in _GRADE_THRESHOLDS:
         if density <= threshold:
@@ -347,7 +380,31 @@ def _check_stale_nosec_cves(suppressions: list[Suppression], pip_audit_args: lis
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Run the suppression audit and print a structured report."""
+    """Run the suppression audit and print a structured report.
+
+    Scans the working directory tree for inline suppression comments, prints a
+    per-file report, a histogram by code, and an overall density grade. With
+    ``--fail-stale-nosec-cve`` it additionally cross-checks CVE-tagged ``# nosec``
+    comments against live pip-audit findings and fails on stale ones.
+
+    Args:
+        argv: Argument list to parse (excluding the program name). Defaults to
+            ``None``, in which case ``sys.argv[1:]`` is used by the module entry
+            point. Unrecognised arguments are forwarded to pip-audit.
+
+    Returns:
+        A process exit code: ``0`` on success, ``1`` when stale CVE-tagged
+        ``# nosec`` suppressions are found, or ``2`` when pip-audit fails to run.
+
+    Example:
+        Run via the Makefile (the supported entry point)::
+
+            $ make suppression-audit
+
+        or invoke the module directly, enabling the stale-CVE gate::
+
+            $ python .rhiza/utils/suppression_audit.py --fail-stale-nosec-cve
+    """
     parser = argparse.ArgumentParser(add_help=True)
     parser.add_argument(
         "--fail-stale-nosec-cve",


### PR DESCRIPTION
## Summary

Closes #1279. Docstring coverage was already at 100% (interrogate, enforced), but coverage measures presence, not richness. This PR enriches the docstrings of the Python modules under `.rhiza/utils/` so downstream adopters get documented arguments, return values, and usage examples for the user-facing entry points.

## Changes

- **`explain_bundles.py`** — module docstring now describes behaviour and includes a `make explain-bundles` usage example; `_is_github`, `_is_gitlab`, `_bundle_group`, and `_print_bundle` document their args/returns.
- **`pip_audit_policy.py`** — `_vuln_ids` documents args/returns; `main()` documents its exit-code contract and adds a usage example (`make security` / forwarding flags).
- **`suppression_audit.py`** — the `Suppression` dataclass documents its attributes; `scan_file`, `count_non_empty_lines`, `compute_grade`, and `main()` document args/returns, and `main()` adds a usage example.

No behavioural changes.

## Acceptance criteria

- [x] Each public function documents parameters and return value
- [x] User-facing entry points include a usage example
- [x] Interrogate stays at 100% (`make docs-coverage`)
- [x] ruff D-rules stay clean (`ruff check .rhiza/utils/`)
- [x] `make typecheck` passes (ty + mypy strict)
- [x] `tests/utils/` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)