### PR TITLE
docs(quality): refresh stale rhiza_quality prose and harden the skill

### DIFF
--- a/.claude/commands/rhiza_quality.md
+++ b/.claude/commands/rhiza_quality.md
@@ -15,15 +15,22 @@ downstream projects sync their dev infrastructure *from* this repo, so there is 
 Run each of the following, in order:
 
 1. `make fmt` — pre-commit hooks (ruff format/check, markdownlint, bandit, actionlint, jsonschema, uv-lock)
-2. `make typecheck` — static type checking with `ty` (being repointed from `src` to `.rhiza/utils`)
+2. `make typecheck` — static type checking with `ty` and `mypy --strict` over `.rhiza/utils`
 3. `make deptry` — unused/missing dependency check
-4. `make docs-coverage` — docstring coverage (being repointed from `src` to `.rhiza/utils`)
+4. `make docs-coverage` — docstring coverage (interrogate) over `.rhiza/utils`
 5. `make test` — full test suite (runs **without** a coverage gate here, since there is no `src/` to measure with `--cov`)
 6. `make security` — pip-audit + bandit scans
 7. `make rhiza-test` — rhiza's own suite under `.rhiza/tests/` (the templates, Makefile-target, sync, and `.rhiza/utils/` tests that travel downstream), distinct from the root `tests/` suite collected by `make test`
 
 Guidelines:
 
+- Run each gate as a single, bare `make <target>` command — one Bash call per
+  gate. Do **not** pipe (`| tee`, `| tail`), redirect (`2>&1 >`), chain
+  (`make fmt && make typecheck`), or prefix with `cd`. Bare `make <target>`
+  invocations match the allow-listed `Bash(make *)` rule and run without a
+  permission prompt; compound or piped commands do not and will prompt on every
+  gate. Read the full output directly from each call rather than capturing it to
+  a file.
 - Run the gates and let earlier failures inform the later ones, but run all of
   them so the user sees the complete picture rather than stopping at the first
   failure.
@@ -33,12 +40,14 @@ Guidelines:
   to run, or specific files/paths to focus the checks on) and adjust accordingly.
 - End with a concise PASS/FAIL summary per gate.
 
-Expected skips are not failures. While `make typecheck` and `make docs-coverage`
-are being repointed from `src` to `.rhiza/utils`, they may still print a
-`[WARN] Source folder src not found, skipping…` and exit clean; once repointed
-they run against `.rhiza/utils`. `make test` runs without a coverage gate (there
-is no `src/` to measure with `--cov`). Report any of these as **SKIP (by design)**
-— do not score them as failures or gaps.
+Expected skips are not failures. `make typecheck` and `make docs-coverage` run
+against `.rhiza/utils` (the repo has no `src/`) and are expected to **pass** —
+`ty` + `mypy --strict` clean, and interrogate at 100% — so score them as PASS,
+not SKIP. `make test` runs without a coverage gate (there is no `src/` to measure
+with `--cov`) and prints a `[WARN] Source folder src not found, running tests
+without coverage` — that one is **SKIP (by design)** for coverage only, not a
+failure or gap. Likewise treat the lone `src`-absent docstring/sync test skip and
+the conditional workflow-hygiene skips as by-design.
 
 Test depth (replaces line-coverage scoring). Since there is no runtime source,
 there is no line-coverage percentage to hit. Judge the test suite by **behavioural

--- a/bundles/core/.claude/commands/rhiza_quality.md
+++ b/bundles/core/.claude/commands/rhiza_quality.md
@@ -17,6 +17,13 @@ failures surface before the slow test suite — and collect results:
 
 Guidelines:
 
+- Run each gate as a single, bare `make <target>` command — one Bash call per
+  gate. Do **not** pipe (`| tee`, `| tail`), redirect (`2>&1 >`), chain
+  (`make fmt && make typecheck`), or prefix with `cd`. Bare `make <target>`
+  invocations match the allow-listed `Bash(make *)` rule and run without a
+  permission prompt; compound or piped commands do not and will prompt on every
+  gate. Read the full output directly from each call rather than capturing it to
+  a file.
 - Run all gates even after an early failure, so the full picture is visible
   rather than stopping at the first red.
 - If something fails, show the relevant output, diagnose the root cause, and

--- a/tests/bundles/test_bundle_claude_commands_sync.py
+++ b/tests/bundles/test_bundle_claude_commands_sync.py
@@ -55,6 +55,23 @@ _ROOT_COMMANDS = _root_commands()
 class TestBundleClaudeCommandsSync:
     """Verify dogfooded .claude/commands/ files stay in sync with their bundle sources."""
 
+    def test_root_commands_dir_exists_and_is_nonempty(self) -> None:
+        """Root .claude/commands/ must exist and contain at least one command file.
+
+        Without this guard, the parametrized tests below produce zero cases when the
+        directory is absent or empty, making CI appear green while the sync check
+        never actually ran.
+        """
+        commands_dir = _ROOT / ".claude" / "commands"
+        assert commands_dir.is_dir(), (
+            ".claude/commands/ directory is missing — create it or remove this test "
+            "if the mother repo no longer dogfoods Claude Code commands"
+        )
+        assert _ROOT_COMMANDS, (
+            ".claude/commands/ exists but contains no command files — add at least one "
+            "command or remove this test if the mother repo no longer dogfoods commands"
+        )
+
     @pytest.mark.parametrize("root_file", _ROOT_COMMANDS, ids=[p.name for p in _ROOT_COMMANDS])
     def test_dogfooded_command_has_bundle_source(self, root_file: Path) -> None:
         """Every dogfooded command must be shipped by some bundle .claude/commands/."""

