### PR TITLE
feat(release): add rhiza_release command and BUMP=major|minor|patch passthrough

### DIFF
--- a/.claude/commands/rhiza_release.md
+++ b/.claude/commands/rhiza_release.md
@@ -1,0 +1,59 @@
+---
+description: Cut a release — preview the version bump, push the tag, and watch the release workflow
+allowed-tools: Bash, Read
+---
+
+Cut a release for this repository. Follow the command-execution policy: always
+prefer `make <target>`; never invoke `.venv/bin/...` directly.
+
+How releasing works here. `make release` delegates to `rhiza-tools release`
+(`.rhiza/make.d/releasing.mk`). It **always bumps** the version, folds a freshly
+generated `CHANGELOG.md` into the version-bump commit (git-cliff pre-commit
+hook), creates a `v*` tag, and pushes it. The tag push triggers the
+`rhiza_release.yml` GitHub Actions workflow (validate → build → SBOM → draft →
+publish → finalize). There is no separate post-tag changelog commit — the tagged
+commit already carries the changelog.
+
+Do the following, in order:
+
+1. **Pre-flight checks.** Confirm the release is safe to cut and stop with a
+   clear explanation if any check fails (do not push a tag from a dirty or
+   behind branch):
+   - Working tree is clean (`git status --porcelain` is empty).
+   - On the default branch (`main`) — or confirm with the user if not.
+   - Local `main` is up to date with `origin/main` (`git fetch` then compare).
+   - `pyproject.toml` exists (the bump is skipped without it).
+
+2. **Preview the bump (dry run).** Run `make release DRY_RUN=1` and show the
+   user the planned new version and tag **before** anything is pushed. The
+   `DRY_RUN=1` flag previews the bump/tag/push without applying them. Summarise
+   what the real run will do (old → new version, tag name).
+
+3. **Confirm.** Unless `$ARGUMENTS` explicitly authorises proceeding (see
+   below), stop here and ask the user to confirm the previewed version before
+   cutting the real release. Pushing a tag triggers a public release workflow —
+   treat it as outward-facing and confirm first.
+
+4. **Cut the release.** Run `make release`. This bumps, commits (with changelog),
+   tags, and pushes. Run it in the foreground so any failure is visible. If it
+   fails, show the relevant output, diagnose the root cause, and stop — do not
+   re-run blindly or hand-craft a tag.
+
+5. **Watch the workflow.** Run `make release-status` to show the release
+   workflow run and the latest release info. If the workflow is still in
+   progress, tell the user it is running and how to re-check
+   (`make release-status`). Report the final release URL once available.
+
+6. **Report.** Tell the user the version that was released, the tag, and the
+   release/workflow URL. If anything is still pending (workflow running, draft
+   not yet published), say so plainly.
+
+`$ARGUMENTS` handling:
+
+- Empty → run the full preview-then-confirm flow above.
+- `dry-run` (or `preview`) → do steps 1–2 only and stop; do **not** cut a real
+  release.
+- `yes` / `confirm` / `--force` → skip the interactive confirmation in step 3
+  and proceed straight through (still run the dry-run preview in step 2 so the
+  user sees what shipped).
+- `status` → skip to step 5 and just report current release/workflow status.

--- a/.claude/commands/rhiza_release.md
+++ b/.claude/commands/rhiza_release.md
@@ -1,5 +1,5 @@
 ---
-description: Cut a release — preview the version bump, push the tag, and watch the release workflow
+description: Cut a release — choose the version bump, push the tag, and watch the release workflow
 allowed-tools: Bash, Read
 ---
 
@@ -14,6 +14,11 @@ hook), creates a `v*` tag, and pushes it. The tag push triggers the
 publish → finalize). There is no separate post-tag changelog commit — the tagged
 commit already carries the changelog.
 
+**The bump type is a user decision.** Run interactively, `make release` prompts
+the user to pick `MAJOR`, `MINOR`, or `PATCH`. Because this command runs in a
+non-interactive shell (where the tool would silently default to `PATCH`), **you
+must ask the user which bump to apply** and pass their choice through explicitly.
+
 Do the following, in order:
 
 1. **Pre-flight checks.** Confirm the release is safe to cut and stop with a
