### PR TITLE
docs(rhiza_quality): offer to file findings as tracker issues

### DIFF
--- a/.claude/commands/rhiza_quality.md
+++ b/.claude/commands/rhiza_quality.md
@@ -70,6 +70,17 @@ Then analyse the repo and give marks on a scale of 1 to 10 for all relevant subc
 
 Scope. Score everything this repo controls: `bundles/` (the shipped templates), `.rhiza/` (the modular Makefile system in `make.d/*.mk`, `rhiza.mk`, the authoritative bundle list in `template-bundles.yml`, utilities in `utils/`, and the test suite in `tests/`), the root `tests/`, `pyproject.toml`, `pytest.ini`, `ruff.toml`, `.pre-commit-config.yaml`, `Makefile`, `README.md`, `docs/`, and the CI workflows in `.github/workflows/` and `.gitlab-ci.yml`. All of this is authored here — there is nothing "Rhiza-owned but external". If a file is machine-generated (e.g. README sections injected by the `make`-help hook), note that it is generated and score the source, not the artifact.
 
-Then, from the scorecard above, identify actionable issues to improve the score — one per subcategory scoring below 10 (skip any that are maxed). For each, give: a concrete title, the subcategory and current→target score it moves, the specific file(s)/lines or config to change, and a crisp acceptance criterion ("done when…"). Order them by leverage (biggest score gain for least effort first). This is a list of recommendations only — do not create GitHub issues or change code unless I explicitly ask.
+Then, from the scorecard above, identify actionable issues to improve the score — one per subcategory scoring below 10 (skip any that are maxed). For each, give: a concrete title, the subcategory and current→target score it moves, the specific file(s)/lines or config to change, and a crisp acceptance criterion ("done when…"). Order them by leverage (biggest score gain for least effort first). This is a list of recommendations only — do not change code unless I explicitly ask.
+
+Then offer to file the findings as issues. After presenting the recommendations,
+ask me whether to turn the actionable findings into tracker issues — ask, do not
+assume, and create nothing without an explicit yes. If I decline, stop. If I
+accept, detect the hosting platform from the git remote
+(`git remote get-url origin`) and create one issue per accepted finding with the
+matching CLI — GitHub → `gh issue create`, GitLab → `glab issue create` (skip and
+say so if the relevant CLI is unavailable or unauthenticated). Make each issue
+self-contained: title from the finding, and a body carrying the subcategory, the
+current→target score, the specific file(s)/lines or config to change, and the
+"done when…" acceptance criterion. Report back the created issue URLs.
 
 If everything passes, say so plainly — but still produce the 1–10 subcategory marks. Do not fix anything unless I ask — this command only assesses.

--- a/bundles/core/.claude/commands/rhiza_quality.md
+++ b/bundles/core/.claude/commands/rhiza_quality.md
@@ -80,8 +80,18 @@ the specific file(s)/lines or config to change, and a crisp acceptance criterion
 ("done when…"). Keep them in-scope (locally-owned, per the scoping rule above) —
 flag anything Rhiza-owned as upstream rather than listing it as a local action.
 Order them by leverage (biggest score gain for least effort first). This is a
-list of recommendations only — do not create GitHub issues or change code unless
-I explicitly ask.
+list of recommendations only — do not change code unless I explicitly ask.
+
+Then offer to file the findings as issues. After presenting the recommendations,
+ask me whether to turn the actionable findings into tracker issues — ask, do not
+assume, and create nothing without an explicit yes. If I decline, stop. If I
+accept, detect the hosting platform from the git remote
+(`git remote get-url origin`) and create one issue per accepted finding with the
+matching CLI — GitHub → `gh issue create`, GitLab → `glab issue create` (skip and
+say so if the relevant CLI is unavailable or unauthenticated). Make each issue
+self-contained: title from the finding, and a body carrying the subcategory, the
+current→target score, the specific file(s)/lines or config to change, and the
+"done when…" acceptance criterion. Report back the created issue URLs.
 
 If everything passes, say so plainly — but still produce the 1–10 subcategory
 marks. Do not fix anything unless I ask — this command only assesses.


### PR DESCRIPTION
Updates the `/rhiza_quality` command instructions — both the root copy
(`.claude/commands/rhiza_quality.md`) and the core-bundle source
(`bundles/core/.claude/commands/rhiza_quality.md`) — to add an explicit
issue-filing workflow.

## What changed
- After presenting the scorecard recommendations, the command now offers to turn
  the actionable findings into tracker issues: it **asks first** (creates nothing
  without an explicit yes), detects the host from `git remote get-url origin`, and
  on acceptance creates one self-contained issue per finding via the matching CLI
  (`gh issue create` / `glab issue create`), reporting back the URLs.
- Drops the old blanket "do not create GitHub issues" clause, which the new
  opt-in workflow supersedes.

The two files are intentionally worded differently (the root copy is more compact
than the wrapped bundle source) and are not byte-identical; both received the same
logical change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)