### PR TITLE
fix(deptry): widen scan to .rhiza/utils and .rhiza/tests

### DIFF
--- a/.rhiza/make.d/quality.mk
+++ b/.rhiza/make.d/quality.mk
@@ -13,12 +13,19 @@ all: fmt deptry test docs-coverage security license typecheck rhiza-test ## run 
 # deptry scans one or more folders for dependency issues. Each feature bundle
 # contributes the folders it owns to DEPTRY_FOLDERS (and any per-folder ignores
 # to DEPTRY_IGNORE), so this core target never needs to know which bundles are
-# present. Core itself contributes SOURCE_FOLDER when it exists; see e.g.
-# marimo.mk for a bundle that appends its own folder.
+# present. Core itself contributes SOURCE_FOLDER plus the .rhiza/utils and
+# .rhiza/tests folders it owns when they exist; see e.g. marimo.mk for a bundle
+# that appends its own folder.
 DEPTRY_FOLDERS ?=
 DEPTRY_IGNORE ?=
 ifneq ($(wildcard $(SOURCE_FOLDER)),)
 DEPTRY_FOLDERS += $(SOURCE_FOLDER)
+endif
+ifneq ($(wildcard .rhiza/utils),)
+DEPTRY_FOLDERS += .rhiza/utils
+endif
+ifneq ($(wildcard .rhiza/tests),)
+DEPTRY_FOLDERS += .rhiza/tests
 endif
 
 deptry: install-uv ## Run deptry over the folders contributed by each bundle

--- a/bundles/core/.rhiza/make.d/quality.mk
+++ b/bundles/core/.rhiza/make.d/quality.mk
@@ -13,12 +13,19 @@ all: fmt deptry test docs-coverage security license typecheck rhiza-test ## run 
 # deptry scans one or more folders for dependency issues. Each feature bundle
 # contributes the folders it owns to DEPTRY_FOLDERS (and any per-folder ignores
 # to DEPTRY_IGNORE), so this core target never needs to know which bundles are
-# present. Core itself contributes SOURCE_FOLDER when it exists; see e.g.
-# marimo.mk for a bundle that appends its own folder.
+# present. Core itself contributes SOURCE_FOLDER plus the .rhiza/utils and
+# .rhiza/tests folders it owns when they exist; see e.g. marimo.mk for a bundle
+# that appends its own folder.
 DEPTRY_FOLDERS ?=
 DEPTRY_IGNORE ?=
 ifneq ($(wildcard $(SOURCE_FOLDER)),)
 DEPTRY_FOLDERS += $(SOURCE_FOLDER)
+endif
+ifneq ($(wildcard .rhiza/utils),)
+DEPTRY_FOLDERS += .rhiza/utils
+endif
+ifneq ($(wildcard .rhiza/tests),)
+DEPTRY_FOLDERS += .rhiza/tests
 endif
 
 deptry: install-uv ## Run deptry over the folders contributed by each bundle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ test = [
     "pyyaml>=6.0.1,<7.0",
     "defusedxml>=0.7,<1",
     "mutmut>=3.6,<3.7",
+    "packaging>=24,<26",
 ]
 docs = [
     "marimo>=0.18.0,<1.0",   # Reactive notebook runtime for book/ examples (v0.18+ for streaming, <1.0 for API stability)
@@ -73,6 +74,7 @@ pytest-html = "pytest_html"
 python-dotenv = "dotenv"
 defusedxml = "defusedxml"
 mutmut = "mutmut"
+packaging = "packaging"
 marimo = "marimo"
 numpy = "numpy"
 plotly = "plotly"

--- a/uv.lock
+++ b/uv.lock
@@ -1117,11 +1117,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.2"
+version = "25.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
 ]
 
 [[package]]
@@ -1638,6 +1638,7 @@ test = [
     { name = "defusedxml" },
     { name = "hypothesis" },
     { name = "mutmut" },
+    { name = "packaging" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-html" },
@@ -1666,6 +1667,7 @@ test = [
     { name = "defusedxml", specifier = ">=0.7,<1" },
     { name = "hypothesis", specifier = ">=6,<7" },
     { name = "mutmut", specifier = ">=3.6,<3.7" },
+    { name = "packaging", specifier = ">=24,<26" },
     { name = "pytest", specifier = ">=9,<10" },
     { name = "pytest-cov", specifier = ">=7,<8" },
     { name = "pytest-html", specifier = ">=4,<5" },


### PR DESCRIPTION
## Summary

`make deptry` previously scanned only `docs/notebooks` (1 file), giving near-zero dependency-drift protection. This widens the scan to the real Python surface by also including `.rhiza/utils` and `.rhiza/tests`.

Following the existing accumulator pattern in `quality.mk`, the core bundle now contributes its own `.rhiza/utils` and `.rhiza/tests` folders to `DEPTRY_FOLDERS`, each guarded by a `wildcard` check so the scan only includes folders that exist.

## Real finding fixed

Widening the scope surfaced a genuine dependency issue: `packaging` was imported in `.rhiza/tests/structure/test_pyproject.py` but only available transitively (DEP003). Fixed by adding `packaging>=24,<26` to the `test` dependency group (plus its module-name mapping under `[tool.deptry.package_module_name_map]`) and refreshing `uv.lock`.

## Dogfood sync

`quality.mk` exists as byte-identical copies at `.rhiza/make.d/quality.mk` and `bundles/core/.rhiza/make.d/quality.mk`. Both were edited identically; the sync tests confirm they match.

## Verification

- `make deptry` now reports `Running deptry on: docs/notebooks .rhiza/utils .rhiza/tests` (27 files scanned) and `Success! No dependency issues found.`
- `make test` — 877 passed, 13 skipped, 0 failed (sync tests green).

Closes #1306

🤖 Generated with [Claude Code](https://claude.com/claude-code)