### PR TITLE
Test benchmark + devcontainer bundles; stop install dependency churn

### DIFF
--- a/.rhiza/make.d/bootstrap.mk
+++ b/.rhiza/make.d/bootstrap.mk
@@ -37,7 +37,9 @@ install: pre-install install-uv ## install
 	  printf "${BLUE}[INFO] Using existing virtual environment at ${VENV}, skipping creation${RESET}\n"; \
 	fi
 
-	# Install the dependencies from pyproject.toml (if it exists)
+	# Install the dependencies from pyproject.toml (if it exists).
+	# --inexact keeps dev tools from .rhiza/requirements/*.txt (installed below) instead of pruning them each run,
+	# so repeated 'make' targets no longer uninstall and reinstall the whole tool set on every invocation.
 	@if [ -f "pyproject.toml" ]; then \
 	  if [ -f "uv.lock" ]; then \
 	    if ! ${UV_BIN} lock --check >/dev/null 2>&1; then \
@@ -47,10 +49,10 @@ install: pre-install install-uv ## install
 	      exit 1; \
 	    fi; \
 	    printf "${BLUE}[INFO] Installing dependencies from lock file${RESET}\n"; \
-	    ${UV_BIN} sync $(UV_SYNC_ARGS) --frozen || { printf "${RED}[ERROR] Failed to install dependencies${RESET}\n"; exit 1; }; \
+	    ${UV_BIN} sync $(UV_SYNC_ARGS) --inexact --frozen || { printf "${RED}[ERROR] Failed to install dependencies${RESET}\n"; exit 1; }; \
 	  else \
 	    printf "${YELLOW}[WARN] uv.lock not found. Generating lock file and installing dependencies...${RESET}\n"; \
-	    ${UV_BIN} sync $(UV_SYNC_ARGS) || { printf "${RED}[ERROR] Failed to install dependencies${RESET}\n"; exit 1; }; \
+	    ${UV_BIN} sync $(UV_SYNC_ARGS) --inexact || { printf "${RED}[ERROR] Failed to install dependencies${RESET}\n"; exit 1; }; \
 	  fi; \
 	else \
 	  printf "${YELLOW}[WARN] No pyproject.toml found, skipping install${RESET}\n"; \

--- a/.rhiza/tests/integration/test_benchmark_targets.py
+++ b/.rhiza/tests/integration/test_benchmark_targets.py
@@ -1,0 +1,66 @@
+"""Tests for the benchmark Makefile target and its resilience.
+
+Mirrors test_marimo_targets.py: the tests bundle ships the ``benchmark`` target
+in .rhiza/make.d/test.mk (and the benchmarks bundle ships the pytest-benchmark
+suite that target runs), so this exercises the target end-to-end against a synced
+repo rather than relying solely on static bundle-content checks.
+"""
+
+import shutil
+import subprocess  # nosec
+
+import pytest
+
+MAKE = shutil.which("make") or "/usr/bin/make"
+
+
+@pytest.fixture
+def test_makefile(git_repo):
+    """Return the test.mk path (home of the benchmark target) or skip if missing."""
+    makefile = git_repo / ".rhiza" / "make.d" / "test.mk"
+    if not makefile.exists():
+        pytest.skip("test.mk not found, skipping test")
+    return makefile
+
+
+def test_benchmark_target_defined(git_repo, test_makefile):
+    """The benchmark target must be defined and dry-run cleanly.
+
+    The recipe guards internally on ${TESTS_FOLDER}/benchmarks existing, so a
+    dry-run (-n) verifies make can resolve the target (and its 'install'
+    prerequisite) without installing pytest-benchmark or running benchmarks.
+    """
+    result = subprocess.run([MAKE, "-n", "benchmark"], cwd=git_repo, capture_output=True, text=True)  # nosec
+    assert "no rule to make target" not in result.stderr.lower(), (
+        "Target benchmark should be defined in .rhiza/make.d/test.mk"
+    )
+    assert result.returncode == 0, f"Dry-run of benchmark failed: {result.stderr}"
+
+
+def test_benchmark_is_phony(test_makefile):
+    """test.mk must declare benchmark as a .PHONY target."""
+    content = test_makefile.read_text()
+
+    phony_targets = set()
+    for line in content.splitlines():
+        if line.startswith(".PHONY:"):
+            phony_targets.update(line.split(":", 1)[1].strip().split())
+
+    assert "benchmark" in phony_targets, f"benchmark should be declared .PHONY, got {phony_targets}"
+
+
+def test_benchmark_depends_on_install(test_makefile):
+    """The benchmark target must depend on 'install' so the venv is ready before use."""
+    content = test_makefile.read_text()
+    assert "benchmark:: install" in content, "benchmark should declare 'install' as a prerequisite"
+
+
+def test_benchmark_recipe_drives_pytest_benchmark(test_makefile):
+    """The recipe must guard on the benchmarks folder and drive pytest-benchmark + reporting."""
+    content = test_makefile.read_text()
+    assert "${TESTS_FOLDER}/benchmarks" in content, (
+        "benchmark recipe should guard on the configurable benchmarks folder existing"
+    )
+    assert "--benchmark-only" in content, "benchmark recipe should run pytest in --benchmark-only mode"
+    assert "--benchmark-json" in content, "benchmark recipe should emit a JSON results file for reporting"
+    assert "analyze-benchmarks" in content, "benchmark recipe should render a report via analyze-benchmarks"

