### PR TITLE
refactor(suppression-audit): drop orchestrator's private re-export shim

### DIFF
--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -4,15 +4,13 @@
 
 cd "$SRC"
 
-# Copy the suppression-audit modules into tests/fuzz/ so PyInstaller can discover
-# and bundle them into the frozen binary. Without this, the harness would
-# dynamically load the files from the source tree at runtime, which is absent in
-# the ClusterFuzzLite runner environment where bad_build_check executes the binary.
-# suppression_audit imports its sibling suppression_parse/suppression_report
-# modules, so all three must be present for PyInstaller's static import analysis.
-cp .rhiza/utils/suppression_audit.py tests/fuzz/suppression_audit.py
+# Copy the suppression parser into tests/fuzz/ so PyInstaller can discover and
+# bundle it into the frozen binary. Without this, the harness would dynamically
+# load the file from the source tree at runtime, which is absent in the
+# ClusterFuzzLite runner environment where bad_build_check executes the binary.
+# fuzz_suppression_audit.py imports suppression_parse (which has no sibling
+# imports), so that single module is all PyInstaller needs to analyse.
 cp .rhiza/utils/suppression_parse.py tests/fuzz/suppression_parse.py
-cp .rhiza/utils/suppression_report.py tests/fuzz/suppression_report.py
 
 for fuzzer in tests/fuzz/fuzz_*.py; do
   compile_python_fuzzer "$fuzzer"

--- a/.rhiza/tests/utils/test_suppression_audit.py
+++ b/.rhiza/tests/utils/test_suppression_audit.py
@@ -1,4 +1,4 @@
-"""Unit tests for suppression_audit.py helpers."""
+"""Unit tests for the suppression-audit utility modules."""
 
 from __future__ import annotations
 
@@ -12,16 +12,38 @@ import pytest
 from test_utils import strip_ansi
 
 
-def _load_module(root: Path):
-    """Import the repo's suppression_audit.py utility as a standalone module."""
-    module_path = root / ".rhiza" / "utils" / "suppression_audit.py"
-    spec = importlib.util.spec_from_file_location("suppression_audit", module_path)
-    assert spec is not None
-    assert spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    sys.modules["suppression_audit"] = module
-    spec.loader.exec_module(module)
-    return module
+def _load_modules(root: Path):
+    """Import the three suppression_* utility modules as standalone modules.
+
+    Each module is loaded from its file under ``.rhiza/utils`` and registered in
+    ``sys.modules`` under its own name so their cross-imports resolve to these
+    instances. Tests reference each symbol on the module that owns it:
+    ``parse`` (scanning/parsing), ``report`` (rendering + pip-audit), and
+    ``audit`` (the thin CLI orchestrator).
+
+    Args:
+        root: Repository root containing the ``.rhiza/utils`` directory.
+
+    Returns:
+        A namespace with ``parse``, ``report``, and ``audit`` module objects.
+    """
+    utils_dir = root / ".rhiza" / "utils"
+
+    loaded = {}
+    for name in ("suppression_parse", "suppression_report", "suppression_audit"):
+        spec = importlib.util.spec_from_file_location(name, utils_dir / f"{name}.py")
+        assert spec is not None
+        assert spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[name] = module
+        spec.loader.exec_module(module)
+        loaded[name] = module
+
+    return SimpleNamespace(
+        parse=loaded["suppression_parse"],
+        report=loaded["suppression_report"],
+        audit=loaded["suppression_audit"],
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -31,20 +53,20 @@ def _load_module(root: Path):
 
 def test_nosec_cves_extracts_only_nosec_entries(root):
     """Only # nosec suppressions with CVE tags should be captured."""
-    module = _load_module(root)
+    parse = _load_modules(root).parse
 
     suppressions = [
-        module.Suppression(file="a.py", line_no=1, kind="nosec", raw="# nosec B101 CVE-2024-1234"),
-        module.Suppression(file="b.py", line_no=2, kind="noqa", raw="# noqa: E501 CVE-2024-0001"),
-        module.Suppression(file="c.py", line_no=3, kind="nosec", raw="# nosec B602"),
+        parse.Suppression(file="a.py", line_no=1, kind="nosec", raw="# nosec B101 CVE-2024-1234"),
+        parse.Suppression(file="b.py", line_no=2, kind="noqa", raw="# noqa: E501 CVE-2024-0001"),
+        parse.Suppression(file="c.py", line_no=3, kind="nosec", raw="# nosec B602"),
     ]
 
-    assert module._nosec_cves(suppressions) == {"CVE-2024-1234"}
+    assert parse.nosec_cves(suppressions) == {"CVE-2024-1234"}
 
 
 def test_active_pip_audit_ids_collects_ids_and_aliases(root, monkeypatch):
     """pip-audit JSON IDs and aliases should be normalized and returned."""
-    module = _load_module(root)
+    report = _load_modules(root).report
 
     payload = """
     {
@@ -55,26 +77,26 @@ def test_active_pip_audit_ids_collects_ids_and_aliases(root, monkeypatch):
     """
 
     monkeypatch.setattr(
-        module.subprocess,
+        report.subprocess,
         "run",
         lambda *args, **kwargs: SimpleNamespace(returncode=1, stdout=payload, stderr=""),
     )
 
-    assert module._active_pip_audit_ids([]) == {"PYSEC-1", "CVE-2024-1111"}
+    assert report._active_pip_audit_ids([]) == {"PYSEC-1", "CVE-2024-1111"}
 
 
 def test_active_pip_audit_ids_raises_on_unexpected_returncode(root, monkeypatch, capsys):
     """A return code outside {0, 1} should surface a RuntimeError and echo output."""
-    module = _load_module(root)
+    report = _load_modules(root).report
 
     monkeypatch.setattr(
-        module.subprocess,
+        report.subprocess,
         "run",
         lambda *args, **kwargs: SimpleNamespace(returncode=2, stdout="boom-out", stderr="boom-err"),
     )
 
     with pytest.raises(RuntimeError, match="pip-audit execution failed"):
-        module._active_pip_audit_ids([])
+        report._active_pip_audit_ids([])
 
     captured = capsys.readouterr()
     assert "boom-out" in captured.out
@@ -83,16 +105,16 @@ def test_active_pip_audit_ids_raises_on_unexpected_returncode(root, monkeypatch,
 
 def test_active_pip_audit_ids_raises_on_invalid_json(root, monkeypatch):
     """Non-JSON pip-audit output should raise a descriptive RuntimeError."""
-    module = _load_module(root)
+    report = _load_modules(root).report
 
     monkeypatch.setattr(
-        module.subprocess,
+        report.subprocess,
         "run",
         lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="not-json", stderr=""),
     )
 
     with pytest.raises(RuntimeError, match="did not return valid JSON"):
-        module._active_pip_audit_ids([])
+        report._active_pip_audit_ids([])
 
 
 # ---------------------------------------------------------------------------
@@ -102,27 +124,27 @@ def test_active_pip_audit_ids_raises_on_invalid_json(root, monkeypatch):
 
 def test_should_skip_matches_skip_dirs(root):
     """Paths inside a skip-listed directory should be skipped."""
-    module = _load_module(root)
+    parse = _load_modules(root).parse
 
-    assert module._should_skip(Path(".venv") / "lib" / "mod.py") is True
-    assert module._should_skip(Path("tests") / "test_mod.py") is True
-    assert module._should_skip(Path("src") / "pkg" / "mod.py") is False
+    assert parse._should_skip(Path(".venv") / "lib" / "mod.py") is True
+    assert parse._should_skip(Path("tests") / "test_mod.py") is True
+    assert parse._should_skip(Path("src") / "pkg" / "mod.py") is False
 
 
 def test_is_rhiza_repo_detects_template_marker(root, tmp_path):
     """A project with .rhiza/template.yml is a consumer repo, otherwise the framework repo."""
-    module = _load_module(root)
+    parse = _load_modules(root).parse
 
-    assert module._is_rhiza_repo(tmp_path) is True
+    assert parse._is_rhiza_repo(tmp_path) is True
 
     (tmp_path / ".rhiza").mkdir()
     (tmp_path / ".rhiza" / "template.yml").write_text("upstream: x\n", encoding="utf-8")
-    assert module._is_rhiza_repo(tmp_path) is False
+    assert parse._is_rhiza_repo(tmp_path) is False
 
 
 def test_scan_file_detects_every_suppression_kind(root, tmp_path):
     """scan_file should classify each suppression family and capture its codes."""
-    module = _load_module(root)
+    parse = _load_modules(root).parse
 
     target = tmp_path / "sample.py"
     target.write_text(
@@ -139,43 +161,43 @@ def test_scan_file_detects_every_suppression_kind(root, tmp_path):
         encoding="utf-8",
     )
 
-    found = {sup.kind: sup for sup in module.scan_file(target)}
+    found = {sup.kind: sup for sup in parse.scan_file(target)}
 
     assert found["noqa"].codes == ["E501", "F401"]
     assert found["nosec"].codes == ["B101"]
     assert found["type:ignore"].codes == ["assignment"]
     assert found["no cover"].codes == []
     assert found["noinspection"].codes == ["PyUnresolvedReferences"]
-    assert "just a normal comment" not in {s.raw for s in module.scan_file(target)}
+    assert "just a normal comment" not in {s.raw for s in parse.scan_file(target)}
 
 
 def test_scan_file_returns_empty_for_unreadable_file(root, tmp_path):
     """A missing file should yield no suppressions rather than raising."""
-    module = _load_module(root)
+    parse = _load_modules(root).parse
 
-    assert module.scan_file(tmp_path / "does-not-exist.py") == []
+    assert parse.scan_file(tmp_path / "does-not-exist.py") == []
 
 
 def test_scan_file_swallows_tokenize_errors(root, tmp_path):
     """A file that fails to tokenize should be skipped without raising."""
-    module = _load_module(root)
+    parse = _load_modules(root).parse
 
     broken = tmp_path / "broken.py"
     broken.write_text('x = "unterminated  # noqa: E501\n', encoding="utf-8")
 
     # Should not raise; tokenize errors are caught and the partial result returned.
-    assert isinstance(module.scan_file(broken), list)
+    assert isinstance(parse.scan_file(broken), list)
 
 
 def test_count_non_empty_lines(root, tmp_path):
     """Only lines with non-whitespace content should be counted."""
-    module = _load_module(root)
+    parse = _load_modules(root).parse
 
     target = tmp_path / "lines.py"
     target.write_text("a = 1\n\n   \nb = 2\n", encoding="utf-8")
 
-    assert module.count_non_empty_lines(target) == 2
-    assert module.count_non_empty_lines(tmp_path / "missing.py") == 0
+    assert parse.count_non_empty_lines(target) == 2
+    assert parse.count_non_empty_lines(tmp_path / "missing.py") == 0
 
 
 # ---------------------------------------------------------------------------
@@ -189,18 +211,18 @@ def test_count_non_empty_lines(root, tmp_path):
 )
 def test_compute_grade_thresholds(root, density, expected):
     """Grades should map to the documented density thresholds."""
