### PR TITLE
ci(gh-aw): add compiler-free lock-file freshness check

### DIFF
--- a/.github/workflows/rhiza_gh-aw-validate.yml
+++ b/.github/workflows/rhiza_gh-aw-validate.yml
@@ -44,6 +44,14 @@ jobs:
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+      - name: Check lock files are fresh (compiler-free body-hash check)
+        run: |
+          if [ -f .rhiza/utils/gh_aw_lock_freshness.py ]; then
+            python3 .rhiza/utils/gh_aw_lock_freshness.py
+          else
+            echo "::notice::gh_aw_lock_freshness.py not present; skipping body-hash freshness check."
+          fi
+
       - name: Install gh-aw extension
         id: install-gh-aw
         continue-on-error: true

--- a/.rhiza/make.d/gh-aw.mk
+++ b/.rhiza/make.d/gh-aw.mk
@@ -44,6 +44,9 @@ gh-aw-logs: install-gh-aw ## show logs for recent agentic workflow runs
 	@gh aw logs
 
 gh-aw-validate: install-gh-aw ## validate lock files are up-to-date
+	@if [ -f .rhiza/utils/gh_aw_lock_freshness.py ]; then \
+		python3 .rhiza/utils/gh_aw_lock_freshness.py || exit 1; \
+	fi
 	@gh aw compile
 	@if ! git diff --quiet .github/workflows/*.lock.yml; then \
 		printf "$${RED}[ERROR] Agentic workflow lock files are out of date. Run 'make gh-aw-compile' and commit the changes.${RESET}\n"; \

--- a/.rhiza/tests/utils/test_gh_aw_lock_freshness.py
+++ b/.rhiza/tests/utils/test_gh_aw_lock_freshness.py
@@ -1,0 +1,119 @@
+"""Unit tests for gh_aw_lock_freshness.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+_MD = "---\non: {}\n---\n\n# Title\n\nBody text here.\n"
+
+
+def _load_module(root: Path) -> ModuleType:
+    """Import the repo's gh_aw_lock_freshness.py utility as a standalone module."""
+    module_path = root / ".rhiza" / "utils" / "gh_aw_lock_freshness.py"
+    spec = importlib.util.spec_from_file_location("gh_aw_lock_freshness", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["gh_aw_lock_freshness"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_workflow(workflows: Path, name: str, md_text: str, body_hash: str | None) -> None:
+    """Write a .md source and (optionally) a matching .lock.yml stub into a dir."""
+    workflows.mkdir(parents=True, exist_ok=True)
+    (workflows / f"{name}.md").write_text(md_text)
+    if body_hash is not None:
+        (workflows / f"{name}.lock.yml").write_text(f'# gh-aw-metadata: {{"body_hash":"{body_hash}"}}\njobs: {{}}\n')
+
+
+def test_source_body_hash_ignores_frontmatter(root: Path) -> None:
+    """The body hash depends only on the markdown body, not the frontmatter."""
+    module = _load_module(root)
+    a = module.source_body_hash("---\non: {}\n---\n\nSame body.\n")
+    b = module.source_body_hash("---\non: {push: {}}\n---\nSame body.")
+    assert a is not None
+    assert a == b
+
+
+def test_source_body_hash_returns_none_without_frontmatter(root: Path) -> None:
+    """Markdown without a frontmatter fence yields no body hash."""
+    module = _load_module(root)
+    assert module.source_body_hash("# Just a heading\n") is None
+
+
+def test_embedded_body_hash_reads_metadata_header(root: Path) -> None:
+    """The embedded hash is parsed from the gh-aw-metadata header line."""
+    module = _load_module(root)
+    lock = '# gh-aw-metadata: {"schema_version":"v4","body_hash":"abc123"}\njobs: {}\n'
+    assert module.embedded_body_hash(lock) == "abc123"
+
+
+def test_embedded_body_hash_returns_none_when_absent(root: Path) -> None:
+    """A lock file without a metadata header yields no embedded hash."""
+    module = _load_module(root)
+    assert module.embedded_body_hash("jobs: {}\n") is None
+
+
+def test_check_freshness_passes_for_matching_hash(root: Path, tmp_path: Path) -> None:
+    """A source whose body matches its lock's embedded hash is reported fresh."""
+    module = _load_module(root)
+    workflows = tmp_path / ".github" / "workflows"
+    _write_workflow(workflows, "demo", _MD, module.source_body_hash(_MD))
+    assert module.check_freshness(tmp_path) == []
+
+
+def test_check_freshness_flags_stale_body(root: Path, tmp_path: Path) -> None:
+    """A source edited since its last compile is flagged as stale."""
+    module = _load_module(root)
+    workflows = tmp_path / ".github" / "workflows"
+    _write_workflow(workflows, "demo", _MD, "0" * 64)
+    problems = module.check_freshness(tmp_path)
+    assert len(problems) == 1
+    assert "demo.md" in problems[0]
+
+
+def test_check_freshness_flags_missing_lock(root: Path, tmp_path: Path) -> None:
+    """A source without any compiled lock file is flagged."""
+    module = _load_module(root)
+    workflows = tmp_path / ".github" / "workflows"
+    _write_workflow(workflows, "demo", _MD, body_hash=None)
+    problems = module.check_freshness(tmp_path)
+    assert len(problems) == 1
+    assert "demo.lock.yml" in problems[0]
+
+
+def test_check_freshness_empty_without_sources(root: Path, tmp_path: Path) -> None:
+    """A repo with no agentic sources reports no problems (graceful no-op)."""
+    module = _load_module(root)
+    (tmp_path / ".github" / "workflows").mkdir(parents=True)
+    assert module.check_freshness(tmp_path) == []
+
+
+def test_repo_lock_files_are_fresh(root: Path) -> None:
+    """The committed lock files in this repository must be up to date."""
+    module = _load_module(root)
+    assert module.check_freshness(root) == []
+
+
+def test_main_returns_one_and_reports_fix_on_stale(root: Path, tmp_path: Path, capsys) -> None:
+    """main() exits non-zero and prints the fix command when a lock is stale."""
+    module = _load_module(root)
+    workflows = tmp_path / ".github" / "workflows"
+    _write_workflow(workflows, "demo", _MD, "0" * 64)
+    assert module.main([str(tmp_path)]) == 1
+    out = capsys.readouterr().out
+    assert "stale" in out.lower()
+    assert "make gh-aw-compile" in out
+
+
+def test_main_returns_zero_when_fresh(root: Path, tmp_path: Path, capsys) -> None:
+    """main() exits zero and prints an OK message when everything is fresh."""
+    module = _load_module(root)
+    workflows = tmp_path / ".github" / "workflows"
+    _write_workflow(workflows, "demo", _MD, module.source_body_hash(_MD))
+    assert module.main([str(tmp_path)]) == 0
+    assert "[OK]" in capsys.readouterr().out

--- a/.rhiza/utils/gh_aw_lock_freshness.py
+++ b/.rhiza/utils/gh_aw_lock_freshness.py
@@ -1,0 +1,142 @@
+"""Compiler-free freshness check for gh-aw agentic workflow lock files.
+
+GitHub Agentic Workflow sources live as ``.github/workflows/*.md`` files that
+compile to ``.lock.yml`` artifacts via ``gh aw compile``. Every generated
+``.lock.yml`` embeds a ``# gh-aw-metadata:`` header recording the SHA-256
+``body_hash`` of its source's markdown body.
+
+This module verifies, without requiring the ``gh-aw`` CLI extension, that each
+source has a compiled lock file and that the embedded ``body_hash`` matches the
+current source. It catches the common drift case: a ``.md`` prompt body edited
+without recompiling. The authoritative full check (which additionally covers
+frontmatter and pinned-action drift) remains ``gh aw compile`` followed by a
+``git diff``, which ``make gh-aw-validate`` runs when the extension is available.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+
+_METADATA_PREFIX = "# gh-aw-metadata:"
+_FIX_HINT = "Run 'make gh-aw-compile' and commit the regenerated .lock.yml files."
+# Capture the markdown body that follows the leading YAML frontmatter block.
+_FRONTMATTER_RE = re.compile(r"^---\r?\n.*?\r?\n---\r?\n?(.*)$", re.DOTALL)
+
+
+def iter_agentic_sources(workflows_dir: Path) -> list[Path]:
+    """Return agentic-workflow markdown sources under a workflows directory.
+
+    A source is any ``*.md`` file that begins with a ``---`` YAML frontmatter
+    fence, matching the gh-aw convention.
+
+    Args:
+        workflows_dir: The ``.github/workflows`` directory to scan.
+
+    Returns:
+        Sorted list of agentic-workflow ``.md`` source paths (empty if the
+        directory does not exist).
+    """
+    if not workflows_dir.is_dir():
+        return []
+    return [md for md in sorted(workflows_dir.glob("*.md")) if md.read_text(encoding="utf-8").startswith("---")]
+
+
+def source_body_hash(md_text: str) -> str | None:
+    """Return the SHA-256 of the markdown body that follows the frontmatter.
+
+    The body is everything after the closing ``---`` fence, stripped of leading
+    and trailing whitespace — the same normalisation gh-aw applies before
+    hashing.
+
+    Args:
+        md_text: Full text of an agentic-workflow ``.md`` source.
+
+    Returns:
+        Hex SHA-256 digest of the stripped body, or ``None`` when no closing
+        frontmatter fence is present.
+    """
+    match = _FRONTMATTER_RE.match(md_text)
+    if match is None:
+        return None
+    return hashlib.sha256(match.group(1).strip().encode("utf-8")).hexdigest()
+
+
+def embedded_body_hash(lock_text: str) -> str | None:
+    """Return the ``body_hash`` recorded in a lock file's gh-aw metadata header.
+
+    Args:
+        lock_text: Full text of a generated ``.lock.yml`` file.
+
+    Returns:
+        The embedded hex digest, or ``None`` when the metadata header or the
+        ``body_hash`` field is absent or unparseable.
+    """
+    for line in lock_text.splitlines()[:5]:
+        if line.startswith(_METADATA_PREFIX):
+            try:
+                data: object = json.loads(line[len(_METADATA_PREFIX) :].strip())
+            except json.JSONDecodeError:
+                return None
+            if isinstance(data, dict):
+                value = data.get("body_hash")
+                return value if isinstance(value, str) else None
+            return None
+    return None
+
+
+def check_freshness(repo_root: Path) -> list[str]:
+    """Return freshness problems for every agentic workflow lock file.
+
+    Args:
+        repo_root: Repository root that contains ``.github/workflows``.
+
+    Returns:
+        Human-readable problem descriptions; empty when every source has a
+        compiled lock file whose embedded body hash matches the source (also
+        empty when there are no agentic sources).
+    """
+    problems: list[str] = []
+    workflows_dir = repo_root / ".github" / "workflows"
+    for md in iter_agentic_sources(workflows_dir):
+        lock = md.with_suffix(".lock.yml")
+        if not lock.exists():
+            problems.append(f"{md.name}: no compiled {lock.name} found")
+            continue
+        expected = embedded_body_hash(lock.read_text(encoding="utf-8"))
+        if expected is None:
+            problems.append(f"{lock.name}: missing or invalid '{_METADATA_PREFIX}' metadata header")
+            continue
+        if expected != source_body_hash(md.read_text(encoding="utf-8")):
+            problems.append(f"{md.name}: body changed since last compile ({lock.name} is stale)")
+    return problems
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Check lock-file freshness and report problems to stdout.
+
+    Args:
+        argv: Optional argument list; the first value, if present, is the
+            repository root to check (defaults to the current directory).
+
+    Returns:
+        ``0`` when all lock files are fresh, ``1`` otherwise.
+    """
+    args = sys.argv[1:] if argv is None else argv
+    repo_root = Path(args[0]) if args else Path.cwd()
+    problems = check_freshness(repo_root)
+    if not problems:
+        print("[OK] All agentic workflow lock files are up to date.")
+        return 0
+    print("[ERROR] Agentic workflow lock files are stale relative to their .md sources:")
+    for problem in problems:
+        print(f"  - {problem}")
+    print(_FIX_HINT)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bundles/gh-aw/.rhiza/make.d/gh-aw.mk
+++ b/bundles/gh-aw/.rhiza/make.d/gh-aw.mk
@@ -44,6 +44,9 @@ gh-aw-logs: install-gh-aw ## show logs for recent agentic workflow runs
 	@gh aw logs
 
 gh-aw-validate: install-gh-aw ## validate lock files are up-to-date
+	@if [ -f .rhiza/utils/gh_aw_lock_freshness.py ]; then \
+		python3 .rhiza/utils/gh_aw_lock_freshness.py || exit 1; \
+	fi
 	@gh aw compile
 	@if ! git diff --quiet .github/workflows/*.lock.yml; then \
 		printf "$${RED}[ERROR] Agentic workflow lock files are out of date. Run 'make gh-aw-compile' and commit the changes.${RESET}\n"; \

--- a/bundles/gh-aw/.rhiza/tests/utils/test_gh_aw_lock_freshness.py
+++ b/bundles/gh-aw/.rhiza/tests/utils/test_gh_aw_lock_freshness.py
@@ -1,0 +1,119 @@
+"""Unit tests for gh_aw_lock_freshness.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+_MD = "---\non: {}\n---\n\n# Title\n\nBody text here.\n"
+
+
+def _load_module(root: Path) -> ModuleType:
+    """Import the repo's gh_aw_lock_freshness.py utility as a standalone module."""
+    module_path = root / ".rhiza" / "utils" / "gh_aw_lock_freshness.py"
+    spec = importlib.util.spec_from_file_location("gh_aw_lock_freshness", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["gh_aw_lock_freshness"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_workflow(workflows: Path, name: str, md_text: str, body_hash: str | None) -> None:
+    """Write a .md source and (optionally) a matching .lock.yml stub into a dir."""
+    workflows.mkdir(parents=True, exist_ok=True)
+    (workflows / f"{name}.md").write_text(md_text)
+    if body_hash is not None:
+        (workflows / f"{name}.lock.yml").write_text(f'# gh-aw-metadata: {{"body_hash":"{body_hash}"}}\njobs: {{}}\n')
+
+
+def test_source_body_hash_ignores_frontmatter(root: Path) -> None:
+    """The body hash depends only on the markdown body, not the frontmatter."""
+    module = _load_module(root)
+    a = module.source_body_hash("---\non: {}\n---\n\nSame body.\n")
+    b = module.source_body_hash("---\non: {push: {}}\n---\nSame body.")
+    assert a is not None
+    assert a == b
+
+
+def test_source_body_hash_returns_none_without_frontmatter(root: Path) -> None:
+    """Markdown without a frontmatter fence yields no body hash."""
+    module = _load_module(root)
+    assert module.source_body_hash("# Just a heading\n") is None
+
+
+def test_embedded_body_hash_reads_metadata_header(root: Path) -> None:
+    """The embedded hash is parsed from the gh-aw-metadata header line."""
+    module = _load_module(root)
+    lock = '# gh-aw-metadata: {"schema_version":"v4","body_hash":"abc123"}\njobs: {}\n'
+    assert module.embedded_body_hash(lock) == "abc123"
+
+
+def test_embedded_body_hash_returns_none_when_absent(root: Path) -> None:
+    """A lock file without a metadata header yields no embedded hash."""
+    module = _load_module(root)
+    assert module.embedded_body_hash("jobs: {}\n") is None
+
+
+def test_check_freshness_passes_for_matching_hash(root: Path, tmp_path: Path) -> None:
+    """A source whose body matches its lock's embedded hash is reported fresh."""
+    module = _load_module(root)
+    workflows = tmp_path / ".github" / "workflows"
+    _write_workflow(workflows, "demo", _MD, module.source_body_hash(_MD))
+    assert module.check_freshness(tmp_path) == []
+
+
+def test_check_freshness_flags_stale_body(root: Path, tmp_path: Path) -> None:
+    """A source edited since its last compile is flagged as stale."""
+    module = _load_module(root)
+    workflows = tmp_path / ".github" / "workflows"
+    _write_workflow(workflows, "demo", _MD, "0" * 64)
+    problems = module.check_freshness(tmp_path)
+    assert len(problems) == 1
+    assert "demo.md" in problems[0]
+
+
+def test_check_freshness_flags_missing_lock(root: Path, tmp_path: Path) -> None:
+    """A source without any compiled lock file is flagged."""
+    module = _load_module(root)
+    workflows = tmp_path / ".github" / "workflows"
+    _write_workflow(workflows, "demo", _MD, body_hash=None)
+    problems = module.check_freshness(tmp_path)
+    assert len(problems) == 1
+    assert "demo.lock.yml" in problems[0]
+
+
+def test_check_freshness_empty_without_sources(root: Path, tmp_path: Path) -> None:
+    """A repo with no agentic sources reports no problems (graceful no-op)."""
+    module = _load_module(root)
+    (tmp_path / ".github" / "workflows").mkdir(parents=True)
+    assert module.check_freshness(tmp_path) == []
+
+
+def test_repo_lock_files_are_fresh(root: Path) -> None:
+    """The committed lock files in this repository must be up to date."""
+    module = _load_module(root)
+    assert module.check_freshness(root) == []
+
+
+def test_main_returns_one_and_reports_fix_on_stale(root: Path, tmp_path: Path, capsys) -> None:
+    """main() exits non-zero and prints the fix command when a lock is stale."""
+    module = _load_module(root)
+    workflows = tmp_path / ".github" / "workflows"
+    _write_workflow(workflows, "demo", _MD, "0" * 64)
+    assert module.main([str(tmp_path)]) == 1
+    out = capsys.readouterr().out
+    assert "stale" in out.lower()
+    assert "make gh-aw-compile" in out
+
+
+def test_main_returns_zero_when_fresh(root: Path, tmp_path: Path, capsys) -> None:
+    """main() exits zero and prints an OK message when everything is fresh."""
+    module = _load_module(root)
+    workflows = tmp_path / ".github" / "workflows"
+    _write_workflow(workflows, "demo", _MD, module.source_body_hash(_MD))
+    assert module.main([str(tmp_path)]) == 0
+    assert "[OK]" in capsys.readouterr().out

--- a/bundles/gh-aw/.rhiza/utils/gh_aw_lock_freshness.py
+++ b/bundles/gh-aw/.rhiza/utils/gh_aw_lock_freshness.py
@@ -1,0 +1,142 @@
+"""Compiler-free freshness check for gh-aw agentic workflow lock files.
+
+GitHub Agentic Workflow sources live as ``.github/workflows/*.md`` files that
+compile to ``.lock.yml`` artifacts via ``gh aw compile``. Every generated
+``.lock.yml`` embeds a ``# gh-aw-metadata:`` header recording the SHA-256
+``body_hash`` of its source's markdown body.
+
+This module verifies, without requiring the ``gh-aw`` CLI extension, that each
+source has a compiled lock file and that the embedded ``body_hash`` matches the
+current source. It catches the common drift case: a ``.md`` prompt body edited
+without recompiling. The authoritative full check (which additionally covers
+frontmatter and pinned-action drift) remains ``gh aw compile`` followed by a
+``git diff``, which ``make gh-aw-validate`` runs when the extension is available.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+
+_METADATA_PREFIX = "# gh-aw-metadata:"
+_FIX_HINT = "Run 'make gh-aw-compile' and commit the regenerated .lock.yml files."
+# Capture the markdown body that follows the leading YAML frontmatter block.
+_FRONTMATTER_RE = re.compile(r"^---\r?\n.*?\r?\n---\r?\n?(.*)$", re.DOTALL)
+
+
+def iter_agentic_sources(workflows_dir: Path) -> list[Path]:
+    """Return agentic-workflow markdown sources under a workflows directory.
+
+    A source is any ``*.md`` file that begins with a ``---`` YAML frontmatter
+    fence, matching the gh-aw convention.
+
+    Args:
+        workflows_dir: The ``.github/workflows`` directory to scan.
+
+    Returns:
+        Sorted list of agentic-workflow ``.md`` source paths (empty if the
+        directory does not exist).
+    """
+    if not workflows_dir.is_dir():
+        return []
+    return [md for md in sorted(workflows_dir.glob("*.md")) if md.read_text(encoding="utf-8").startswith("---")]
+
+
+def source_body_hash(md_text: str) -> str | None:
+    """Return the SHA-256 of the markdown body that follows the frontmatter.
+
+    The body is everything after the closing ``---`` fence, stripped of leading
+    and trailing whitespace — the same normalisation gh-aw applies before
+    hashing.
+
+    Args:
+        md_text: Full text of an agentic-workflow ``.md`` source.
+
+    Returns:
+        Hex SHA-256 digest of the stripped body, or ``None`` when no closing
+        frontmatter fence is present.
+    """
+    match = _FRONTMATTER_RE.match(md_text)
+    if match is None:
+        return None
+    return hashlib.sha256(match.group(1).strip().encode("utf-8")).hexdigest()
+
+
+def embedded_body_hash(lock_text: str) -> str | None:
+    """Return the ``body_hash`` recorded in a lock file's gh-aw metadata header.
+
+    Args:
+        lock_text: Full text of a generated ``.lock.yml`` file.
+
+    Returns:
+        The embedded hex digest, or ``None`` when the metadata header or the
+        ``body_hash`` field is absent or unparseable.
+    """
+    for line in lock_text.splitlines()[:5]:
+        if line.startswith(_METADATA_PREFIX):
+            try:
+                data: object = json.loads(line[len(_METADATA_PREFIX) :].strip())
+            except json.JSONDecodeError:
+                return None
+            if isinstance(data, dict):
+                value = data.get("body_hash")
+                return value if isinstance(value, str) else None
+            return None
+    return None
+
+
+def check_freshness(repo_root: Path) -> list[str]:
+    """Return freshness problems for every agentic workflow lock file.
+
+    Args:
+        repo_root: Repository root that contains ``.github/workflows``.
+
+    Returns:
+        Human-readable problem descriptions; empty when every source has a
+        compiled lock file whose embedded body hash matches the source (also
+        empty when there are no agentic sources).
+    """
+    problems: list[str] = []
+    workflows_dir = repo_root / ".github" / "workflows"
+    for md in iter_agentic_sources(workflows_dir):
+        lock = md.with_suffix(".lock.yml")
+        if not lock.exists():
+            problems.append(f"{md.name}: no compiled {lock.name} found")
+            continue
+        expected = embedded_body_hash(lock.read_text(encoding="utf-8"))
+        if expected is None:
+            problems.append(f"{lock.name}: missing or invalid '{_METADATA_PREFIX}' metadata header")
+            continue
+        if expected != source_body_hash(md.read_text(encoding="utf-8")):
+            problems.append(f"{md.name}: body changed since last compile ({lock.name} is stale)")
+    return problems
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Check lock-file freshness and report problems to stdout.
+
+    Args:
+        argv: Optional argument list; the first value, if present, is the
+            repository root to check (defaults to the current directory).
+
+    Returns:
+        ``0`` when all lock files are fresh, ``1`` otherwise.
+    """
+    args = sys.argv[1:] if argv is None else argv
+    repo_root = Path(args[0]) if args else Path.cwd()
+    problems = check_freshness(repo_root)
+    if not problems:
+        print("[OK] All agentic workflow lock files are up to date.")
+        return 0
+    print("[ERROR] Agentic workflow lock files are stale relative to their .md sources:")
+    for problem in problems:
+        print(f"  - {problem}")
+    print(_FIX_HINT)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #1278

## Problem

The lock-file drift guard (`gh aw compile` + `git diff`, in both `rhiza_gh-aw-validate.yml` and `make gh-aw-validate`) **silently skips** when the gh-aw CLI extension can't be installed — which is the norm for public repos today (the install step hits HTTP 403 and the workflow emits a `::notice::` and passes). So in practice the drift check never fails on drift.

## Approach

Add an **always-on, compiler-free** freshness check that needs no extension.

Every generated `.lock.yml` embeds a `# gh-aw-metadata:` header recording the SHA-256 `body_hash` of its `.md` source's markdown body (verified: `sha256(body.strip())` matches across all three workflows). `gh_aw_lock_freshness.py` recomputes that hash and compares it, catching the common drift case — a prompt body edited without recompiling — and also flags any `.md` missing a compiled `.lock.yml`. It names the offending file and prints the `make gh-aw-compile` fix command.

The authoritative full check (which additionally covers frontmatter and pinned-action drift) **remains** `gh aw compile` + diff, still run when the extension is available. The two are complementary: the hash check is the always-on floor; the compile+diff is the complete check when gh-aw is installable.

### What this does *not* cover
Frontmatter edits (`permissions`, `tools`, triggers) aren't caught by the body hash — gh-aw normalises frontmatter before hashing and that scheme is compiler-version-specific, so reproducing it without the compiler would be brittle. Those are still caught by the authoritative compile+diff path.

## Changes

- **`.rhiza/utils/gh_aw_lock_freshness.py`** — stdlib-only, typed (`ty` + `mypy --strict`), 100% docstrings. `check_freshness(root) -> list[str]` + a `main()` CLI returning 0/1.
- **`.github/workflows/rhiza_gh-aw-validate.yml`** — new always-on step (runs right after checkout, independent of gh-aw availability); fails the job on drift.
- **`.rhiza/make.d/gh-aw.mk`** — `gh-aw-validate` runs the freshness check first.
- **`.rhiza/tests/utils/test_gh_aw_lock_freshness.py`** — 11 unit tests (hash logic, stale/missing/fresh detection, `main()` exit codes, and a regression test that this repo's committed locks are fresh).
- Shipped in the **gh-aw bundle** (`bundles/gh-aw/...`) and the synced `.rhiza/` copies (byte-identical).

## Testing

- `make typecheck` — ty + mypy --strict clean (4 files)
- `make docs-coverage` — 100%
- `make fmt` — all hooks pass (actionlint on the workflow, bandit, interrogate)
- `pytest .rhiza/tests/utils/test_gh_aw_lock_freshness.py tests/bundles/test_bundle_rhiza_sync.py` — 76 passed
- Manually verified the check **detects** a simulated body edit (exit 1, names the file + fix command) and passes when fresh.

## Acceptance criteria (from #1278)

- ✅ CI fails on a PR that edits a `.md` source without committing the regenerated `.lock.yml` (now via an always-on step, not gated on the extension)
- ✅ Passes when source and lock are in sync
- ✅ Names the offending file and the fix command

🤖 Generated with [Claude Code](https://claude.com/claude-code)