### PR TITLE
test(paper,docker,marimo): add dedicated make-target integration tests

### DIFF
--- a/.rhiza/tests/integration/test_docker_targets.py
+++ b/.rhiza/tests/integration/test_docker_targets.py
@@ -1,0 +1,71 @@
+"""Tests for the Docker Makefile targets and their resilience.
+
+Mirrors test_presentation_targets.py: the docker bundle ships make targets
+(docker-build, docker-run, docker-clean) in .rhiza/make.d/docker.mk, and this
+exercises them end-to-end against a synced repo rather than relying solely on
+static bundle-content checks.
+"""
+
+import shutil
+import subprocess  # nosec
+
+import pytest
+
+MAKE = shutil.which("make") or "/usr/bin/make"
+
+
+@pytest.fixture
+def docker_makefile(git_repo):
+    """Return the docker.mk path or skip tests if missing."""
+    makefile = git_repo / ".rhiza" / "make.d" / "docker.mk"
+    if not makefile.exists():
+        pytest.skip("docker.mk not found, skipping test")
+    return makefile
+
+
+def test_docker_targets_defined(git_repo, docker_makefile):
+    """Docker targets must be defined and parseable even without a docker/ folder.
+
+    docker-build short-circuits when no Dockerfile exists, so a dry-run (-n)
+    verifies make can resolve the targets without invoking the docker CLI.
+    """
+    assert not (git_repo / "docker").exists()
+
+    for target in ["docker-build", "docker-run", "docker-clean"]:
+        result = subprocess.run([MAKE, "-n", target], cwd=git_repo, capture_output=True, text=True)  # nosec
+        assert "no rule to make target" not in result.stderr.lower(), (
+            f"Target {target} should be defined in .rhiza/make.d/docker.mk"
+        )
+        assert result.returncode == 0, f"Dry-run of {target} failed: {result.stderr}"
+
+
+def test_docker_phony_targets(docker_makefile):
+    """docker.mk must declare the expected phony targets."""
+    content = docker_makefile.read_text()
+
+    phony_targets = [line.strip() for line in content.splitlines() if line.startswith(".PHONY:")]
+    assert phony_targets, "expected at least one .PHONY declaration in docker.mk"
+
+    all_targets = set()
+    for phony_line in phony_targets:
+        all_targets.update(phony_line.split(":")[1].strip().split())
+
+    expected_targets = {"docker-build", "docker-run", "docker-clean"}
+    assert expected_targets.issubset(all_targets), (
+        f"Expected phony targets to include {expected_targets}, got {all_targets}"
+    )
+
+
+def test_docker_run_depends_on_build(docker_makefile):
+    """docker-run must depend on docker-build so a run always builds first."""
+    content = docker_makefile.read_text()
+    assert "docker-run: docker-build" in content, "docker-run should declare docker-build as a prerequisite"
+
+
+def test_docker_recipes_drive_docker_cli(docker_makefile):
+    """The recipes must build, run, and remove the configured image via the docker CLI."""
+    content = docker_makefile.read_text()
+    assert "DOCKER_IMAGE_NAME" in content, "docker.mk should expose a configurable DOCKER_IMAGE_NAME"
+    assert "docker buildx build" in content, "docker-build should build via 'docker buildx build'"
+    assert "docker run" in content, "docker-run should launch the container via 'docker run'"
+    assert "docker rmi" in content, "docker-clean should remove the image via 'docker rmi'"

--- a/.rhiza/tests/integration/test_marimo_targets.py
+++ b/.rhiza/tests/integration/test_marimo_targets.py
@@ -1,0 +1,70 @@
+"""Tests for the Marimo notebook Makefile targets and their resilience.
+
+Mirrors test_presentation_targets.py: the marimo bundle ships make targets
+(marimo, marimo-validate) in .rhiza/make.d/marimo.mk, and this exercises them
+end-to-end against a synced repo rather than relying solely on static
+bundle-content checks.
+"""
+
+import shutil
+import subprocess  # nosec
+
+import pytest
+
+MAKE = shutil.which("make") or "/usr/bin/make"
+
+
+@pytest.fixture
+def marimo_makefile(git_repo):
+    """Return the marimo.mk path or skip tests if missing."""
+    makefile = git_repo / ".rhiza" / "make.d" / "marimo.mk"
+    if not makefile.exists():
+        pytest.skip("marimo.mk not found, skipping test")
+    return makefile
+
+
+def test_marimo_targets_defined(git_repo, marimo_makefile):
+    """Marimo targets must be defined and parseable even without a notebook folder.
+
+    Both targets guard internally on MARIMO_FOLDER existing, so a dry-run (-n)
+    verifies make can resolve them (and their 'install' prerequisite) without
+    starting a server or running notebooks.
+    """
+    for target in ["marimo", "marimo-validate"]:
+        result = subprocess.run([MAKE, "-n", target], cwd=git_repo, capture_output=True, text=True)  # nosec
+        assert "no rule to make target" not in result.stderr.lower(), (
+            f"Target {target} should be defined in .rhiza/make.d/marimo.mk"
+        )
+        assert result.returncode == 0, f"Dry-run of {target} failed: {result.stderr}"
+
+
+def test_marimo_phony_targets(marimo_makefile):
+    """marimo.mk must declare the expected phony targets."""
+    content = marimo_makefile.read_text()
+
+    phony_targets = [line.strip() for line in content.splitlines() if line.startswith(".PHONY:")]
+    assert phony_targets, "expected at least one .PHONY declaration in marimo.mk"
+
+    all_targets = set()
+    for phony_line in phony_targets:
+        all_targets.update(phony_line.split(":")[1].strip().split())
+
+    expected_targets = {"marimo", "marimo-validate"}
+    assert expected_targets.issubset(all_targets), (
+        f"Expected phony targets to include {expected_targets}, got {all_targets}"
+    )
+
+
+def test_marimo_targets_depend_on_install(marimo_makefile):
+    """Both targets must depend on 'install' so the venv is ready before use."""
+    content = marimo_makefile.read_text()
+    assert "marimo: install" in content, "marimo should declare 'install' as a prerequisite"
+    assert "marimo-validate: install" in content, "marimo-validate should declare 'install' as a prerequisite"
+
+
+def test_marimo_recipes_drive_marimo_cli(marimo_makefile):
+    """The recipes must launch the Marimo editor and validate notebooks under MARIMO_FOLDER."""
+    content = marimo_makefile.read_text()
+    assert "MARIMO_FOLDER" in content, "marimo.mk should reference the configurable MARIMO_FOLDER"
+    assert "marimo edit" in content, "marimo target should launch the editor via 'marimo edit'"
+    assert "Validating" in content, "marimo-validate should report on notebook validation"