-    module = _load_module(root)
+    parse = _load_modules(root).parse
 
-    assert module.compute_grade(density) == expected
+    assert parse.compute_grade(density) == expected
 
 
 def test_bar_renders_fixed_width(root):
     """The histogram bar is always _BAR_WIDTH wide, all-empty when max is zero."""
-    module = _load_module(root)
+    report = _load_modules(root).report
 
-    assert module._bar(0, 0) == "░" * module._BAR_WIDTH
-    bar = module._bar(5, 10)
-    assert len(bar) == module._BAR_WIDTH
+    assert report._bar(0, 0) == "░" * report._BAR_WIDTH
+    bar = report._bar(5, 10)
+    assert len(bar) == report._BAR_WIDTH
     assert "█" in bar
     assert "░" in bar
 
@@ -212,13 +234,13 @@ def test_bar_renders_fixed_width(root):
 
 def test_collect_suppressions_includes_rhiza_dir_in_framework_repo(root, tmp_path):
     """In the framework repo (no template.yml) .rhiza/ files are scanned."""
-    module = _load_module(root)
+    parse = _load_modules(root).parse
 
     (tmp_path / ".rhiza" / "utils").mkdir(parents=True)
     (tmp_path / "app.py").write_text("a = 1  # noqa: E501\n", encoding="utf-8")
     (tmp_path / ".rhiza" / "utils" / "helper.py").write_text("b = 2  # nosec B101\n", encoding="utf-8")
 
-    py_files, suppressions, total_lines = module._collect_suppressions(tmp_path)
+    py_files, suppressions, total_lines = parse.collect_suppressions(tmp_path)
 
     scanned = {Path(s.file).name for s in suppressions}
     assert scanned == {"app.py", "helper.py"}
