### PR TITLE
test(rhiza-utils): cover last 3 uncovered .rhiza/utils lines

### DIFF
--- a/.rhiza/tests/utils/test_pip_audit_policy.py
+++ b/.rhiza/tests/utils/test_pip_audit_policy.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import runpy
 import sys
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
 from test_utils import strip_ansi
 
 
@@ -126,3 +128,20 @@ def test_main_fails_for_runtime_vulnerabilities_and_warns_for_tooling(root, monk
     output = strip_ansi(capsys.readouterr().out)
     assert "[WARN] setuptools==70.0: PYSEC-2024-2 (tooling — not failing build)" in output
     assert "[FAIL] requests==2.0.0: GHSA-abcd, CVE-2024-5678" in output
+
+
+def test_module_entrypoint_exits_with_main_return_code(root, monkeypatch, capsys):
+    """Running the module as __main__ forwards main()'s return code to sys.exit."""
+    module_path = root / ".rhiza" / "utils" / "pip_audit_policy.py"
+
+    monkeypatch.setattr(sys, "argv", ["pip_audit_policy.py"])
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        runpy.run_path(str(module_path), run_name="__main__")
+
+    assert excinfo.value.code == 0
+    assert "[OK] pip-audit: no vulnerabilities found" in strip_ansi(capsys.readouterr().out)

--- a/.rhiza/tests/utils/test_suppression_audit.py
+++ b/.rhiza/tests/utils/test_suppression_audit.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import runpy
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -225,6 +226,21 @@ def test_collect_suppressions_includes_rhiza_dir_in_framework_repo(root, tmp_pat
     assert len(py_files) == 2
 
 
+def test_collect_suppressions_skips_files_in_skip_dirs(root, tmp_path):
+    """Python files inside skip-listed directories (e.g. tests/) are excluded from the scan."""
+    module = _load_module(root)
+
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "app.py").write_text("a = 1  # noqa: E501\n", encoding="utf-8")
+    (tmp_path / "tests" / "test_app.py").write_text("b = 2  # nosec B101\n", encoding="utf-8")
+
+    py_files, suppressions, _total = module._collect_suppressions(tmp_path)
+
+    scanned = {Path(s.file).name for s in suppressions}
+    assert scanned == {"app.py"}
+    assert {p.name for p in py_files} == {"app.py"}
+
+
 def test_collect_suppressions_skips_rhiza_dir_in_consumer_repo(root, tmp_path):
     """In a consumer repo (template.yml present) the .rhiza/ tree is excluded."""
     module = _load_module(root)
@@ -343,3 +359,18 @@ def test_main_with_stale_gate_returns_one(root, monkeypatch, tmp_path, capsys):
 
     assert module.main(["--fail-stale-nosec-cve"]) == 1
     assert "Stale # nosec CVE suppressions detected:" in strip_ansi(capsys.readouterr().out)
+
+
+def test_module_entrypoint_exits_with_main_return_code(root, monkeypatch, tmp_path, capsys):
+    """Running the module as __main__ forwards main()'s return code to sys.exit."""
+    module_path = root / ".rhiza" / "utils" / "suppression_audit.py"
+
+    (tmp_path / "app.py").write_text("a = 1  # noqa: E501\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "argv", ["suppression_audit.py"])
+
+    with pytest.raises(SystemExit) as excinfo:
+        runpy.run_path(str(module_path), run_name="__main__")
+
+    assert excinfo.value.code == 0
+    assert "Suppression Audit Report" in strip_ansi(capsys.readouterr().out)

--- a/bundles/tests/.rhiza/tests/utils/test_pip_audit_policy.py
+++ b/bundles/tests/.rhiza/tests/utils/test_pip_audit_policy.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import runpy
 import sys
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
 from test_utils import strip_ansi
 
 
@@ -126,3 +128,20 @@ def test_main_fails_for_runtime_vulnerabilities_and_warns_for_tooling(root, monk
     output = strip_ansi(capsys.readouterr().out)
     assert "[WARN] setuptools==70.0: PYSEC-2024-2 (tooling — not failing build)" in output
     assert "[FAIL] requests==2.0.0: GHSA-abcd, CVE-2024-5678" in output
+
+
+def test_module_entrypoint_exits_with_main_return_code(root, monkeypatch, capsys):
+    """Running the module as __main__ forwards main()'s return code to sys.exit."""
+    module_path = root / ".rhiza" / "utils" / "pip_audit_policy.py"
+
+    monkeypatch.setattr(sys, "argv", ["pip_audit_policy.py"])
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        runpy.run_path(str(module_path), run_name="__main__")
+
+    assert excinfo.value.code == 0
+    assert "[OK] pip-audit: no vulnerabilities found" in strip_ansi(capsys.readouterr().out)

--- a/bundles/tests/.rhiza/tests/utils/test_suppression_audit.py
+++ b/bundles/tests/.rhiza/tests/utils/test_suppression_audit.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import runpy
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -225,6 +226,21 @@ def test_collect_suppressions_includes_rhiza_dir_in_framework_repo(root, tmp_pat
     assert len(py_files) == 2
 
 
+def test_collect_suppressions_skips_files_in_skip_dirs(root, tmp_path):
+    """Python files inside skip-listed directories (e.g. tests/) are excluded from the scan."""
+    module = _load_module(root)
+
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "app.py").write_text("a = 1  # noqa: E501\n", encoding="utf-8")
+    (tmp_path / "tests" / "test_app.py").write_text("b = 2  # nosec B101\n", encoding="utf-8")
+
+    py_files, suppressions, _total = module._collect_suppressions(tmp_path)
+
+    scanned = {Path(s.file).name for s in suppressions}
+    assert scanned == {"app.py"}
+    assert {p.name for p in py_files} == {"app.py"}
+
+
 def test_collect_suppressions_skips_rhiza_dir_in_consumer_repo(root, tmp_path):
     """In a consumer repo (template.yml present) the .rhiza/ tree is excluded."""
     module = _load_module(root)
@@ -343,3 +359,18 @@ def test_main_with_stale_gate_returns_one(root, monkeypatch, tmp_path, capsys):
 
     assert module.main(["--fail-stale-nosec-cve"]) == 1
     assert "Stale # nosec CVE suppressions detected:" in strip_ansi(capsys.readouterr().out)
+
+
+def test_module_entrypoint_exits_with_main_return_code(root, monkeypatch, tmp_path, capsys):
+    """Running the module as __main__ forwards main()'s return code to sys.exit."""
+    module_path = root / ".rhiza" / "utils" / "suppression_audit.py"
+
+    (tmp_path / "app.py").write_text("a = 1  # noqa: E501\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "argv", ["suppression_audit.py"])
+
+    with pytest.raises(SystemExit) as excinfo:
+        runpy.run_path(str(module_path), run_name="__main__")
+
+    assert excinfo.value.code == 0
+    assert "Suppression Audit Report" in strip_ansi(capsys.readouterr().out)


### PR DESCRIPTION
## Summary

`make rhiza-test` reported **98.94%** coverage on `.rhiza/utils` (floor 90%) with three lines uncovered. This PR adds targeted tests to reach **100.00%** without touching the coverage floor.

Uncovered lines addressed:
- `.rhiza/utils/pip_audit_policy.py:97` — the `if __name__ == "__main__": sys.exit(main())` entry point
- `.rhiza/utils/suppression_audit.py:282` — `_include` returning `False` for files inside skip-listed dirs
- `.rhiza/utils/suppression_audit.py:427` — the `if __name__ == "__main__": sys.exit(main(...))` entry point

## Tests added (existing style, in `.rhiza/tests/utils/`)

- `test_collect_suppressions_skips_files_in_skip_dirs` — places a `.py` file under `tests/` so `_include` hits the `_should_skip(p) -> return False` branch (line 282).
- `test_module_entrypoint_exits_with_main_return_code` (suppression_audit) — runs the module via `runpy.run_path(..., run_name="__main__")` and asserts `SystemExit(0)` (line 427).
- `test_module_entrypoint_exits_with_main_return_code` (pip_audit_policy) — same approach with `subprocess.run` mocked to a passing pip-audit result (line 97).

All edits are mirrored byte-identically into the `bundles/tests/...` copies so the rhiza-sync dogfood test stays green.

## Verification

`make rhiza-test`:

```
Name                                Stmts   Miss  Cover   Missing
-----------------------------------------------------------------
.rhiza/utils/explain_bundles.py        59      0   100%
.rhiza/utils/pip_audit_policy.py       40      0   100%
.rhiza/utils/suppression_audit.py     184      0   100%
-----------------------------------------------------------------
TOTAL                                 283      0   100%
Required test coverage of 90% reached. Total coverage: 100.00%
```

`make test` — 870 passed, 13 skipped (sync tests green). `make fmt` — all hooks pass.

Closes #1307

🤖 Generated with [Claude Code](https://claude.com/claude-code)