--- a/.rhiza/tests/integration/test_paper_targets.py
+++ b/.rhiza/tests/integration/test_paper_targets.py
@@ -1,0 +1,71 @@
+"""Tests for the LaTeX paper Makefile targets and their resilience.
+
+Mirrors test_presentation_targets.py: the paper bundle ships make targets
+(paper, paper-clean) in .rhiza/make.d/paper.mk, and this exercises them
+end-to-end against a synced repo rather than relying solely on static
+bundle-content checks.
+"""
+
+import shutil
+import subprocess  # nosec
+
+import pytest
+
+MAKE = shutil.which("make") or "/usr/bin/make"
+
+
+@pytest.fixture
+def paper_makefile(git_repo):
+    """Return the paper.mk path or skip tests if missing."""
+    makefile = git_repo / ".rhiza" / "make.d" / "paper.mk"
+    if not makefile.exists():
+        pytest.skip("paper.mk not found, skipping test")
+    return makefile
+
+
+def test_paper_targets_defined(git_repo, paper_makefile):
+    """Paper targets must be defined and parseable even without a docs/paper folder.
+
+    The targets are double-colon rules with no prerequisites, so a dry-run (-n)
+    verifies make can resolve them without invoking latexmk or needing sources.
+    """
+    assert not (git_repo / "docs" / "paper").exists()
+
+    for target in ["paper", "paper-clean"]:
+        result = subprocess.run([MAKE, "-n", target], cwd=git_repo, capture_output=True, text=True)  # nosec
+        assert "no rule to make target" not in result.stderr.lower(), (
+            f"Target {target} should be defined in .rhiza/make.d/paper.mk"
+        )
+        assert result.returncode == 0, f"Dry-run of {target} failed: {result.stderr}"
+
+
+def test_paper_phony_targets(paper_makefile):
+    """paper.mk must declare the expected phony targets."""
+    content = paper_makefile.read_text()
+
+    phony_targets = [line.strip() for line in content.splitlines() if line.startswith(".PHONY:")]
+    assert phony_targets, "expected at least one .PHONY declaration in paper.mk"
+
+    all_targets = set()
+    for phony_line in phony_targets:
+        all_targets.update(phony_line.split(":")[1].strip().split())
+
+    expected_targets = {"paper", "paper-clean"}
+    assert expected_targets.issubset(all_targets), (
+        f"Expected phony targets to include {expected_targets}, got {all_targets}"
+    )
+
+
+def test_paper_double_colon_rules(paper_makefile):
+    """paper.mk must define each target as a '::' rule for hook chaining."""
+    content = paper_makefile.read_text()
+    for target in ["paper", "paper-clean"]:
+        assert f"{target}::" in content, f"paper.mk should define '{target}' as a '::' (double-colon) rule"
+
+
+def test_paper_invokes_latexmk(paper_makefile):
+    """The recipes must drive latexmk against the configured paper directory."""
+    content = paper_makefile.read_text()
+    assert "PAPER_DIR" in content, "paper.mk should expose a configurable PAPER_DIR"
+    assert "latexmk -pdf" in content, "paper target should compile PDFs via latexmk"
+    assert "latexmk -C" in content, "paper-clean target should remove artifacts via 'latexmk -C'"


### PR DESCRIPTION
## Summary

Closes the residual test-depth gap from `/rhiza_quality` (Test depth 9→10): the `paper`, `docker`, and `marimo` bundles shipped make targets that were only covered by the generic 5-name `test_makefile_contains_targets`, never exercised directly.

Mirrors the merged `.rhiza/tests/integration/test_presentation_targets.py` with one file per module, each dry-running (`make -n`) every target against the synced `git_repo` fixture and asserting it resolves (no "no rule to make target"), plus `.PHONY` and recipe-shape checks:

- **`test_paper_targets.py`** — `paper`, `paper-clean` (`::` rules; latexmk against `PAPER_DIR`)
- **`test_docker_targets.py`** — `docker-build`, `docker-run`, `docker-clean` (`docker-run` depends on `docker-build`; `buildx`/`run`/`rmi` via the docker CLI)
- **`test_marimo_targets.py`** — `marimo`, `marimo-validate` (both depend on `install`; `marimo edit` and notebook validation under `MARIMO_FOLDER`)

## Test plan
- `make fmt` — pass (interrogate 100% docstrings on the new files)
- `make rhiza-test` — 203 passed (was 191; +12 new tests), 1 by-design skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)