### PR TITLE
ci: gate lowest-deps in the CI roll-up

### DIFF
--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -434,13 +434,14 @@ jobs:
 
   ci-gate:
     name: CI gate
-    # Roll-up gate: a single required status check that aggregates the test and
-    # typecheck matrices. Branch protection requires this context instead of
-    # every per-leg name, so the matrix can change without editing the ruleset.
+    # Roll-up gate: a single required status check that aggregates the test,
+    # typecheck, and lowest-deps jobs. Branch protection requires this context
+    # instead of every per-leg name, so the matrix can change without editing
+    # the ruleset.
     # CI budget: ≤5 min (result aggregation only). Last measured: 2026-06-27.
     timeout-minutes: 5
     if: always()
-    needs: [test, typecheck]
+    needs: [test, typecheck, lowest-deps]
     runs-on: ubuntu-latest
 
     steps:
@@ -449,12 +450,15 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Verify test and typecheck succeeded
+      - name: Verify test, typecheck, and lowest-deps succeeded
         run: |
-          echo "test result:      ${{ needs.test.result }}"
-          echo "typecheck result: ${{ needs.typecheck.result }}"
-          if [[ "${{ needs.test.result }}" != "success" || "${{ needs.typecheck.result }}" != "success" ]]; then
-            echo "::error::test and/or typecheck did not succeed; failing the CI gate."
+          echo "test result:       ${{ needs.test.result }}"
+          echo "typecheck result:  ${{ needs.typecheck.result }}"
+          echo "lowest-deps result: ${{ needs.lowest-deps.result }}"
+          if [[ "${{ needs.test.result }}" != "success" \
+             || "${{ needs.typecheck.result }}" != "success" \
+             || "${{ needs.lowest-deps.result }}" != "success" ]]; then
+            echo "::error::test, typecheck, and/or lowest-deps did not succeed; failing the CI gate."
             exit 1
           fi
-          echo "All required matrix jobs succeeded."
+          echo "All required CI jobs succeeded."


### PR DESCRIPTION
Follow-up to #1316 / PR #1321 — closes the last sub-10 item from the `/rhiza_quality` scorecard (CI/tooling health 9 → 10).

## Why

The `ci-gate` roll-up currently aggregates only `test` + `typecheck`. `Lowest-direct dependency compatibility` (`lowest-deps`) is a correctness-relevant job that still runs **non-blocking** — a lowest-direct dependency break could merge to `main`.

## What

Adds `lowest-deps` to the `ci-gate` job's `needs:` and extends the success check to require `needs.lowest-deps.result == success`. Because **"CI gate"** is already a required status check on `main-branch-protection`, this makes lowest-deps effectively blocking with no ruleset change.

CodeQL is intentionally left non-blocking for now — gating it is a separate security-policy decision, not bundled here.

> The full `rhiza_ci.yml` lives only at the repo root (the `github-tests` bundle ships a thin stub that calls it), so there is no byte-identical bundle mirror to update.

## Verification (local)

- `make fmt` → clean (actionlint validated the gate job)
- `tests/api/test_ci_workflow.py` + `test_workflow_hygiene.py` → 93 passed

## Done when

A PR whose `Lowest-direct dependency compatibility` job fails cannot be merged to `main` (the gate fails), and a fully green PR still merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)