--- a/bundles/core/.rhiza/make.d/bootstrap.mk
+++ b/bundles/core/.rhiza/make.d/bootstrap.mk
@@ -37,7 +37,9 @@ install: pre-install install-uv ## install
 	  printf "${BLUE}[INFO] Using existing virtual environment at ${VENV}, skipping creation${RESET}\n"; \
 	fi
 
-	# Install the dependencies from pyproject.toml (if it exists)
+	# Install the dependencies from pyproject.toml (if it exists).
+	# --inexact keeps dev tools from .rhiza/requirements/*.txt (installed below) instead of pruning them each run,
+	# so repeated 'make' targets no longer uninstall and reinstall the whole tool set on every invocation.
 	@if [ -f "pyproject.toml" ]; then \
 	  if [ -f "uv.lock" ]; then \
 	    if ! ${UV_BIN} lock --check >/dev/null 2>&1; then \
@@ -47,10 +49,10 @@ install: pre-install install-uv ## install
 	      exit 1; \
 	    fi; \
 	    printf "${BLUE}[INFO] Installing dependencies from lock file${RESET}\n"; \
-	    ${UV_BIN} sync $(UV_SYNC_ARGS) --frozen || { printf "${RED}[ERROR] Failed to install dependencies${RESET}\n"; exit 1; }; \
+	    ${UV_BIN} sync $(UV_SYNC_ARGS) --inexact --frozen || { printf "${RED}[ERROR] Failed to install dependencies${RESET}\n"; exit 1; }; \
 	  else \
 	    printf "${YELLOW}[WARN] uv.lock not found. Generating lock file and installing dependencies...${RESET}\n"; \
-	    ${UV_BIN} sync $(UV_SYNC_ARGS) || { printf "${RED}[ERROR] Failed to install dependencies${RESET}\n"; exit 1; }; \
+	    ${UV_BIN} sync $(UV_SYNC_ARGS) --inexact || { printf "${RED}[ERROR] Failed to install dependencies${RESET}\n"; exit 1; }; \
 	  fi; \
 	else \
 	  printf "${YELLOW}[WARN] No pyproject.toml found, skipping install${RESET}\n"; \

--- a/tests/bundles/test_bundle_content_validity.py
+++ b/tests/bundles/test_bundle_content_validity.py
@@ -595,3 +595,72 @@ class TestCorePreCommitConfig:
             "'default_language_version.node' must be a non-empty version string to keep markdownlint-cli "
             "installable on odd-numbered current node releases (EBADENGINE guard)"
         )
