### PR TITLE
test(workflow-hygiene): resolve reusable-workflow concurrency skips

### DIFF
--- a/tests/api/test_workflow_hygiene.py
+++ b/tests/api/test_workflow_hygiene.py
@@ -119,10 +119,21 @@ class TestWorkflowConcurrency:
 
     @pytest.mark.parametrize("workflow_file", _WORKFLOWS, ids=_IDS)
     def test_cancel_in_progress_policy(self, workflow_file: Path) -> None:
-        """Release/sync workflows queue; other job-running workflows cancel superseded runs."""
+        """Release/sync workflows queue; other job-running workflows cancel superseded runs.
+
+        Reusable-workflow callers carry no concurrency block of their own (the
+        called workflow owns the policy, and a duplicate caller-level group
+        deadlocks the run), so for them this asserts the block stays absent
+        rather than checking a cancel-in-progress value.
+        """
         workflow = _load(workflow_file)
         if _delegates_to_reusable(workflow):
-            pytest.skip("reusable-workflow caller declares no concurrency block")
+            assert workflow.get("concurrency") is None, (
+                f"{workflow_file.name}: reusable-workflow caller must not declare a "
+                f"top-level 'concurrency' block — it shares the called workflow's "
+                f"cancel-in-progress policy and a duplicate group deadlocks the run"
+            )
+            return
         concurrency = workflow.get("concurrency") or {}
         expected = workflow_file.name not in _QUEUE_WORKFLOWS
         assert concurrency.get("cancel-in-progress") is expected, (


### PR DESCRIPTION
## Summary

`make test` reported 13 skips in `tests/api/test_workflow_hygiene.py::TestWorkflowConcurrency::test_cancel_in_progress_policy` with the reason *"reusable-workflow caller declares no concurrency block"*. This turns those skips into real passing assertions.

## Finding

The 13 flagged workflows are all reusable-workflow **caller stubs** under `bundles/*/.github/workflows/` (e.g. `rhiza_ci.yml`, `rhiza_book.yml`, `rhiza_docker.yml`, ...). Each is a thin stub whose single job does `uses: jebel-quant/rhiza/.github/workflows/<name>.yml@<ref>`.

The test file's own design (and `test_has_concurrency_group`) is explicit: these callers **must NOT** declare a top-level `concurrency:` block. The reusable workflow they invoke already owns the `${{ github.workflow }}-${{ github.ref }}` group, and a duplicate caller-level group with the same key **deadlocks** the run (top-level run and nested job each wait on the other for the shared group).

So adding `concurrency:` blocks to the callers — a literal reading of the issue — would break `test_has_concurrency_group` and introduce a real CI deadlock downstream. The skip was masking an invariant that should instead be asserted.

## Change

`test_cancel_in_progress_policy` now, for reusable-workflow callers, **asserts the concurrency block is absent** rather than skipping — converting all 13 skips into passing assertions. No workflow files are touched, so there is no dogfood-sync risk.

## Verification

- `make test`: **890 passed**, 0 skipped, 0 failed (previously 13 skipped).
- `make fmt`: all hooks pass (actionlint, yaml validation, ruff, etc.).

Closes #1309

🤖 Generated with [Claude Code](https://claude.com/claude-code)