### PR TITLE
fix(release): add PUSH=1 passthrough so non-interactive cuts push the tag

### DIFF
--- a/.claude/commands/rhiza_release.md
+++ b/.claude/commands/rhiza_release.md
@@ -47,10 +47,14 @@ Do the following, in order:
    cutting the real release. Pushing a tag triggers a public release workflow —
    treat it as outward-facing and confirm first.
 
-5. **Cut the release.** Run `make release BUMP=<bump>`. This bumps, commits
-   (with changelog), tags, and pushes. Run it in the foreground so any failure
-   is visible. If it fails, show the relevant output, diagnose the root cause,
-   and stop — do not re-run blindly or hand-craft a tag.
+5. **Cut the release.** Run `make release BUMP=<bump> PUSH=1`. This bumps,
+   commits (with changelog), tags, and pushes. The `PUSH=1` flag is **required
+   here**: without it the tool asks an interactive `Push tag to remote? [y/N]`
+   question that this non-interactive shell auto-declines, leaving the bump
+   commit and tag stranded locally (unpushed). Since you already confirmed with
+   the user in step 4, `PUSH=1` pushes straight through. Run it in the
+   foreground so any failure is visible. If it fails, show the relevant output,
+   diagnose the root cause, and stop — do not re-run blindly or hand-craft a tag.
 
 6. **Watch the workflow.** Run `make release-status` to show the release
    workflow run and the latest release info. If the workflow is still in

--- a/.rhiza/make.d/releasing.mk
+++ b/.rhiza/make.d/releasing.mk
@@ -15,6 +15,9 @@ _DRY_RUN_FLAG := $(if $(DRY_RUN),--dry-run,)
 # BUMP support: pass BUMP=major|minor|patch to choose the bump type explicitly
 # (omit BUMP to select the bump type interactively, the default behaviour)
 _BUMP_FLAG := $(if $(BUMP),--bump $(BUMP),)
+# PUSH support: pass PUSH=1 to push the tag without the interactive y/N prompt
+# (omit PUSH to be prompted before the tag is pushed, the default behaviour)
+_PUSH_FLAG := $(if $(PUSH),--push,)
 _VERSION=0.7.1
 
 ##@ Releasing and Versioning
@@ -31,8 +34,8 @@ bump: pre-bump ## bump version of the project (supports DRY_RUN=1, BUMP=major|mi
 	fi
 	@$(MAKE) post-bump
 
-release: pre-release install-uv ## bump version, create tag and push to trigger the release workflow (supports DRY_RUN=1, BUMP=major|minor|patch)
-	${UVX_BIN} "rhiza-tools>=$(_VERSION)" release $(_DRY_RUN_FLAG) $(_BUMP_FLAG);
+release: pre-release install-uv ## bump version, create tag and push to trigger the release workflow (supports DRY_RUN=1, BUMP=major|minor|patch, PUSH=1)
+	${UVX_BIN} "rhiza-tools>=$(_VERSION)" release $(_DRY_RUN_FLAG) $(_BUMP_FLAG) $(_PUSH_FLAG);
 	@$(MAKE) post-release
 
 release-status: ## show release workflow status and latest release information

--- a/bundles/core/.rhiza/make.d/releasing.mk
+++ b/bundles/core/.rhiza/make.d/releasing.mk
@@ -15,6 +15,9 @@ _DRY_RUN_FLAG := $(if $(DRY_RUN),--dry-run,)
 # BUMP support: pass BUMP=major|minor|patch to choose the bump type explicitly
 # (omit BUMP to select the bump type interactively, the default behaviour)
 _BUMP_FLAG := $(if $(BUMP),--bump $(BUMP),)
+# PUSH support: pass PUSH=1 to push the tag without the interactive y/N prompt
+# (omit PUSH to be prompted before the tag is pushed, the default behaviour)
+_PUSH_FLAG := $(if $(PUSH),--push,)
 _VERSION=0.7.1
 
 ##@ Releasing and Versioning
@@ -31,8 +34,8 @@ bump: pre-bump ## bump version of the project (supports DRY_RUN=1, BUMP=major|mi
 	fi
 	@$(MAKE) post-bump
 
-release: pre-release install-uv ## bump version, create tag and push to trigger the release workflow (supports DRY_RUN=1, BUMP=major|minor|patch)
-	${UVX_BIN} "rhiza-tools>=$(_VERSION)" release $(_DRY_RUN_FLAG) $(_BUMP_FLAG);
+release: pre-release install-uv ## bump version, create tag and push to trigger the release workflow (supports DRY_RUN=1, BUMP=major|minor|patch, PUSH=1)
+	${UVX_BIN} "rhiza-tools>=$(_VERSION)" release $(_DRY_RUN_FLAG) $(_BUMP_FLAG) $(_PUSH_FLAG);
 	@$(MAKE) post-release
 
 release-status: ## show release workflow status and latest release information


### PR DESCRIPTION
## Problem

`make release` delegates to `rhiza-tools release`, which asks an interactive `Push tag to remote? [y/N]` question. In a non-interactive shell — e.g. the `/rhiza_release` command running through Claude Code's Bash tool — that prompt defaults to **N** and aborts. The bump commit and `v*` tag are created locally but never pushed, so the release workflow is never triggered. (This happened on the `v0.19.5` cut and had to be pushed by hand.)

## Fix

`rhiza-tools release` already exposes a `--push` flag that pushes without prompting. This PR:

- **`.rhiza/make.d/releasing.mk`** — adds a `PUSH=1` make variable mapping to `--push` (`_PUSH_FLAG`), appended to the `release` recipe, and documents it in the target help. Default behaviour is unchanged: running `make release` interactively still gets the confirmation prompt.
- **`.claude/commands/rhiza_release.md`** — step 5 now runs `make release BUMP=<bump> PUSH=1`, with a note on why the flag is needed (the user already confirms in step 4).

## Verification

- `make release BUMP=patch PUSH=1` → `rhiza-tools release --bump patch --push`
- `make release BUMP=patch` → `rhiza-tools release --bump patch` (prompt preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)