### PR TITLE
docs(rhiza_quality): make the issue-filing prompt a multi-select menu

### DIFF
--- a/.claude/commands/rhiza_quality.md
+++ b/.claude/commands/rhiza_quality.md
@@ -72,11 +72,12 @@ Scope. Score everything this repo controls: `bundles/` (the shipped templates), 
 
 Then, from the scorecard above, identify actionable issues to improve the score — one per subcategory scoring below 10 (skip any that are maxed). For each, give: a concrete title, the subcategory and current→target score it moves, the specific file(s)/lines or config to change, and a crisp acceptance criterion ("done when…"). Order them by leverage (biggest score gain for least effort first). This is a list of recommendations only — do not change code unless I explicitly ask.
 
-Then offer to file the findings as issues. After presenting the recommendations,
-ask me whether to turn the actionable findings into tracker issues — ask, do not
-assume, and create nothing without an explicit yes. If I decline, stop. If I
-accept, detect the hosting platform from the git remote
-(`git remote get-url origin`) and create one issue per accepted finding with the
+Then offer to file the findings as issues — using a menu, not a free-text prompt.
+Present the actionable findings as a multi-select menu (the AskUserQuestion tool
+with `multiSelect: true`), one option per finding labelled by its title, so I can
+pick exactly which ones to file — including none. Create nothing without an
+explicit selection. For each finding I select, detect the hosting platform from
+the git remote (`git remote get-url origin`) and create one issue with the
 matching CLI — GitHub → `gh issue create`, GitLab → `glab issue create` (skip and
 say so if the relevant CLI is unavailable or unauthenticated). Make each issue
 self-contained: title from the finding, and a body carrying the subcategory, the

--- a/bundles/core/.claude/commands/rhiza_quality.md
+++ b/bundles/core/.claude/commands/rhiza_quality.md
@@ -82,11 +82,12 @@ flag anything Rhiza-owned as upstream rather than listing it as a local action.
 Order them by leverage (biggest score gain for least effort first). This is a
 list of recommendations only — do not change code unless I explicitly ask.
 
-Then offer to file the findings as issues. After presenting the recommendations,
-ask me whether to turn the actionable findings into tracker issues — ask, do not
-assume, and create nothing without an explicit yes. If I decline, stop. If I
-accept, detect the hosting platform from the git remote
-(`git remote get-url origin`) and create one issue per accepted finding with the
+Then offer to file the findings as issues — using a menu, not a free-text prompt.
+Present the actionable findings as a multi-select menu (the AskUserQuestion tool
+with `multiSelect: true`), one option per finding labelled by its title, so I can
+pick exactly which ones to file — including none. Create nothing without an
+explicit selection. For each finding I select, detect the hosting platform from
+the git remote (`git remote get-url origin`) and create one issue with the
 matching CLI — GitHub → `gh issue create`, GitLab → `glab issue create` (skip and
 say so if the relevant CLI is unavailable or unauthenticated). Make each issue
 self-contained: title from the finding, and a body carrying the subcategory, the


### PR DESCRIPTION
Follow-up to #1337. Turns the `/rhiza_quality` issue-filing step from a free-text
yes/no into a **multi-select menu**.

## What changed
After presenting the scorecard recommendations, the command now presents the
actionable findings as a multi-select menu (the AskUserQuestion tool with
`multiSelect: true`) — one option per finding, labelled by its title — so I pick
exactly which findings to file (including none). It still creates nothing without
an explicit selection, detects the host from the git remote, and files one
self-contained issue per selected finding via `gh`/`glab`.

Applied to both the root copy (`.claude/commands/rhiza_quality.md`) and the
core-bundle source (`bundles/core/.claude/commands/rhiza_quality.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)