### PR TITLE
chore(deptry): exclude .rhiza/utils & .rhiza/tests; declare util deps via PEP 723

### DIFF
--- a/.rhiza/make.d/bundles.mk
+++ b/.rhiza/make.d/bundles.mk
@@ -5,4 +5,4 @@
 
 ##@ Bundles
 explain-bundles: ## print all bundles and profiles with descriptions and dependencies
-	@uv run python .rhiza/utils/explain_bundles.py
+	@uv run .rhiza/utils/explain_bundles.py

--- a/.rhiza/make.d/quality.mk
+++ b/.rhiza/make.d/quality.mk
@@ -13,19 +13,16 @@ all: fmt deptry test docs-coverage security license typecheck rhiza-test ## run 
 # deptry scans one or more folders for dependency issues. Each feature bundle
 # contributes the folders it owns to DEPTRY_FOLDERS (and any per-folder ignores
 # to DEPTRY_IGNORE), so this core target never needs to know which bundles are
-# present. Core itself contributes SOURCE_FOLDER plus the .rhiza/utils and
-# .rhiza/tests folders it owns when they exist; see e.g. marimo.mk for a bundle
-# that appends its own folder.
+# present. Core itself contributes SOURCE_FOLDER when it exists; see e.g.
+# marimo.mk for a bundle that appends its own folder. Rhiza's own tooling and
+# test folders (.rhiza/utils, .rhiza/tests) are deliberately excluded: their
+# dependencies are declared inline via PEP 723 script metadata or shipped in
+# .rhiza/requirements/, not in the project's pyproject, so deptry (which
+# validates against pyproject) would only emit noise for them.
 DEPTRY_FOLDERS ?=
 DEPTRY_IGNORE ?=
 ifneq ($(wildcard $(SOURCE_FOLDER)),)
 DEPTRY_FOLDERS += $(SOURCE_FOLDER)
-endif
-ifneq ($(wildcard .rhiza/utils),)
-DEPTRY_FOLDERS += .rhiza/utils
-endif
-ifneq ($(wildcard .rhiza/tests),)
-DEPTRY_FOLDERS += .rhiza/tests
 endif
 
 deptry: install-uv ## Run deptry over the folders contributed by each bundle
@@ -57,7 +54,7 @@ todos: ## search and report all TODO/FIXME/HACK comments in the codebase
 
 suppression-audit: ## scan codebase for inline suppressions and report (grade, detail, histogram)
 	@printf "${BLUE}[INFO] Running suppression audit...${RESET}\n"
-	@${UV_BIN} run python .rhiza/utils/suppression_audit.py
+	@${UV_BIN} run .rhiza/utils/suppression_audit.py
 
 semgrep: install ## run Semgrep static analysis
 	@printf "${BLUE}[INFO] Running Semgrep...${RESET}\n"

--- a/.rhiza/make.d/test.mk
+++ b/.rhiza/make.d/test.mk
@@ -98,7 +98,7 @@ PIP_AUDIT_ARGS ?=
 # 2. Runs bandit to find common security issues in Python source folders that exist.
 security: install ## run security scans (pip-audit and bandit)
 	@printf "${BLUE}[INFO] Running pip-audit for dependency vulnerabilities...${RESET}\n"
-	@${UV_BIN} run python .rhiza/utils/pip_audit_policy.py ${PIP_AUDIT_ARGS}
+	@${UV_BIN} run .rhiza/utils/pip_audit_policy.py ${PIP_AUDIT_ARGS}
 	@bandit_paths=""; \
 	if [ -d "${SOURCE_FOLDER}" ]; then \
 	  bandit_paths="${SOURCE_FOLDER}"; \

--- a/.rhiza/requirements/tests.txt
+++ b/.rhiza/requirements/tests.txt
@@ -8,6 +8,7 @@ pytest-xdist>=3.0
 pytest-timeout>=2.0
 PyYAML>=6.0
 defusedxml>=0.7.0
+packaging>=24
 mutmut>=2.0,<3.0
 
 # For property-based testing

--- a/.rhiza/tests/api/test_makefile_targets.py
+++ b/.rhiza/tests/api/test_makefile_targets.py
@@ -259,8 +259,7 @@ class TestMakefile:
         """Suppression-audit target should invoke the Python audit script via uv run in dry-run output."""
         proc = run_make(logger, ["suppression-audit"])
         out = proc.stdout