@@ -228,13 +250,13 @@ def test_collect_suppressions_includes_rhiza_dir_in_framework_repo(root, tmp_pat
 
 def test_collect_suppressions_skips_files_in_skip_dirs(root, tmp_path):
     """Python files inside skip-listed directories (e.g. tests/) are excluded from the scan."""
-    module = _load_module(root)
+    parse = _load_modules(root).parse
 
     (tmp_path / "tests").mkdir()
     (tmp_path / "app.py").write_text("a = 1  # noqa: E501\n", encoding="utf-8")
     (tmp_path / "tests" / "test_app.py").write_text("b = 2  # nosec B101\n", encoding="utf-8")
 
-    py_files, suppressions, _total = module._collect_suppressions(tmp_path)
+    py_files, suppressions, _total = parse.collect_suppressions(tmp_path)
 
     scanned = {Path(s.file).name for s in suppressions}
     assert scanned == {"app.py"}
@@ -243,14 +265,14 @@ def test_collect_suppressions_skips_files_in_skip_dirs(root, tmp_path):
 
 def test_collect_suppressions_skips_rhiza_dir_in_consumer_repo(root, tmp_path):
     """In a consumer repo (template.yml present) the .rhiza/ tree is excluded."""
-    module = _load_module(root)
+    parse = _load_modules(root).parse
 
     (tmp_path / ".rhiza").mkdir()
     (tmp_path / ".rhiza" / "template.yml").write_text("upstream: x\n", encoding="utf-8")
     (tmp_path / "app.py").write_text("a = 1  # noqa: E501\n", encoding="utf-8")
     (tmp_path / ".rhiza" / "framework.py").write_text("b = 2  # nosec B101\n", encoding="utf-8")
 
-    _py_files, suppressions, _total = module._collect_suppressions(tmp_path)
+    _py_files, suppressions, _total = parse.collect_suppressions(tmp_path)
 
     scanned = {Path(s.file).name for s in suppressions}
     assert scanned == {"app.py"}
@@ -258,13 +280,13 @@ def test_collect_suppressions_skips_rhiza_dir_in_consumer_repo(root, tmp_path):
 
 def test_print_report_with_suppressions(root, capsys):
     """The report should render details, a histogram, and a grade when suppressions exist."""
-    module = _load_module(root)
+    mods = _load_modules(root)
 
     suppressions = [
-        module.Suppression(file="app.py", line_no=10, kind="noqa", codes=["E501"], raw="# noqa: E501"),
-        module.Suppression(file="app.py", line_no=20, kind="nosec", codes=[], raw="# nosec"),
+        mods.parse.Suppression(file="app.py", line_no=10, kind="noqa", codes=["E501"], raw="# noqa: E501"),
+        mods.parse.Suppression(file="app.py", line_no=20, kind="nosec", codes=[], raw="# nosec"),
     ]
-    module._print_report([Path("app.py")], suppressions, total_lines=100)
+    mods.report.print_report([Path("app.py")], suppressions, total_lines=100)
 
     out = strip_ansi(capsys.readouterr().out)
     assert "Suppression Audit Report" in out
@@ -277,9 +299,9 @@ def test_print_report_with_suppressions(root, capsys):
 
 def test_print_report_without_suppressions(root, capsys):
     """A clean codebase should report no suppressions and an empty histogram."""
-    module = _load_module(root)
+    report = _load_modules(root).report
 
-    module._print_report([Path("app.py")], [], total_lines=0)
+    report.print_report([Path("app.py")], [], total_lines=0)
 
     out = strip_ansi(capsys.readouterr().out)
     assert "No inline suppressions found." in out
@@ -293,71 +315,71 @@ def test_print_report_without_suppressions(root, capsys):
 
 def test_check_stale_nosec_cves_no_suppressions(root, capsys):
     """With no CVE-tagged # nosec comments the check passes without calling pip-audit."""
-    module = _load_module(root)
+    report = _load_modules(root).report
 
-    assert module._check_stale_nosec_cves([], []) == 0
+    assert report.check_stale_nosec_cves([], []) == 0
     assert "No CVE-tagged # nosec suppressions found." in strip_ansi(capsys.readouterr().out)
 
 
 def test_check_stale_nosec_cves_flags_stale(root, monkeypatch, capsys):
     """A suppressed CVE that pip-audit no longer reports is flagged as stale."""
-    module = _load_module(root)
+    mods = _load_modules(root)
 
-    suppressions = [module.Suppression(file="a.py", line_no=1, kind="nosec", raw="# nosec B101 CVE-2024-1234")]
-    monkeypatch.setattr(module, "_active_pip_audit_ids", lambda _args: set())
+    suppressions = [mods.parse.Suppression(file="a.py", line_no=1, kind="nosec", raw="# nosec B101 CVE-2024-1234")]
+    monkeypatch.setattr(mods.report, "_active_pip_audit_ids", lambda _args: set())
 
-    assert module._check_stale_nosec_cves(suppressions, []) == 1
+    assert mods.report.check_stale_nosec_cves(suppressions, []) == 1
     assert "Stale # nosec CVE suppressions detected:" in strip_ansi(capsys.readouterr().out)
 
 
 def test_check_stale_nosec_cves_all_active(root, monkeypatch, capsys):
     """A suppressed CVE that pip-audit still reports is considered current."""
-    module = _load_module(root)
+    mods = _load_modules(root)
 
-    suppressions = [module.Suppression(file="a.py", line_no=1, kind="nosec", raw="# nosec B101 CVE-2024-1234")]
-    monkeypatch.setattr(module, "_active_pip_audit_ids", lambda _args: {"CVE-2024-1234"})
+    suppressions = [mods.parse.Suppression(file="a.py", line_no=1, kind="nosec", raw="# nosec B101 CVE-2024-1234")]
+    monkeypatch.setattr(mods.report, "_active_pip_audit_ids", lambda _args: {"CVE-2024-1234"})
 
-    assert module._check_stale_nosec_cves(suppressions, []) == 0
+    assert mods.report.check_stale_nosec_cves(suppressions, []) == 0
     assert "match active pip-audit findings." in strip_ansi(capsys.readouterr().out)
 
 
 def test_check_stale_nosec_cves_pip_audit_failure(root, monkeypatch, capsys):
     """A pip-audit RuntimeError should surface as exit code 2."""
-    module = _load_module(root)
+    mods = _load_modules(root)
 
-    suppressions = [module.Suppression(file="a.py", line_no=1, kind="nosec", raw="# nosec B101 CVE-2024-1234")]
+    suppressions = [mods.parse.Suppression(file="a.py", line_no=1, kind="nosec", raw="# nosec B101 CVE-2024-1234")]
     # A return code outside {0, 1} makes the real _active_pip_audit_ids raise,
-    # which _check_stale_nosec_cves should translate into exit code 2.
+    # which check_stale_nosec_cves should translate into exit code 2.
     monkeypatch.setattr(
-        module.subprocess,
+        mods.report.subprocess,
         "run",
         lambda *args, **kwargs: SimpleNamespace(returncode=2, stdout="", stderr=""),
     )
 
-    assert module._check_stale_nosec_cves(suppressions, []) == 2
+    assert mods.report.check_stale_nosec_cves(suppressions, []) == 2
     assert "pip-audit execution failed" in strip_ansi(capsys.readouterr().out)
 
 
 def test_main_reports_and_returns_zero(root, monkeypatch, tmp_path, capsys):
     """A plain run scans the working tree, prints the report, and returns 0."""
-    module = _load_module(root)
+    audit = _load_modules(root).audit
 
     (tmp_path / "app.py").write_text("a = 1  # noqa: E501\n", encoding="utf-8")
     monkeypatch.chdir(tmp_path)
 
-    assert module.main([]) == 0
+    assert audit.main([]) == 0
     assert "Suppression Audit Report" in strip_ansi(capsys.readouterr().out)
 
 
 def test_main_with_stale_gate_returns_one(root, monkeypatch, tmp_path, capsys):
     """The --fail-stale-nosec-cve flag fails when a suppressed CVE is no longer active."""
-    module = _load_module(root)
+    mods = _load_modules(root)
 
     (tmp_path / "app.py").write_text("a = 1  # nosec B101 CVE-2024-9999\n", encoding="utf-8")
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(module, "_active_pip_audit_ids", lambda _args: set())
+    monkeypatch.setattr(mods.report, "_active_pip_audit_ids", lambda _args: set())
 
-    assert module.main(["--fail-stale-nosec-cve"]) == 1
+    assert mods.audit.main(["--fail-stale-nosec-cve"]) == 1
     assert "Stale # nosec CVE suppressions detected:" in strip_ansi(capsys.readouterr().out)
 
 

--- a/.rhiza/utils/suppression_audit.py
+++ b/.rhiza/utils/suppression_audit.py
@@ -27,69 +27,10 @@ _UTILS_DIR = str(Path(__file__).resolve().parent)
 if _UTILS_DIR not in sys.path:
     sys.path.insert(0, _UTILS_DIR)
 
-import subprocess  # noqa: E402  # nosec B404  # re-exported for callers/tests
+from suppression_parse import collect_suppressions  # noqa: E402
+from suppression_report import check_stale_nosec_cves, print_report  # noqa: E402
 
-from suppression_parse import (  # noqa: E402
-    SUPPRESSION_PATTERNS,
-    Suppression,
-    _is_rhiza_repo,
-    _should_skip,
-    collect_suppressions,
-    compute_grade,
-    count_non_empty_lines,
-    nosec_cves,
-    scan_file,
-)
-from suppression_report import (  # noqa: E402
-    _BAR_WIDTH,
-    _active_pip_audit_ids,
-    _bar,
-    check_stale_nosec_cves,
-    print_report,
-)
-
-# Backwards-compatible private aliases preserved for existing callers and tests.
-_nosec_cves = nosec_cves
-_collect_suppressions = collect_suppressions
-_print_report = print_report
-
-__all__ = [
-    "SUPPRESSION_PATTERNS",
-    "_BAR_WIDTH",
-    "Suppression",
-    "_active_pip_audit_ids",
-    "_bar",
-    "_is_rhiza_repo",
-    "_should_skip",
-    "collect_suppressions",
-    "compute_grade",
-    "count_non_empty_lines",
-    "main",
-    "nosec_cves",
-    "scan_file",
-    "subprocess",
-]
-
-
-def _check_stale_nosec_cves(suppressions: list[Suppression], pip_audit_args: list[str]) -> int:
-    """Run the stale-CVE gate, resolving active CVEs via this module's reference.
-
-    Thin wrapper over :func:`suppression_report.check_stale_nosec_cves` that
-    injects this module's ``_active_pip_audit_ids``. Because the lookup happens
-    in this namespace at call time, tests can monkeypatch
-    ``_active_pip_audit_ids`` here and have it take effect.
-
-    Args:
-        suppressions: Suppression records to inspect for CVE-tagged ``# nosec``
-            comments.
-        pip_audit_args: Extra arguments forwarded to ``pip-audit``.
-
-    Returns:
-        A process exit code: ``0`` when no stale CVE suppressions are found,
-        ``1`` when stale suppressions are detected, or ``2`` when pip-audit
-        fails to run.
-    """
-    return check_stale_nosec_cves(suppressions, pip_audit_args, active_ids=_active_pip_audit_ids)
+__all__ = ["main"]
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -131,7 +72,7 @@ def main(argv: list[str] | None = None) -> int:
     print_report(py_files, all_suppressions, total_lines)
 
     if args.fail_stale_nosec_cve:
-        return _check_stale_nosec_cves(all_suppressions, pip_audit_args)
+        return check_stale_nosec_cves(all_suppressions, pip_audit_args)
 
     return 0
 

--- a/.rhiza/utils/suppression_report.py
+++ b/.rhiza/utils/suppression_report.py
@@ -18,7 +18,6 @@ import shutil
 import subprocess  # nosec B404
 import sys
 from collections import Counter
-from collections.abc import Callable
 from pathlib import Path
 
 from suppression_parse import Suppression, compute_grade, nosec_cves
@@ -158,34 +157,26 @@ def _active_pip_audit_ids(extra_args: list[str]) -> set[str]:
     return ids
 
 
-def check_stale_nosec_cves(
-    suppressions: list[Suppression],
-    pip_audit_args: list[str],
-    active_ids: Callable[[list[str]], set[str]] | None = None,
-) -> int:
+def check_stale_nosec_cves(suppressions: list[Suppression], pip_audit_args: list[str]) -> int:
     """Validate CVE-tagged # nosec suppressions against active pip-audit findings.
 
     Args:
         suppressions: Suppression records to inspect for CVE-tagged ``# nosec``
             comments.
         pip_audit_args: Extra arguments forwarded to ``pip-audit``.
-        active_ids: Resolver returning the set of CVE identifiers pip-audit
-            currently reports. Defaults to :func:`_active_pip_audit_ids`;
-            injectable so the orchestrator can supply a patchable reference.
 
     Returns:
         A process exit code: ``0`` when no stale CVE suppressions are found,
         ``1`` when stale suppressions are detected, or ``2`` when pip-audit
         fails to run.
     """
-    resolve_active_ids = active_ids if active_ids is not None else _active_pip_audit_ids
     suppressed_cves = nosec_cves(suppressions)
     if not suppressed_cves:
         print(f"{_GREEN}[OK]{_RESET} No CVE-tagged # nosec suppressions found.")
         return 0
 
     try:
-        active_cves = resolve_active_ids(pip_audit_args)
+        active_cves = _active_pip_audit_ids(pip_audit_args)
     except RuntimeError as exc:
         print(f"{_RED}[FAIL]{_RESET} {exc}")
         return 2

--- a/bundles/core/.rhiza/utils/suppression_audit.py
+++ b/bundles/core/.rhiza/utils/suppression_audit.py
@@ -27,69 +27,10 @@ _UTILS_DIR = str(Path(__file__).resolve().parent)
 if _UTILS_DIR not in sys.path:
     sys.path.insert(0, _UTILS_DIR)
 
-import subprocess  # noqa: E402  # nosec B404  # re-exported for callers/tests
+from suppression_parse import collect_suppressions  # noqa: E402
+from suppression_report import check_stale_nosec_cves, print_report  # noqa: E402
 
-from suppression_parse import (  # noqa: E402
-    SUPPRESSION_PATTERNS,
-    Suppression,
-    _is_rhiza_repo,
-    _should_skip,
-    collect_suppressions,
-    compute_grade,
-    count_non_empty_lines,
-    nosec_cves,
-    scan_file,
-)
-from suppression_report import (  # noqa: E402
-    _BAR_WIDTH,
-    _active_pip_audit_ids,
-    _bar,
-    check_stale_nosec_cves,
-    print_report,
-)
-
-# Backwards-compatible private aliases preserved for existing callers and tests.
-_nosec_cves = nosec_cves
-_collect_suppressions = collect_suppressions
-_print_report = print_report
-
-__all__ = [
-    "SUPPRESSION_PATTERNS",
-    "_BAR_WIDTH",
-    "Suppression",
-    "_active_pip_audit_ids",
-    "_bar",
-    "_is_rhiza_repo",
-    "_should_skip",
-    "collect_suppressions",
-    "compute_grade",
-    "count_non_empty_lines",
-    "main",
-    "nosec_cves",
-    "scan_file",
-    "subprocess",
-]
-
-
-def _check_stale_nosec_cves(suppressions: list[Suppression], pip_audit_args: list[str]) -> int:
-    """Run the stale-CVE gate, resolving active CVEs via this module's reference.
-
-    Thin wrapper over :func:`suppression_report.check_stale_nosec_cves` that
-    injects this module's ``_active_pip_audit_ids``. Because the lookup happens
-    in this namespace at call time, tests can monkeypatch
-    ``_active_pip_audit_ids`` here and have it take effect.
-
-    Args:
-        suppressions: Suppression records to inspect for CVE-tagged ``# nosec``
-            comments.
-        pip_audit_args: Extra arguments forwarded to ``pip-audit``.
-
-    Returns:
-        A process exit code: ``0`` when no stale CVE suppressions are found,
-        ``1`` when stale suppressions are detected, or ``2`` when pip-audit
-        fails to run.
-    """
-    return check_stale_nosec_cves(suppressions, pip_audit_args, active_ids=_active_pip_audit_ids)
+__all__ = ["main"]
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -131,7 +72,7 @@ def main(argv: list[str] | None = None) -> int:
     print_report(py_files, all_suppressions, total_lines)
 
     if args.fail_stale_nosec_cve:
-        return _check_stale_nosec_cves(all_suppressions, pip_audit_args)
+        return check_stale_nosec_cves(all_suppressions, pip_audit_args)
 
     return 0
 

--- a/bundles/core/.rhiza/utils/suppression_report.py
+++ b/bundles/core/.rhiza/utils/suppression_report.py
@@ -18,7 +18,6 @@ import shutil
 import subprocess  # nosec B404
 import sys
 from collections import Counter
-from collections.abc import Callable
 from pathlib import Path
 
 from suppression_parse import Suppression, compute_grade, nosec_cves
@@ -158,34 +157,26 @@ def _active_pip_audit_ids(extra_args: list[str]) -> set[str]:
     return ids
 
 
-def check_stale_nosec_cves(
-    suppressions: list[Suppression],
-    pip_audit_args: list[str],
-    active_ids: Callable[[list[str]], set[str]] | None = None,
-) -> int:
+def check_stale_nosec_cves(suppressions: list[Suppression], pip_audit_args: list[str]) -> int:
     """Validate CVE-tagged # nosec suppressions against active pip-audit findings.
 
     Args:
         suppressions: Suppression records to inspect for CVE-tagged ``# nosec``
             comments.
         pip_audit_args: Extra arguments forwarded to ``pip-audit``.
-        active_ids: Resolver returning the set of CVE identifiers pip-audit
-            currently reports. Defaults to :func:`_active_pip_audit_ids`;
-            injectable so the orchestrator can supply a patchable reference.
 
     Returns:
         A process exit code: ``0`` when no stale CVE suppressions are found,
         ``1`` when stale suppressions are detected, or ``2`` when pip-audit
         fails to run.
     """
-    resolve_active_ids = active_ids if active_ids is not None else _active_pip_audit_ids
     suppressed_cves = nosec_cves(suppressions)
     if not suppressed_cves:
         print(f"{_GREEN}[OK]{_RESET} No CVE-tagged # nosec suppressions found.")
         return 0
 
     try:
-        active_cves = resolve_active_ids(pip_audit_args)
+        active_cves = _active_pip_audit_ids(pip_audit_args)
     except RuntimeError as exc:
         print(f"{_RED}[FAIL]{_RESET} {exc}")
         return 2

--- a/bundles/tests/.rhiza/tests/utils/test_suppression_audit.py
+++ b/bundles/tests/.rhiza/tests/utils/test_suppression_audit.py
@@ -1,4 +1,4 @@
-"""Unit tests for suppression_audit.py helpers."""
+"""Unit tests for the suppression-audit utility modules."""
 
 from __future__ import annotations
 
@@ -12,16 +12,38 @@ import pytest
 from test_utils import strip_ansi
 
 
-def _load_module(root: Path):
-    """Import the repo's suppression_audit.py utility as a standalone module."""
-    module_path = root / ".rhiza" / "utils" / "suppression_audit.py"
-    spec = importlib.util.spec_from_file_location("suppression_audit", module_path)
-    assert spec is not None
-    assert spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    sys.modules["suppression_audit"] = module
-    spec.loader.exec_module(module)
-    return module
+def _load_modules(root: Path):
+    """Import the three suppression_* utility modules as standalone modules.
+
+    Each module is loaded from its file under ``.rhiza/utils`` and registered in
+    ``sys.modules`` under its own name so their cross-imports resolve to these
+    instances. Tests reference each symbol on the module that owns it:
+    ``parse`` (scanning/parsing), ``report`` (rendering + pip-audit), and
+    ``audit`` (the thin CLI orchestrator).
+
+    Args:
+        root: Repository root containing the ``.rhiza/utils`` directory.
+
+    Returns:
+        A namespace with ``parse``, ``report``, and ``audit`` module objects.
+    """
+    utils_dir = root / ".rhiza" / "utils"
+
+    loaded = {}
+    for name in ("suppression_parse", "suppression_report", "suppression_audit"):
+        spec = importlib.util.spec_from_file_location(name, utils_dir / f"{name}.py")
+        assert spec is not None
+        assert spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[name] = module
+        spec.loader.exec_module(module)
+        loaded[name] = module
+
+    return SimpleNamespace(
+        parse=loaded["suppression_parse"],
+        report=loaded["suppression_report"],
+        audit=loaded["suppression_audit"],
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -31,20 +53,20 @@ def _load_module(root: Path):
 
 def test_nosec_cves_extracts_only_nosec_entries(root):
     """Only # nosec suppressions with CVE tags should be captured."""
-    module = _load_module(root)
+    parse = _load_modules(root).parse
 
     suppressions = [
-        module.Suppression(file="a.py", line_no=1, kind="nosec", raw="# nosec B101 CVE-2024-1234"),
-        module.Suppression(file="b.py", line_no=2, kind="noqa", raw="# noqa: E501 CVE-2024-0001"),
-        module.Suppression(file="c.py", line_no=3, kind="nosec", raw="# nosec B602"),
+        parse.Suppression(file="a.py", line_no=1, kind="nosec", raw="# nosec B101 CVE-2024-1234"),
+        parse.Suppression(file="b.py", line_no=2, kind="noqa", raw="# noqa: E501 CVE-2024-0001"),
+        parse.Suppression(file="c.py", line_no=3, kind="nosec", raw="# nosec B602"),
     ]
 
-    assert module._nosec_cves(suppressions) == {"CVE-2024-1234"}
+    assert parse.nosec_cves(suppressions) == {"CVE-2024-1234"}
 
 
 def test_active_pip_audit_ids_collects_ids_and_aliases(root, monkeypatch):
     """pip-audit JSON IDs and aliases should be normalized and returned."""
-    module = _load_module(root)
+    report = _load_modules(root).report
 
     payload = """
     {
@@ -55,26 +77,26 @@ def test_active_pip_audit_ids_collects_ids_and_aliases(root, monkeypatch):
     """
 
     monkeypatch.setattr(
-        module.subprocess,
+        report.subprocess,
         "run",
         lambda *args, **kwargs: SimpleNamespace(returncode=1, stdout=payload, stderr=""),
     )
 
-    assert module._active_pip_audit_ids([]) == {"PYSEC-1", "CVE-2024-1111"}
+    assert report._active_pip_audit_ids([]) == {"PYSEC-1", "CVE-2024-1111"}
 
 
 def test_active_pip_audit_ids_raises_on_unexpected_returncode(root, monkeypatch, capsys):
     """A return code outside {0, 1} should surface a RuntimeError and echo output."""
-    module = _load_module(root)
+    report = _load_modules(root).report
 
     monkeypatch.setattr(
-        module.subprocess,
+        report.subprocess,
         "run",
         lambda *args, **kwargs: SimpleNamespace(returncode=2, stdout="boom-out", stderr="boom-err"),
     )
 
     with pytest.raises(RuntimeError, match="pip-audit execution failed"):
-        module._active_pip_audit_ids([])
+        report._active_pip_audit_ids([])
 
     captured = capsys.readouterr()
     assert "boom-out" in captured.out
@@ -83,16 +105,16 @@ def test_active_pip_audit_ids_raises_on_unexpected_returncode(root, monkeypatch,
 
 def test_active_pip_audit_ids_raises_on_invalid_json(root, monkeypatch):
     """Non-JSON pip-audit output should raise a descriptive RuntimeError."""
-    module = _load_module(root)
+    report = _load_modules(root).report
 
     monkeypatch.setattr(
-        module.subprocess,
+        report.subprocess,
         "run",
         lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="not-json", stderr=""),
     )
 
     with pytest.raises(RuntimeError, match="did not return valid JSON"):
-        module._active_pip_audit_ids([])
+        report._active_pip_audit_ids([])
 
 
 # ---------------------------------------------------------------------------
@@ -102,27 +124,27 @@ def test_active_pip_audit_ids_raises_on_invalid_json(root, monkeypatch):
 
 def test_should_skip_matches_skip_dirs(root):
     """Paths inside a skip-listed directory should be skipped."""
-    module = _load_module(root)
+    parse = _load_modules(root).parse
 
-    assert module._should_skip(Path(".venv") / "lib" / "mod.py") is True
-    assert module._should_skip(Path("tests") / "test_mod.py") is True
-    assert module._should_skip(Path("src") / "pkg" / "mod.py") is False
+    assert parse._should_skip(Path(".venv") / "lib" / "mod.py") is True
+    assert parse._should_skip(Path("tests") / "test_mod.py") is True
+    assert parse._should_skip(Path("src") / "pkg" / "mod.py") is False
 
 
 def test_is_rhiza_repo_detects_template_marker(root, tmp_path):
     """A project with .rhiza/template.yml is a consumer repo, otherwise the framework repo."""
-    module = _load_module(root)
+    parse = _load_modules(root).parse
 
-    assert module._is_rhiza_repo(tmp_path) is True
+    assert parse._is_rhiza_repo(tmp_path) is True
 
     (tmp_path / ".rhiza").mkdir()
     (tmp_path / ".rhiza" / "template.yml").write_text("upstream: x\n", encoding="utf-8")
-    assert module._is_rhiza_repo(tmp_path) is False
+    assert parse._is_rhiza_repo(tmp_path) is False
 
 
 def test_scan_file_detects_every_suppression_kind(root, tmp_path):
     """scan_file should classify each suppression family and capture its codes."""
-    module = _load_module(root)
+    parse = _load_modules(root).parse
 
     target = tmp_path / "sample.py"
     target.write_text(
@@ -139,43 +161,43 @@ def test_scan_file_detects_every_suppression_kind(root, tmp_path):
         encoding="utf-8",
     )
 
-    found = {sup.kind: sup for sup in module.scan_file(target)}
+    found = {sup.kind: sup for sup in parse.scan_file(target)}
 
     assert found["noqa"].codes == ["E501", "F401"]
     assert found["nosec"].codes == ["B101"]
     assert found["type:ignore"].codes == ["assignment"]
     assert found["no cover"].codes == []
     assert found["noinspection"].codes == ["PyUnresolvedReferences"]
-    assert "just a normal comment" not in {s.raw for s in module.scan_file(target)}
+    assert "just a normal comment" not in {s.raw for s in parse.scan_file(target)}
 
 
 def test_scan_file_returns_empty_for_unreadable_file(root, tmp_path):
     """A missing file should yield no suppressions rather than raising."""
-    module = _load_module(root)
+    parse = _load_modules(root).parse
 
-    assert module.scan_file(tmp_path / "does-not-exist.py") == []
+    assert parse.scan_file(tmp_path / "does-not-exist.py") == []
 
 
 def test_scan_file_swallows_tokenize_errors(root, tmp_path):
     """A file that fails to tokenize should be skipped without raising."""
-    module = _load_module(root)
+    parse = _load_modules(root).parse
 
     broken = tmp_path / "broken.py"
     broken.write_text('x = "unterminated  # noqa: E501\n', encoding="utf-8")
 
     # Should not raise; tokenize errors are caught and the partial result returned.
-    assert isinstance(module.scan_file(broken), list)
+    assert isinstance(parse.scan_file(broken), list)
 
 
 def test_count_non_empty_lines(root, tmp_path):
     """Only lines with non-whitespace content should be counted."""
-    module = _load_module(root)
+    parse = _load_modules(root).parse
 
     target = tmp_path / "lines.py"
     target.write_text("a = 1\n\n   \nb = 2\n", encoding="utf-8")
 
-    assert module.count_non_empty_lines(target) == 2
-    assert module.count_non_empty_lines(tmp_path / "missing.py") == 0
+    assert parse.count_non_empty_lines(target) == 2
+    assert parse.count_non_empty_lines(tmp_path / "missing.py") == 0
 
 
 # ---------------------------------------------------------------------------
@@ -189,18 +211,18 @@ def test_count_non_empty_lines(root, tmp_path):
 )
 def test_compute_grade_thresholds(root, density, expected):
     """Grades should map to the documented density thresholds."""
-    module = _load_module(root)
+    parse = _load_modules(root).parse
 
-    assert module.compute_grade(density) == expected
+    assert parse.compute_grade(density) == expected
 
 
 def test_bar_renders_fixed_width(root):
     """The histogram bar is always _BAR_WIDTH wide, all-empty when max is zero."""
-    module = _load_module(root)
+    report = _load_modules(root).report
 
-    assert module._bar(0, 0) == "░" * module._BAR_WIDTH
-    bar = module._bar(5, 10)
-    assert len(bar) == module._BAR_WIDTH
+    assert report._bar(0, 0) == "░" * report._BAR_WIDTH
+    bar = report._bar(5, 10)
+    assert len(bar) == report._BAR_WIDTH
     assert "█" in bar
     assert "░" in bar
 
@@ -212,13 +234,13 @@ def test_bar_renders_fixed_width(root):
 
 def test_collect_suppressions_includes_rhiza_dir_in_framework_repo(root, tmp_path):
     """In the framework repo (no template.yml) .rhiza/ files are scanned."""
-    module = _load_module(root)
+    parse = _load_modules(root).parse
 
     (tmp_path / ".rhiza" / "utils").mkdir(parents=True)
     (tmp_path / "app.py").write_text("a = 1  # noqa: E501\n", encoding="utf-8")
     (tmp_path / ".rhiza" / "utils" / "helper.py").write_text("b = 2  # nosec B101\n", encoding="utf-8")
 
-    py_files, suppressions, total_lines = module._collect_suppressions(tmp_path)
+    py_files, suppressions, total_lines = parse.collect_suppressions(tmp_path)
 
     scanned = {Path(s.file).name for s in suppressions}
     assert scanned == {"app.py", "helper.py"}
@@ -228,13 +250,13 @@ def test_collect_suppressions_includes_rhiza_dir_in_framework_repo(root, tmp_pat
 
 def test_collect_suppressions_skips_files_in_skip_dirs(root, tmp_path):
     """Python files inside skip-listed directories (e.g. tests/) are excluded from the scan."""
-    module = _load_module(root)
+    parse = _load_modules(root).parse
 
     (tmp_path / "tests").mkdir()
     (tmp_path / "app.py").write_text("a = 1  # noqa: E501\n", encoding="utf-8")
     (tmp_path / "tests" / "test_app.py").write_text("b = 2  # nosec B101\n", encoding="utf-8")
 
-    py_files, suppressions, _total = module._collect_suppressions(tmp_path)
+    py_files, suppressions, _total = parse.collect_suppressions(tmp_path)
 
     scanned = {Path(s.file).name for s in suppressions}
     assert scanned == {"app.py"}
@@ -243,14 +265,14 @@ def test_collect_suppressions_skips_files_in_skip_dirs(root, tmp_path):
 
 def test_collect_suppressions_skips_rhiza_dir_in_consumer_repo(root, tmp_path):
     """In a consumer repo (template.yml present) the .rhiza/ tree is excluded."""
-    module = _load_module(root)
+    parse = _load_modules(root).parse
 
     (tmp_path / ".rhiza").mkdir()
     (tmp_path / ".rhiza" / "template.yml").write_text("upstream: x\n", encoding="utf-8")
     (tmp_path / "app.py").write_text("a = 1  # noqa: E501\n", encoding="utf-8")
     (tmp_path / ".rhiza" / "framework.py").write_text("b = 2  # nosec B101\n", encoding="utf-8")
 
-    _py_files, suppressions, _total = module._collect_suppressions(tmp_path)
+    _py_files, suppressions, _total = parse.collect_suppressions(tmp_path)
 
     scanned = {Path(s.file).name for s in suppressions}
     assert scanned == {"app.py"}
@@ -258,13 +280,13 @@ def test_collect_suppressions_skips_rhiza_dir_in_consumer_repo(root, tmp_path):
 
 def test_print_report_with_suppressions(root, capsys):
     """The report should render details, a histogram, and a grade when suppressions exist."""
-    module = _load_module(root)
+    mods = _load_modules(root)
 
     suppressions = [
-        module.Suppression(file="app.py", line_no=10, kind="noqa", codes=["E501"], raw="# noqa: E501"),
-        module.Suppression(file="app.py", line_no=20, kind="nosec", codes=[], raw="# nosec"),
+        mods.parse.Suppression(file="app.py", line_no=10, kind="noqa", codes=["E501"], raw="# noqa: E501"),
+        mods.parse.Suppression(file="app.py", line_no=20, kind="nosec", codes=[], raw="# nosec"),
     ]
-    module._print_report([Path("app.py")], suppressions, total_lines=100)
+    mods.report.print_report([Path("app.py")], suppressions, total_lines=100)
 
     out = strip_ansi(capsys.readouterr().out)
     assert "Suppression Audit Report" in out
@@ -277,9 +299,9 @@ def test_print_report_with_suppressions(root, capsys):
 
 def test_print_report_without_suppressions(root, capsys):
     """A clean codebase should report no suppressions and an empty histogram."""
-    module = _load_module(root)
+    report = _load_modules(root).report
 
-    module._print_report([Path("app.py")], [], total_lines=0)
+    report.print_report([Path("app.py")], [], total_lines=0)
 
     out = strip_ansi(capsys.readouterr().out)
     assert "No inline suppressions found." in out
@@ -293,71 +315,71 @@ def test_print_report_without_suppressions(root, capsys):
 
 def test_check_stale_nosec_cves_no_suppressions(root, capsys):
     """With no CVE-tagged # nosec comments the check passes without calling pip-audit."""
-    module = _load_module(root)
+    report = _load_modules(root).report
 
-    assert module._check_stale_nosec_cves([], []) == 0
+    assert report.check_stale_nosec_cves([], []) == 0
     assert "No CVE-tagged # nosec suppressions found." in strip_ansi(capsys.readouterr().out)
 
 
 def test_check_stale_nosec_cves_flags_stale(root, monkeypatch, capsys):
     """A suppressed CVE that pip-audit no longer reports is flagged as stale."""
-    module = _load_module(root)
+    mods = _load_modules(root)
 
-    suppressions = [module.Suppression(file="a.py", line_no=1, kind="nosec", raw="# nosec B101 CVE-2024-1234")]
-    monkeypatch.setattr(module, "_active_pip_audit_ids", lambda _args: set())
+    suppressions = [mods.parse.Suppression(file="a.py", line_no=1, kind="nosec", raw="# nosec B101 CVE-2024-1234")]
+    monkeypatch.setattr(mods.report, "_active_pip_audit_ids", lambda _args: set())
 
-    assert module._check_stale_nosec_cves(suppressions, []) == 1
+    assert mods.report.check_stale_nosec_cves(suppressions, []) == 1
     assert "Stale # nosec CVE suppressions detected:" in strip_ansi(capsys.readouterr().out)
 
 
 def test_check_stale_nosec_cves_all_active(root, monkeypatch, capsys):
     """A suppressed CVE that pip-audit still reports is considered current."""
-    module = _load_module(root)
+    mods = _load_modules(root)
 
-    suppressions = [module.Suppression(file="a.py", line_no=1, kind="nosec", raw="# nosec B101 CVE-2024-1234")]
-    monkeypatch.setattr(module, "_active_pip_audit_ids", lambda _args: {"CVE-2024-1234"})
+    suppressions = [mods.parse.Suppression(file="a.py", line_no=1, kind="nosec", raw="# nosec B101 CVE-2024-1234")]
+    monkeypatch.setattr(mods.report, "_active_pip_audit_ids", lambda _args: {"CVE-2024-1234"})
 
-    assert module._check_stale_nosec_cves(suppressions, []) == 0
+    assert mods.report.check_stale_nosec_cves(suppressions, []) == 0
     assert "match active pip-audit findings." in strip_ansi(capsys.readouterr().out)
 
 
 def test_check_stale_nosec_cves_pip_audit_failure(root, monkeypatch, capsys):
     """A pip-audit RuntimeError should surface as exit code 2."""
-    module = _load_module(root)
+    mods = _load_modules(root)
 
-    suppressions = [module.Suppression(file="a.py", line_no=1, kind="nosec", raw="# nosec B101 CVE-2024-1234")]
+    suppressions = [mods.parse.Suppression(file="a.py", line_no=1, kind="nosec", raw="# nosec B101 CVE-2024-1234")]
     # A return code outside {0, 1} makes the real _active_pip_audit_ids raise,
-    # which _check_stale_nosec_cves should translate into exit code 2.
+    # which check_stale_nosec_cves should translate into exit code 2.
     monkeypatch.setattr(
-        module.subprocess,
+        mods.report.subprocess,
         "run",
         lambda *args, **kwargs: SimpleNamespace(returncode=2, stdout="", stderr=""),
     )
 
-    assert module._check_stale_nosec_cves(suppressions, []) == 2
+    assert mods.report.check_stale_nosec_cves(suppressions, []) == 2
     assert "pip-audit execution failed" in strip_ansi(capsys.readouterr().out)
 
 
 def test_main_reports_and_returns_zero(root, monkeypatch, tmp_path, capsys):
     """A plain run scans the working tree, prints the report, and returns 0."""
-    module = _load_module(root)
+    audit = _load_modules(root).audit
 
     (tmp_path / "app.py").write_text("a = 1  # noqa: E501\n", encoding="utf-8")
     monkeypatch.chdir(tmp_path)
 
-    assert module.main([]) == 0
+    assert audit.main([]) == 0
     assert "Suppression Audit Report" in strip_ansi(capsys.readouterr().out)
 
 
 def test_main_with_stale_gate_returns_one(root, monkeypatch, tmp_path, capsys):
     """The --fail-stale-nosec-cve flag fails when a suppressed CVE is no longer active."""
-    module = _load_module(root)
+    mods = _load_modules(root)
 
     (tmp_path / "app.py").write_text("a = 1  # nosec B101 CVE-2024-9999\n", encoding="utf-8")
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(module, "_active_pip_audit_ids", lambda _args: set())
+    monkeypatch.setattr(mods.report, "_active_pip_audit_ids", lambda _args: set())
 
-    assert module.main(["--fail-stale-nosec-cve"]) == 1
+    assert mods.audit.main(["--fail-stale-nosec-cve"]) == 1
     assert "Stale # nosec CVE suppressions detected:" in strip_ansi(capsys.readouterr().out)
 
 

--- a/tests/api/test_fuzzing_workflow.py
+++ b/tests/api/test_fuzzing_workflow.py
@@ -90,4 +90,4 @@ def test_clusterfuzzlite_configuration_targets_python(root):
 
     assert project["language"] == "python"
     assert "import atheris" in fuzz_target
-    assert "suppression_audit.py" in fuzz_target
+    assert "suppression_parse" in fuzz_target

--- a/tests/fuzz/fuzz_suppression_audit.py
+++ b/tests/fuzz/fuzz_suppression_audit.py
@@ -17,8 +17,8 @@ from pathlib import Path
 import atheris
 
 # When running from the source tree (local development), add .rhiza/utils to
-# sys.path so suppression_audit can be imported without installation.
-# In ClusterFuzzLite, build.sh copies suppression_audit.py into tests/fuzz/
+# sys.path so suppression_parse can be imported without installation.
+# In ClusterFuzzLite, build.sh copies suppression_parse.py into tests/fuzz/
 # before invoking PyInstaller, which allows PyInstaller to discover and bundle
 # it into the frozen binary. At runtime inside the frozen binary, PyInstaller's
 # import system loads the bundled copy regardless of filesystem paths.
@@ -27,7 +27,7 @@ _utils_dir = str(_REPO_ROOT / ".rhiza" / "utils")
 if _utils_dir not in sys.path:
     sys.path.insert(0, _utils_dir)
 
-import suppression_audit  # noqa: E402
+import suppression_parse  # noqa: E402
 
 
 def test_one_input(data: bytes) -> None:
@@ -36,10 +36,10 @@ def test_one_input(data: bytes) -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         candidate = Path(tmpdir) / "candidate.py"
         candidate.write_text(source, encoding="utf-8", errors="replace")
-        suppressions = suppression_audit.scan_file(candidate)
-        suppression_audit.count_non_empty_lines(candidate)
-        suppression_audit._nosec_cves(suppressions)
-        suppression_audit.compute_grade(float(len(suppressions)))
+        suppressions = suppression_parse.scan_file(candidate)
+        suppression_parse.count_non_empty_lines(candidate)
+        suppression_parse.nosec_cves(suppressions)
+        suppression_parse.compute_grade(float(len(suppressions)))
 
 
 def main() -> None:


### PR DESCRIPTION
Closes #1317.

## Problem

After the parse/report split, `suppression_audit.py` re-exported private helpers (`_should_skip`, `_is_rhiza_repo`, `_bar`, `_BAR_WIDTH`, `_active_pip_audit_ids`) and kept backward-compat aliases (`_nosec_cves`, `_collect_suppressions`, `_print_report`, a `_check_stale_nosec_cves` wrapper) **solely so the tests could reach them through the module loaded by path**. It also carried an `active_ids` injection parameter on `check_stale_nosec_cves` purely to make a monkeypatch on the orchestrator take effect — a coupling/readability smell.

## Change

- **Tests** (`.rhiza/tests/utils/test_suppression_audit.py`): a new `_load_modules` loads `parse`/`report`/`audit` and registers them in `sys.modules`; every test references each symbol on its **owning** module and monkeypatches `_active_pip_audit_ids` on `suppression_report` where it actually lives.
- **`suppression_report.py`**: `check_stale_nosec_cves` reverts to a direct `_active_pip_audit_ids` lookup (no injection param, no `Callable` import). The natural dynamic global resolution now serves both the direct call and the `main()` path.
- **`suppression_audit.py`**: shrinks to the CLI orchestrator — `__all__ = ["main"]`, no wrapper, no aliases, no test-only re-exports (22 stmts, down from 28).
- **ClusterFuzzLite**: the harness fuzzes the parser, so `fuzz_suppression_audit.py` now imports `suppression_parse` directly; `build.sh` copies only that module; `test_fuzzing_workflow.py`'s assertion updated to match.

All `.rhiza/` edits mirrored byte-identically into `bundles/core` and `bundles/tests`.

## Verification (local)

- `make rhiza-test` → 187 passed, `.rhiza/utils` at **100%**
- `make typecheck` → `ty` + `mypy --strict` clean (5 files)
- `make test` → **956 passed** (includes sync mirrors + the updated fuzzing-workflow test)
- `make fmt` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)