### PR TITLE
ci: add CI gate roll-up job for branch protection (#1316)

### DIFF
--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -431,3 +431,30 @@ jobs:
           name: LICENSES.md
           path: LICENSES.md
           if-no-files-found: ignore
+
+  ci-gate:
+    name: CI gate
+    # Roll-up gate: a single required status check that aggregates the test and
+    # typecheck matrices. Branch protection requires this context instead of
+    # every per-leg name, so the matrix can change without editing the ruleset.
+    # CI budget: ≤5 min (result aggregation only). Last measured: 2026-06-27.
+    timeout-minutes: 5
+    if: always()
+    needs: [test, typecheck]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Verify test and typecheck succeeded
+        run: |
+          echo "test result:      ${{ needs.test.result }}"
+          echo "typecheck result: ${{ needs.typecheck.result }}"
+          if [[ "${{ needs.test.result }}" != "success" || "${{ needs.typecheck.result }}" != "success" ]]; then
+            echo "::error::test and/or typecheck did not succeed; failing the CI gate."
+            exit 1
+          fi
+          echo "All required matrix jobs succeeded."

--- a/tests/api/test_ci_workflow.py
+++ b/tests/api/test_ci_workflow.py
@@ -71,6 +71,7 @@ def test_ci_jobs_define_timeout_budgets(root):
         "validation": 5,
         "security": 10,
         "license": 10,
+        "ci-gate": 5,
     }
 
     for job_name, timeout in expected.items():


### PR DESCRIPTION
Part of #1316.

## Why

The `main-branch-protection` ruleset requires 6 status checks, but the **`test` matrix and `Type checking` jobs are not required** — so a PR can merge with red tests or type errors. Requiring every matrix leg by name is brittle: the Python matrix is generated dynamically (`generate-matrix`), so a renamed/removed leg would silently block every PR under strict mode.

## What

Adds a single `ci-gate` job to the reusable `rhiza_ci.yml`:

```yaml
ci-gate:
  name: CI gate
  if: always()
  needs: [test, typecheck]
  runs-on: ubuntu-latest
  steps:
    - # harden-runner (audit)
    - name: Verify test and typecheck succeeded
      run: |
        if [[ "${{ needs.test.result }}" != "success" || "${{ needs.typecheck.result }}" != "success" ]]; then
          exit 1
        fi
```

It aggregates the `test` and `typecheck` matrix results into one stable context. `if: always()` ensures it reports even when an upstream leg fails; any non-`success` result (failure/cancelled/skipped) fails the gate.

`tests/api/test_ci_workflow.py` is updated to expect the new job's timeout budget.

> Note: the full `rhiza_ci.yml` lives only at the repo root (the `github-tests` bundle ships a thin stub that *calls* it), so there is no byte-identical bundle mirror to update.

## Follow-up (separate step, after this merges)

Add the **"CI gate"** context to `required_status_checks` in the `main-branch-protection` ruleset. Doing it after this lands avoids blocking PRs on a context that doesn't yet exist on `main`. Once required, the acceptance criterion of #1316 is met: a PR whose `test` or `Type checking` is failing cannot be merged.

## Verification (local)

- `make fmt` → clean (actionlint + workflow validation pass)
- `tests/api/test_ci_workflow.py` + `test_workflow_hygiene.py` → 93 passed
- `make test` → 956 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)