-        assert "uv run python" in out
-        assert "suppression_audit.py" in out
+        assert "run .rhiza/utils/suppression_audit.py" in out
 
     def test_license_target_dry_run(self, logger):
         """License target should invoke pip-licenses via uv run --with in dry-run output."""

--- a/.rhiza/utils/explain_bundles.py
+++ b/.rhiza/utils/explain_bundles.py
@@ -1,3 +1,7 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["pyyaml"]
+# ///
 """Print all Rhiza bundles and profiles with descriptions and dependencies.
 
 Run as a script from a project root that contains ``.rhiza/template-bundles.yml``.

--- a/.rhiza/utils/pip_audit_policy.py
+++ b/.rhiza/utils/pip_audit_policy.py
@@ -1,3 +1,7 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+# ///
 """Run pip-audit with a tiered vulnerability policy.
 
 Fails the build for vulnerabilities in runtime dependencies.

--- a/.rhiza/utils/suppression_audit.py
+++ b/.rhiza/utils/suppression_audit.py
@@ -1,3 +1,7 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+# ///
 """Suppression audit: scan codebase for inline suppressions of security, coverage, docs, and linting.
 
 Detects and reports on inline suppression comments such as:

--- a/.rhiza/utils/suppression_parse.py
+++ b/.rhiza/utils/suppression_parse.py
@@ -1,3 +1,7 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+# ///
 """Parsing layer for the suppression audit: scan source for inline suppressions.
 
 This module owns the *parsing* concerns of the suppression audit:

--- a/.rhiza/utils/suppression_report.py
+++ b/.rhiza/utils/suppression_report.py
@@ -1,3 +1,7 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+# ///
 """Reporting layer for the suppression audit: render output and run pip-audit.
 
 This module owns the *reporting* and *output* concerns of the suppression audit:

--- a/bundles/core/.rhiza/make.d/quality.mk
+++ b/bundles/core/.rhiza/make.d/quality.mk
@@ -13,19 +13,16 @@ all: fmt deptry test docs-coverage security license typecheck rhiza-test ## run 
 # deptry scans one or more folders for dependency issues. Each feature bundle
 # contributes the folders it owns to DEPTRY_FOLDERS (and any per-folder ignores
 # to DEPTRY_IGNORE), so this core target never needs to know which bundles are
-# present. Core itself contributes SOURCE_FOLDER plus the .rhiza/utils and
-# .rhiza/tests folders it owns when they exist; see e.g. marimo.mk for a bundle
-# that appends its own folder.
+# present. Core itself contributes SOURCE_FOLDER when it exists; see e.g.
+# marimo.mk for a bundle that appends its own folder. Rhiza's own tooling and
+# test folders (.rhiza/utils, .rhiza/tests) are deliberately excluded: their
+# dependencies are declared inline via PEP 723 script metadata or shipped in
+# .rhiza/requirements/, not in the project's pyproject, so deptry (which
+# validates against pyproject) would only emit noise for them.
 DEPTRY_FOLDERS ?=
 DEPTRY_IGNORE ?=
 ifneq ($(wildcard $(SOURCE_FOLDER)),)
 DEPTRY_FOLDERS += $(SOURCE_FOLDER)
-endif
-ifneq ($(wildcard .rhiza/utils),)
-DEPTRY_FOLDERS += .rhiza/utils
-endif
-ifneq ($(wildcard .rhiza/tests),)
-DEPTRY_FOLDERS += .rhiza/tests
 endif
 
 deptry: install-uv ## Run deptry over the folders contributed by each bundle
@@ -57,7 +54,7 @@ todos: ## search and report all TODO/FIXME/HACK comments in the codebase
 
 suppression-audit: ## scan codebase for inline suppressions and report (grade, detail, histogram)
 	@printf "${BLUE}[INFO] Running suppression audit...${RESET}\n"
-	@${UV_BIN} run python .rhiza/utils/suppression_audit.py
+	@${UV_BIN} run .rhiza/utils/suppression_audit.py
 
 semgrep: install ## run Semgrep static analysis
 	@printf "${BLUE}[INFO] Running Semgrep...${RESET}\n"

--- a/bundles/core/.rhiza/utils/pip_audit_policy.py
+++ b/bundles/core/.rhiza/utils/pip_audit_policy.py
@@ -1,3 +1,7 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+# ///
 """Run pip-audit with a tiered vulnerability policy.
 
 Fails the build for vulnerabilities in runtime dependencies.