@@ -24,36 +29,51 @@ Do the following, in order:
    - Local `main` is up to date with `origin/main` (`git fetch` then compare).
    - `pyproject.toml` exists (the bump is skipped without it).
 
-2. **Preview the bump (dry run).** Run `make release DRY_RUN=1` and show the
-   user the planned new version and tag **before** anything is pushed. The
-   `DRY_RUN=1` flag previews the bump/tag/push without applying them. Summarise
-   what the real run will do (old → new version, tag name).
+2. **Ask the user for the bump type.** Just like `make release` does
+   interactively, ask the user to choose **MAJOR**, **MINOR**, or **PATCH**
+   (semver: breaking / feature / fix). Skip this question only when
+   `$ARGUMENTS` already names a bump type or authorises a default (see below).
+   Hold the chosen `<bump>` (lowercase: `major` / `minor` / `patch`) for the
+   next steps.
 
-3. **Confirm.** Unless `$ARGUMENTS` explicitly authorises proceeding (see
+3. **Preview the bump (dry run).** Run
+   `uvx "rhiza-tools>=0.7.1" release --bump <bump> --dry-run` — the same tool
+   `make release` wraps — to show the user the planned new version and tag
+   **before** anything is pushed. Summarise what the real run will do
+   (old → new version, tag name).
+
+4. **Confirm.** Unless `$ARGUMENTS` explicitly authorises proceeding (see
    below), stop here and ask the user to confirm the previewed version before
    cutting the real release. Pushing a tag triggers a public release workflow —
    treat it as outward-facing and confirm first.
 
-4. **Cut the release.** Run `make release`. This bumps, commits (with changelog),
-   tags, and pushes. Run it in the foreground so any failure is visible. If it
-   fails, show the relevant output, diagnose the root cause, and stop — do not
-   re-run blindly or hand-craft a tag.
+5. **Cut the release.** Run `uvx "rhiza-tools>=0.7.1" release --bump <bump>`.
+   This bumps, commits (with changelog), tags, and pushes. Run it in the
+   foreground so any failure is visible. If it fails, show the relevant output,
+   diagnose the root cause, and stop — do not re-run blindly or hand-craft a
+   tag.
 
-5. **Watch the workflow.** Run `make release-status` to show the release
+6. **Watch the workflow.** Run `make release-status` to show the release
    workflow run and the latest release info. If the workflow is still in
    progress, tell the user it is running and how to re-check
    (`make release-status`). Report the final release URL once available.
 
-6. **Report.** Tell the user the version that was released, the tag, and the
+7. **Report.** Tell the user the version that was released, the tag, and the
    release/workflow URL. If anything is still pending (workflow running, draft
    not yet published), say so plainly.
 
 `$ARGUMENTS` handling:
 
-- Empty → run the full preview-then-confirm flow above.
-- `dry-run` (or `preview`) → do steps 1–2 only and stop; do **not** cut a real
-  release.
-- `yes` / `confirm` / `--force` → skip the interactive confirmation in step 3
-  and proceed straight through (still run the dry-run preview in step 2 so the
-  user sees what shipped).
-- `status` → skip to step 5 and just report current release/workflow status.
+- Empty → run the full ask-bump → preview → confirm flow above.
+- `major` / `minor` / `patch` → use that as the bump type and skip the question
+  in step 2 (still preview and confirm).
+- `dry-run` (or `preview`) → do steps 1–3 only and stop; do **not** cut a real
+  release. If no bump type is also given, still ask for it in step 2.
+- `yes` / `confirm` / `--force` → skip the interactive confirmation in step 4
+  and proceed straight through (still run the dry-run preview in step 3 so the
+  user sees what shipped). If no bump type is also given, still ask for it in
+  step 2.
+- `status` → skip to step 6 and just report current release/workflow status.
+
+Argument tokens combine, e.g. `minor yes` cuts a minor release without the
+confirmation prompt; `minor dry-run` previews a minor bump only.

--- a/.claude/commands/rhiza_release.md
+++ b/.claude/commands/rhiza_release.md
@@ -17,7 +17,8 @@ commit already carries the changelog.
 **The bump type is a user decision.** Run interactively, `make release` prompts
 the user to pick `MAJOR`, `MINOR`, or `PATCH`. Because this command runs in a
 non-interactive shell (where the tool would silently default to `PATCH`), **you
-must ask the user which bump to apply** and pass their choice through explicitly.
+must ask the user which bump to apply** and pass their choice through with
+`BUMP=major|minor|patch` (supported by both `make release` and `make bump`).
 
 Do the following, in order:
 
@@ -36,22 +37,20 @@ Do the following, in order:
    Hold the chosen `<bump>` (lowercase: `major` / `minor` / `patch`) for the
    next steps.
 
-3. **Preview the bump (dry run).** Run
-   `uvx "rhiza-tools>=0.7.1" release --bump <bump> --dry-run` — the same tool
-   `make release` wraps — to show the user the planned new version and tag
-   **before** anything is pushed. Summarise what the real run will do
-   (old → new version, tag name).
+3. **Preview the bump (dry run).** Run `make release DRY_RUN=1 BUMP=<bump>` to
+   show the user the planned new version and tag **before** anything is pushed.
+   The `DRY_RUN=1` flag previews the bump/tag/push without applying them.
+   Summarise what the real run will do (old → new version, tag name).
 
 4. **Confirm.** Unless `$ARGUMENTS` explicitly authorises proceeding (see
    below), stop here and ask the user to confirm the previewed version before
    cutting the real release. Pushing a tag triggers a public release workflow —
    treat it as outward-facing and confirm first.
 
-5. **Cut the release.** Run `uvx "rhiza-tools>=0.7.1" release --bump <bump>`.
-   This bumps, commits (with changelog), tags, and pushes. Run it in the
-   foreground so any failure is visible. If it fails, show the relevant output,
-   diagnose the root cause, and stop — do not re-run blindly or hand-craft a
-   tag.
+5. **Cut the release.** Run `make release BUMP=<bump>`. This bumps, commits
+   (with changelog), tags, and pushes. Run it in the foreground so any failure
+   is visible. If it fails, show the relevant output, diagnose the root cause,
+   and stop — do not re-run blindly or hand-craft a tag.
 
 6. **Watch the workflow.** Run `make release-status` to show the release
    workflow run and the latest release info. If the workflow is still in

--- a/.rhiza/make.d/releasing.mk
+++ b/.rhiza/make.d/releasing.mk
@@ -12,13 +12,16 @@ post-release:: ; @:
 
 # DRY_RUN support: pass DRY_RUN=1 to preview changes without applying them
 _DRY_RUN_FLAG := $(if $(DRY_RUN),--dry-run,)
+# BUMP support: pass BUMP=major|minor|patch to choose the bump type explicitly
+# (omit BUMP to select the bump type interactively, the default behaviour)
+_BUMP_FLAG := $(if $(BUMP),--bump $(BUMP),)
 _VERSION=0.7.1
 
 ##@ Releasing and Versioning
-bump: pre-bump ## bump version of the project (supports DRY_RUN=1)
+bump: pre-bump ## bump version of the project (supports DRY_RUN=1, BUMP=major|minor|patch)
 	@if [ -f "pyproject.toml" ]; then \
 		$(MAKE) install; \
-		PATH="$(abspath ${VENV})/bin:$$PATH" ${UVX_BIN} "rhiza-tools>=$(_VERSION)" bump $(_DRY_RUN_FLAG); \
+		PATH="$(abspath ${VENV})/bin:$$PATH" ${UVX_BIN} "rhiza-tools>=$(_VERSION)" bump $(_DRY_RUN_FLAG) $(_BUMP_FLAG); \
 		if [ -z "$(DRY_RUN)" ]; then \
 			printf "${BLUE}[INFO] Checking uv.lock file...${RESET}\n"; \
 			${UV_BIN} lock; \
@@ -28,8 +31,8 @@ bump: pre-bump ## bump version of the project (supports DRY_RUN=1)
 	fi
 	@$(MAKE) post-bump
 
-release: pre-release install-uv ## bump version, create tag and push to trigger the release workflow (supports DRY_RUN=1)
-	${UVX_BIN} "rhiza-tools>=$(_VERSION)" release $(_DRY_RUN_FLAG);
+release: pre-release install-uv ## bump version, create tag and push to trigger the release workflow (supports DRY_RUN=1, BUMP=major|minor|patch)
+	${UVX_BIN} "rhiza-tools>=$(_VERSION)" release $(_DRY_RUN_FLAG) $(_BUMP_FLAG);
 	@$(MAKE) post-release
 
 release-status: ## show release workflow status and latest release information

--- a/bundles/core/.rhiza/make.d/releasing.mk
+++ b/bundles/core/.rhiza/make.d/releasing.mk
@@ -12,13 +12,16 @@ post-release:: ; @:
 
 # DRY_RUN support: pass DRY_RUN=1 to preview changes without applying them
 _DRY_RUN_FLAG := $(if $(DRY_RUN),--dry-run,)
+# BUMP support: pass BUMP=major|minor|patch to choose the bump type explicitly
+# (omit BUMP to select the bump type interactively, the default behaviour)
+_BUMP_FLAG := $(if $(BUMP),--bump $(BUMP),)
 _VERSION=0.7.1
 
 ##@ Releasing and Versioning
-bump: pre-bump ## bump version of the project (supports DRY_RUN=1)
+bump: pre-bump ## bump version of the project (supports DRY_RUN=1, BUMP=major|minor|patch)
 	@if [ -f "pyproject.toml" ]; then \
 		$(MAKE) install; \
-		PATH="$(abspath ${VENV})/bin:$$PATH" ${UVX_BIN} "rhiza-tools>=$(_VERSION)" bump $(_DRY_RUN_FLAG); \
+		PATH="$(abspath ${VENV})/bin:$$PATH" ${UVX_BIN} "rhiza-tools>=$(_VERSION)" bump $(_DRY_RUN_FLAG) $(_BUMP_FLAG); \
 		if [ -z "$(DRY_RUN)" ]; then \
 			printf "${BLUE}[INFO] Checking uv.lock file...${RESET}\n"; \
 			${UV_BIN} lock; \
@@ -28,8 +31,8 @@ bump: pre-bump ## bump version of the project (supports DRY_RUN=1)
 	fi
 	@$(MAKE) post-bump
 
-release: pre-release install-uv ## bump version, create tag and push to trigger the release workflow (supports DRY_RUN=1)
-	${UVX_BIN} "rhiza-tools>=$(_VERSION)" release $(_DRY_RUN_FLAG);
+release: pre-release install-uv ## bump version, create tag and push to trigger the release workflow (supports DRY_RUN=1, BUMP=major|minor|patch)
+	${UVX_BIN} "rhiza-tools>=$(_VERSION)" release $(_DRY_RUN_FLAG) $(_BUMP_FLAG);
 	@$(MAKE) post-release
 
 release-status: ## show release workflow status and latest release information


### PR DESCRIPTION
## Summary

Adds a `/rhiza_release` slash command and a `BUMP=` passthrough so the version bump type is an explicit user choice.

- **`/rhiza_release` command** — guides cutting a release: pre-flight checks, asks the user for the bump type (MAJOR/MINOR/PATCH, matching the interactive `make release` prompt), dry-run preview, confirmation gate, the real release, and post-tag workflow watching via `make release-status`.
- **`releasing.mk`** — adds a `BUMP=major|minor|patch` variable to `make release` and `make bump`, mapped to the tool's `--bump` flag. Omitting `BUMP` preserves the existing behaviour (interactive selection, patch default in non-interactive mode), so it is fully backward-compatible. This lets the command stay behind `make` rather than calling `rhiza-tools` directly.

The command follows the repo's command-execution policy (always prefer `make`) and treats the tag push as outward-facing, confirming before triggering the public release workflow.

## Verification

- `make fmt` — all pre-commit hooks pass (README help + Makefile-target checks green).
- `pytest .rhiza/tests/api/test_makefile_targets.py` — 26 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)