--- a/tests/bundles/test_bundle_claude_commands_sync.py
+++ b/tests/bundles/test_bundle_claude_commands_sync.py
@@ -1,0 +1,81 @@
+"""Tests that dogfooded .claude/commands/ files match the bundles that ship them.
+
+Bundles ship Claude Code slash commands under .claude/commands/. The mother repo
+dogfoods a subset of those commands into its own root .claude/commands/ directory.
+Every dogfooded command must be byte-for-byte identical to its bundle source,
+except for the deliberate mother-repo overrides listed in _LOCAL_OVERRIDES — these
+are adapted to this repo's specifics (e.g. no src/, a rhiza-test gate) and are
+documented inside the command file itself.
+
+The root directory is intentionally a *subset* of all bundle commands (e.g.
+rhiza_update is not dogfooded here because the mother repo has no upstream to sync
+from), so the check is driven from the root side: each dogfooded command is matched
+back to the bundle that ships it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+# Root .claude/commands/ files that intentionally diverge from their bundle source.
+# Each is a mother-repo-specific variant documented inside the command file. The
+# byte-comparison test asserts these *do* differ, so a stale entry is caught here.
+_LOCAL_OVERRIDES = frozenset({"rhiza_quality.md"})
+
+
+def _bundle_command_sources() -> dict[str, Path]:
+    """Map each command filename to the bundle .claude/commands/ file that ships it."""
+    sources: dict[str, Path] = {}
+    bundles_dir = _ROOT / "bundles"
+    if not bundles_dir.is_dir():
+        return sources
+    for cmd_file in sorted(bundles_dir.glob("*/.claude/commands/*")):
+        if not cmd_file.is_file() or "__pycache__" in cmd_file.parts:
+            continue
+        sources.setdefault(cmd_file.name, cmd_file)
+    return sources
+
+
+def _root_commands() -> list[Path]:
+    """Return every dogfooded command file under the root .claude/commands/."""
+    commands_dir = _ROOT / ".claude" / "commands"
+    if not commands_dir.is_dir():
+        return []
+    return [p for p in sorted(commands_dir.glob("*")) if p.is_file()]
+
+
+_SOURCES = _bundle_command_sources()
+_ROOT_COMMANDS = _root_commands()
+
+
+class TestBundleClaudeCommandsSync:
+    """Verify dogfooded .claude/commands/ files stay in sync with their bundle sources."""
+
+    @pytest.mark.parametrize("root_file", _ROOT_COMMANDS, ids=[p.name for p in _ROOT_COMMANDS])
+    def test_dogfooded_command_has_bundle_source(self, root_file: Path) -> None:
+        """Every dogfooded command must be shipped by some bundle .claude/commands/."""
+        assert root_file.name in _SOURCES, (
+            f"{root_file.name}: not shipped by any bundle .claude/commands/ — "
+            f"add it to a bundle or remove the dogfooded copy"
+        )
+
+    @pytest.mark.parametrize("root_file", _ROOT_COMMANDS, ids=[p.name for p in _ROOT_COMMANDS])
+    def test_dogfooded_command_matches_bundle(self, root_file: Path) -> None:
+        """Each dogfooded command matches its bundle source, unless a documented override."""
+        source = _SOURCES.get(root_file.name)
+        if source is None:
+            pytest.skip(f"{root_file.name}: no bundle source (covered by the existence test)")
+        if root_file.name in _LOCAL_OVERRIDES:
+            assert root_file.read_bytes() != source.read_bytes(), (
+                f"{root_file.name}: listed in _LOCAL_OVERRIDES but identical to its bundle "
+                f"source — drop it from _LOCAL_OVERRIDES so drift is caught"
+            )
+            return
+        assert root_file.read_bytes() == source.read_bytes(), (
+            f"{root_file.name}: dogfooded copy differs from bundle source "
+            f"{source.relative_to(_ROOT)} — edit both sides or add a documented override"
+        )


### PR DESCRIPTION
Closes #1301.

## What & why

The mother-repo `rhiza_quality` skill still described `make typecheck` and `make docs-coverage` as *"being repointed from `src` to `.rhiza/utils`"* and told the reader to expect a `[WARN] Source folder src not found` **SKIP (by design)**. That is stale: both gates now run against `.rhiza/utils` and **pass** (`ty` + `mypy --strict` clean; interrogate 100%). The old text under-reported the repo and would mislead a scorer into marking passing gates as skips.

## Changes

- **`.claude/commands/rhiza_quality.md`** — step descriptions for typecheck/docs-coverage now say "over `.rhiza/utils`"; the "Expected skips" paragraph is rewritten so those two are scored **PASS**, with only `make test`'s coverage-off WARN and the `src`-absent / workflow-hygiene skips called out as by-design.

Folded in from the same session's work on this skill:
- **Bare-`make` guideline** (root + `bundles/core` copy) — run each gate as a single bare `make <target>` call (no pipes/redirects/chaining/`cd`) so they match the allow-listed `Bash(make *)` rule and stop triggering a permission prompt on every gate.
- **New dogfood test** `tests/bundles/test_bundle_claude_commands_sync.py` — keeps root `.claude/commands/` copies byte-identical to the bundles that ship them, with a documented `_LOCAL_OVERRIDES` set for the intentional mother-repo `rhiza_quality` variant.

## Verification

- `make fmt` — all hooks green (markdownlint included)
- `tests/bundles/test_bundle_claude_commands_sync.py` — 6 passed
- Full `/rhiza_quality` run this session: all 7 gates PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)