--- a/bundles/core/.rhiza/utils/suppression_audit.py
+++ b/bundles/core/.rhiza/utils/suppression_audit.py
@@ -1,3 +1,7 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+# ///
 """Suppression audit: scan codebase for inline suppressions of security, coverage, docs, and linting.
 
 Detects and reports on inline suppression comments such as:

--- a/bundles/core/.rhiza/utils/suppression_parse.py
+++ b/bundles/core/.rhiza/utils/suppression_parse.py
@@ -1,3 +1,7 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+# ///
 """Parsing layer for the suppression audit: scan source for inline suppressions.
 
 This module owns the *parsing* concerns of the suppression audit:

--- a/bundles/core/.rhiza/utils/suppression_report.py
+++ b/bundles/core/.rhiza/utils/suppression_report.py
@@ -1,3 +1,7 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+# ///
 """Reporting layer for the suppression audit: render output and run pip-audit.
 
 This module owns the *reporting* and *output* concerns of the suppression audit:

--- a/bundles/tests/.rhiza/make.d/test.mk
+++ b/bundles/tests/.rhiza/make.d/test.mk
@@ -98,7 +98,7 @@ PIP_AUDIT_ARGS ?=
 # 2. Runs bandit to find common security issues in Python source folders that exist.
 security: install ## run security scans (pip-audit and bandit)
 	@printf "${BLUE}[INFO] Running pip-audit for dependency vulnerabilities...${RESET}\n"
-	@${UV_BIN} run python .rhiza/utils/pip_audit_policy.py ${PIP_AUDIT_ARGS}
+	@${UV_BIN} run .rhiza/utils/pip_audit_policy.py ${PIP_AUDIT_ARGS}
 	@bandit_paths=""; \
 	if [ -d "${SOURCE_FOLDER}" ]; then \
 	  bandit_paths="${SOURCE_FOLDER}"; \

--- a/bundles/tests/.rhiza/requirements/tests.txt
+++ b/bundles/tests/.rhiza/requirements/tests.txt
@@ -8,6 +8,7 @@ pytest-xdist>=3.0
 pytest-timeout>=2.0
 PyYAML>=6.0
 defusedxml>=0.7.0
+packaging>=24
 mutmut>=2.0,<3.0
 
 # For property-based testing

--- a/bundles/tests/.rhiza/tests/api/test_makefile_targets.py
+++ b/bundles/tests/.rhiza/tests/api/test_makefile_targets.py
@@ -259,8 +259,7 @@ class TestMakefile:
         """Suppression-audit target should invoke the Python audit script via uv run in dry-run output."""
         proc = run_make(logger, ["suppression-audit"])
         out = proc.stdout
-        assert "uv run python" in out
-        assert "suppression_audit.py" in out
+        assert "run .rhiza/utils/suppression_audit.py" in out
 
     def test_license_target_dry_run(self, logger):
         """License target should invoke pip-licenses via uv run --with in dry-run output."""


### PR DESCRIPTION
## Why

`make deptry` validates imports against the project's `pyproject.toml`, but Rhiza's own tooling (`.rhiza/utils`) and tests (`.rhiza/tests`) carry their dependencies elsewhere — so scanning them only produced false positives. Concretely, `explain_bundles.py` was flagged with `DEP004 'yaml' imported but declared as a dev dependency`.

This applies the principle consistently: deptry only validates the project's own source; Rhiza's shipped tooling/tests declare their own dependencies.

## What

- **PEP 723 headers** on all 5 `.rhiza/utils` scripts (`requires-python = ">=3.12"`; `explain_bundles.py` declares `pyyaml`, the rest declare none). Make targets switched to `uv run X.py` (no `python`) so the inline metadata is honored — `bundles.mk` (explain-bundles), `quality.mk` (suppression-audit), `test.mk` (security).
- **Dropped `.rhiza/utils` and `.rhiza/tests`** from `DEPTRY_FOLDERS`; deptry now scans only bundle-contributed project source.
- **Added `packaging>=24`** to `.rhiza/requirements/tests.txt` (imported by `.rhiza/tests/conftest.py` and `test_pyproject.py`).
- All `bundles/` sources kept **byte-identical** with their root `.rhiza/` copies; updated the suppression-audit invocation assertion.

## Verification

- `make deptry` → scans only `docs/notebooks` (marimo), no issues.
- `make explain-bundles` / `make suppression-audit` run correctly through the isolated `uv run` path.
- 114 tests pass (bundle-sync + make-target + variable-override); ruff clean; pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)