+
+
+# ---------------------------------------------------------------------------
+# Devcontainer bundle content
+# ---------------------------------------------------------------------------
+
+
+class TestDevcontainerBundleContent:
+    """The devcontainer bundle must ship a coherent, runnable dev-container setup.
+
+    Goes beyond the JSONC non-empty check in TestBundleJsonValidity: it parses
+    devcontainer.json (stripping its // comments) and verifies the config actually
+    wires up the bootstrap script, a pinned base image, and the non-root user the
+    bundle promises — the behaviour a downstream repo relies on after syncing it.
+    """
+
+    @pytest.fixture
+    def devcontainer_dir(self, root: Path) -> Path:
+        """Return the .devcontainer directory inside the devcontainer bundle."""
+        d = root / "bundles" / "devcontainer" / ".devcontainer"
+        if not d.is_dir():
+            pytest.skip("devcontainer bundle not present")
+        return d
+
+    @pytest.fixture
+    def devcontainer_config(self, devcontainer_dir: Path) -> dict:
+        """Parse devcontainer.json, stripping its full-line // comments (JSONC)."""
+        raw = (devcontainer_dir / "devcontainer.json").read_text(encoding="utf-8")
+        stripped = "\n".join(line for line in raw.splitlines() if not line.lstrip().startswith("//"))
+        return json.loads(stripped)
+
+    def test_devcontainer_json_parses(self, devcontainer_config: dict) -> None:
+        """devcontainer.json must parse to a named JSON object once comments are stripped."""
+        assert isinstance(devcontainer_config, dict), "devcontainer.json must be a JSON object"
+        assert devcontainer_config.get("name"), "devcontainer.json must declare a 'name'"
+
+    def test_oncreate_points_to_existing_bootstrap(self, devcontainer_dir: Path, devcontainer_config: dict) -> None:
+        """OnCreateCommand must reference a bootstrap script that actually ships in the bundle."""
+        on_create = devcontainer_config.get("onCreateCommand")
+        assert on_create == ".devcontainer/bootstrap.sh", (
+            f"onCreateCommand should run the bundled bootstrap script, got {on_create!r}"
+        )
+        assert (devcontainer_dir / "bootstrap.sh").exists(), (
+            "bootstrap.sh referenced by onCreateCommand is missing from the bundle"
+        )
+
+    def test_bootstrap_is_a_shell_script(self, devcontainer_dir: Path) -> None:
+        """bootstrap.sh must be a real shell script: a shebang plus the dependency-install step."""
+        content = (devcontainer_dir / "bootstrap.sh").read_text(encoding="utf-8")
+        assert content.startswith("#!"), "bootstrap.sh must start with a shebang line"
+        assert "make install" in content, "bootstrap.sh should install dependencies via 'make install'"
+
+    def test_base_image_is_pinned_python(self, devcontainer_config: dict) -> None:
+        """The container image must be a tag-pinned devcontainers Python image."""
+        image = devcontainer_config.get("image", "")
+        assert "devcontainers/python" in image, f"expected a devcontainers Python base image, got {image!r}"
+        assert ":" in image.rsplit("/", 1)[-1], f"base image should pin a tag, got {image!r}"
+
+    def test_remote_user_is_vscode(self, devcontainer_config: dict) -> None:
+        """The container must run as the non-root 'vscode' user."""
+        assert devcontainer_config.get("remoteUser") == "vscode", "devcontainer should run as the 'vscode' user"
+
+    def test_overlay_ci_triggers_on_devcontainer_changes(self, root: Path) -> None:
+        """The github-devcontainer overlay must rebuild the image when .devcontainer/** changes."""
+        wf = root / "bundles" / "github-devcontainer" / ".github" / "workflows" / "rhiza_devcontainer.yml"
+        if not wf.exists():
+            pytest.skip("github-devcontainer overlay not present")
+        content = wf.read_text(encoding="utf-8")
+        assert ".devcontainer/**" in content, "devcontainer CI overlay should trigger on .devcontainer/** path changes"


### PR DESCRIPTION
Addresses the three quality-gate findings filed from `/rhiza_quality`.

Closes #1333
Closes #1334
Closes #1335

## What changed

### #1333 — benchmarks bundle integration test (Test depth 8→9)
New `.rhiza/tests/integration/test_benchmark_targets.py` (4 tests), mirroring `test_marimo_targets.py`:
- dry-runs `make benchmark` in a synced `git_repo` (resolves the target + its `install` prerequisite)
- asserts `benchmark` is declared `.PHONY`, depends on `install`
- asserts the recipe guards on `${TESTS_FOLDER}/benchmarks` and drives pytest-benchmark (`--benchmark-only`, `--benchmark-json`, `analyze-benchmarks`)

Runs under `make rhiza-test`.

### #1334 — devcontainer bundle behaviour test (Test depth 9→10)
New `TestDevcontainerBundleContent` class (6 tests) in `tests/bundles/test_bundle_content_validity.py`. Goes beyond the existing JSONC non-empty check: parses `devcontainer.json` (stripping `//` comments) and asserts
- `onCreateCommand` → a `bootstrap.sh` that ships in the bundle
- `bootstrap.sh` has a shebang and runs `make install`
- the base image is a tag-pinned `devcontainers/python` image
- the container runs as the non-root `vscode` user
- the `github-devcontainer` overlay triggers CI on `.devcontainer/**` changes

(devcontainer has no make target and isn't synced into the mother repo, so the behaviour test validates the shippable bundle source — alongside the other per-bundle classes in this file, under `make test`.)

### #1335 — idempotent install, no dependency churn (CI/tooling health 9→10)
Added `--inexact` to both `uv sync` calls in `bootstrap.mk`. The lock sync defaulted to `--exact`, which pruned the dev tools installed from `.rhiza/requirements/*.txt` on every run; the next gate re-synced (pruned again) and reinstalled them — the "Uninstalled 68 / Installed N" churn on each `make` target. `--inexact` keeps packages not in the lock, which is correct here since the venv legitimately holds lock deps **plus** the requirements tools.

Applied to both dogfood copies (`.rhiza/make.d/bootstrap.mk` and `bundles/core/.rhiza/make.d/bootstrap.mk`), kept byte-identical.

## Verification
- `make rhiza-test`: **212 passed**, 1 by-design skip (was 208)
- `make test`: **999 passed** (was 993)
- `make fmt`: clean
- Idempotency proof: the run immediately after the edit printed `Checked N packages` for every requirement group instead of uninstall/reinstall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)