### PR TITLE
docs: bundle taxonomy + CI enforcement references, document Makefile loading

### DIFF
--- a/.rhiza/make.d/README.md
+++ b/.rhiza/make.d/README.md
@@ -76,6 +76,58 @@ pre-install::
 
 ## ℹ️ Reference
 
+### How the modular Makefile loads
+
+The root `Makefile` is intentionally thin — it only `include`s `.rhiza/rhiza.mk`,
+whose **last line** auto-loads every fragment in this directory:
+
+```makefile
+# In .rhiza/rhiza.mk (last line)
+-include .rhiza/make.d/*.mk
+```
+
+Key consequences:
+
+- **Alphabetical load order.** `make` expands the `*.mk` glob alphabetically, so
+  fragments are included in filename order (`book.mk`, `bootstrap.mk`,
+  `bundles.mk`, …). Don't rely on a later fragment overriding an earlier one — a
+  duplicate **single-colon** target across two fragments is a silent
+  last-definition-wins bug, and CI fails it (see
+  `tests/utils/test_make_structure.py`). Use a hook instead (below).
+- **Drop-in extension.** Adding a feature is just dropping a new `.mk` file here;
+  there is no include list to maintain.
+- **`local.mk`** (project root, not committed) is auto-loaded the same way for
+  developer-only shortcuts.
+
+### The hook contract (double-colon targets)
+
+Lifecycle hooks use GNU Make **double-colon** (`::`) rules. Unlike single-colon
+targets, a double-colon target **may be defined any number of times**, and make
+runs **every** definition in order. That is what lets a fragment, the root
+`Makefile`, and a downstream project all attach behaviour to the same lifecycle
+point without colliding:
+
+```makefile
+# .rhiza/rhiza.mk ships an empty default so the hook always exists:
+post-sync:: ; @:
+
+# Your root Makefile adds to it (this does NOT replace the default):
+post-sync::
+	@echo "Regenerating lockfile after sync..."
+	@uv lock
+```
+
+Both recipes run on `make sync`. Rules of the road:
+
+- Always use `::` for hooks — a single `:` would trigger the duplicate-target
+  gate and silently drop one definition.
+- Where to put what:
+  - **Project-specific hooks / custom targets** → your root `Makefile`, *above*
+    the `include .rhiza/rhiza.mk` line (committed, shared with the team).
+  - **Developer-local, throwaway shortcuts** → `local.mk` (not committed).
+  - **Never** edit files in `.rhiza/make.d/` directly — they are overwritten on
+    the next template sync.
+
 ### File Organization
 - **`.rhiza/make.d/`**: Template-managed files (do not edit)
 - **Root `Makefile`**: Project-specific customizations (variables, hooks, custom targets)
@@ -87,12 +139,15 @@ pre-install::
 |------|---------|
 | `book.mk` | Documentation book generation |
 | `bootstrap.mk` | Installation and environment setup |
+| `bundles.mk` | Bundle inspection (`make explain-bundles`) |
 | `custom-env.mk` | Example environment customizations |
 | `custom-task.mk` | Example custom tasks |
 | `docker.mk` | Docker build and run targets |
+| `doctor.mk` | Environment diagnostics (`make doctor`) |
 | `github.mk` | GitHub CLI integrations |
 | `lfs.mk` | Git LFS management |
 | `marimo.mk` | Marimo notebook support |
+| `paper.mk` | LaTeX paper compilation |
 | `presentation.mk` | Presentation building (Marp) |
 | `quality.mk` | Code quality and formatting |
 | `releasing.mk` | Release and versioning |

--- a/docs/operations/CI_ENFORCEMENT.md
+++ b/docs/operations/CI_ENFORCEMENT.md
@@ -1,0 +1,66 @@
+# CI Enforcement Model
+
+Not every Rhiza workflow is a merge gate. Some **block** a pull request when they
+fail; others are **report-only** — they publish results for inspection but never
+fail CI. This page records which is which, so the intent is discoverable rather
+than buried in each workflow's header.
+
+## Blocking gates
+
+These fail the pull request when they fail. They run on every PR via
+`rhiza_ci.yml` (and the equivalent GitLab pipeline):
+
+| Check | Workflow / target | Notes |
+|-------|-------------------|-------|
+| Format, lint, hooks | `make fmt` | ruff, markdownlint, bandit, actionlint, shellcheck, jsonschema, uv-lock. |
+| Type checking | `make typecheck` | `ty` + `mypy --strict` over `.rhiza/utils`. |
+| Tests | `make test`, `make rhiza-test` | Full suites; rhiza-test enforces 90% coverage on `.rhiza/utils`. |
+| Dependency hygiene | `make deptry` | Unused/missing dependency scan. |
+| Docstring coverage | `make docs-coverage` | interrogate at 100%. |
+| Security | `make security` | pip-audit + bandit. |
+| CodeQL | `rhiza_codeql.yml` | Code scanning on PR and push. |
+
+## Conditional / opt-in gates
+
+### Mutation testing (`rhiza_mutation.yml`)
+
+- **Enforcing when enabled.** `make mutation` exits non-zero on any surviving
+  mutant, and the workflow's *Enforce mutation gate* step propagates that failure,
+  so it is a hard gate equivalent to a 100% mutation-score threshold.
+- **Opt-in, OFF by default.** The `mutation` job only runs when the repository
+  variable `MUTATION_ENABLED` is set to `'true'`; otherwise it skips cleanly and
+  CI stays green. This keeps downstream repos from being forced into mutation
+  testing.
+- **Status in this repo:** `MUTATION_ENABLED` is currently unset, so mutation
+  runs are skipped on `jebel-quant/rhiza` PRs. To turn it into an active gate
+  here, set the variable:
+
+  ```bash
+  gh variable set MUTATION_ENABLED --body true --repo Jebel-Quant/rhiza
+  ```
+
+## Report-only (monitoring) workflows
+
+These never fail a PR by design — they exist to publish security/quality signals.
+
+### OpenSSF Scorecard (`rhiza_scorecard.yml`)
+
+- Runs on push to `main`/`master`, weekly, on branch-protection changes, and
+  manual dispatch — **not** on `pull_request`.
+- Uploads SARIF to GitHub code scanning and (on public repos) publishes to the
+  OpenSSF REST API that powers the README badge.
+- There is no step that fails the run on a low score; a dropping score surfaces
+  as a code-scanning alert and a lower badge, not a red check. Auto-detect runs
+  on public repos; force it with the `SCORECARD_ENABLED` variable (`'true'` /
+  `'false'`).
+
+### Other periodic scans
+
+`rhiza_weekly.yml` and `rhiza_fuzzing.yml` run on a schedule to surface drift and
+robustness issues; they are diagnostic and are not PR merge gates.
+
+## Summary
+
+- **PR merge gates:** `fmt`, `typecheck`, `test`, `rhiza-test`, `deptry`,
+  `docs-coverage`, `security`, CodeQL — plus mutation **iff** `MUTATION_ENABLED=true`.
+- **Report-only:** Scorecard, weekly, fuzzing.

--- a/docs/reference/BUNDLE_TAXONOMY.md
+++ b/docs/reference/BUNDLE_TAXONOMY.md
@@ -1,0 +1,109 @@
+# Bundle Taxonomy
+
+Rhiza ships development infrastructure as **bundles** — named groups of
+configuration files. A downstream project adopts Rhiza by listing the bundles
+(or profiles) it wants in `.rhiza/template.yml`; `make sync` then materialises
+exactly those files. This page is the map of what you can choose from.
+
+The authoritative, machine-readable definition lives in
+`.rhiza/template-bundles.yml`. This document explains the *model*; that file is
+the source of truth for the exact set. See
+[ADR-0006](../adr/0006-organise-templates-into-bundles.md) and
+[ADR-0010](../adr/0010-layered-bundle-profile-model.md) for the rationale.
+
+## The three groups
+
+1. **Feature bundles** — one per capability. They are *local-first*: a feature
+   bundle never ships hosted-CI workflow files, so it works the same whether or
+   not you use GitHub or GitLab.
+2. **Platform-overlay bundles** — thin CI stubs that pair a feature with a
+   hosting platform (`github-<feature>`, `gitlab-<feature>`). Each delegates to a
+   reusable workflow in `jebel-quant/rhiza`.
+3. **Profiles** — higher-level presets (sometimes called *meta-bundles*) that
+   expand to a curated set of bundles for a stable intent (local-only,
+   GitHub-hosted, GitLab-hosted).
+
+## Feature bundles
+
+| Bundle | Purpose |
+|--------|---------|
+| `core` | Required base: thin Makefile, `.rhiza/` modular make system, linting, bootstrap. |
+| `tests` | Local testing: pytest, coverage, and type checking. |
+| `benchmarks` | Performance benchmarking with `pytest-benchmark` and reporting (builds on `tests`). |
+| `book` | Documentation site with MkDocs + zensical. |
+| `marimo` | Interactive Marimo notebooks for exploration and docs. |
+| `presentation` | Slides built from `PRESENTATION.md` with Marp. |
+| `paper` | LaTeX paper compilation targets (`make paper`). |
+| `docker` | Docker containerization support. |
+| `devcontainer` | VS Code Dev Container for reproducible environments. |
+| `lfs` | Git LFS installation and management. |
+| `github` | GitHub repository configuration (actions, dependabot, templates, rulesets, core workflows). |
+| `gitlab` | GitLab CI/CD pipeline configuration and core workflows. |
+| `renovate` | Renovate bot configuration for automated dependency updates. |
+| `legal` | Legal and community documentation files. |
+
+Bundles declare relationships in `.rhiza/template-bundles.yml`:
+
+- `requires` — hard dependencies pulled in automatically (e.g. `tests` requires
+  `core` and `book`).
+- `recommends` — soft companions you may want (e.g. `book` recommends `tests`
+  and `marimo`).
+- `standalone` — whether the bundle is usable on its own (`benchmarks` and
+  `marimo` are not).
+
+## Platform-overlay bundles
+
+Each overlay adds the hosted-CI workflow stub for a feature. Pick the overlay
+that matches your platform *and* the feature bundle it pairs with.
+
+| Bundle | Pairs feature → platform |
+|--------|--------------------------|
+| `github-tests` | `tests` → GitHub Actions (CI, CodeQL, mutation) |
+| `github-book` | `book` → GitHub Pages publishing |
+| `github-marimo` | `marimo` → GitHub Actions notebook publishing |
+| `github-docker` | `docker` → GitHub Actions lint/build/scan |
+| `github-devcontainer` | `devcontainer` → GitHub Actions image build validation |
+| `github-paper` | `paper` → GitHub Actions LaTeX build + PDF publishing |
+| `gitlab-tests` | `tests` → GitLab CI |
+| `gitlab-book` | `book` → GitLab Pages publishing |
+| `gitlab-marimo` | `marimo` → GitLab CI notebook execution |
+
+## Profiles (meta-presets)
+
+Profiles are the recommended entry point: pick the one that matches your hosting
+context and Rhiza expands it to a sensible bundle set.
+
+| Profile | Expands to | Use when |
+|---------|-----------|----------|
+| `local` | `core`, `tests`, `book`, `marimo` | Local-first work with no hosted CI (experiments, private/other-host repos). |
+| `github-project` | the `local` set + `github` and the `github-*` overlays | A standard GitHub-hosted project. |
+| `gitlab-project` | the `local` set + `gitlab` and the `gitlab-*` overlays | A standard GitLab-hosted project. |
+
+## Adoption flow
+
+Declare what you want in `.rhiza/template.yml`:
+
+```yaml
+# Profile-based (recommended):
+profiles:
+  - github-project
+
+# ...optionally add extra bundles on top:
+templates:
+  - paper
+  - github-paper
+```
+
+or take full manual control with bundles only:
+
+```yaml
+templates:
+  - core
+  - tests
+  - github
+  - github-tests
+```
+
+Then run `make sync` to materialise the selected files. Required bundles
+(`core`) and any `requires` dependencies are pulled in automatically, so you only
+list the capabilities you care about.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
     - Extending Rhiza: guides/EXTENDING_RHIZA.md
   - Reference:
     - Architecture: reference/ARCHITECTURE.md
+    - Bundle Taxonomy: reference/BUNDLE_TAXONOMY.md
     - Dependencies: reference/DEPENDENCIES.md
     - Tools Reference: reference/TOOLS_REFERENCE.md
     - Shell Scripts: reference/SHELL_SCRIPTS.md
@@ -30,6 +31,7 @@ nav:
     - Marimo: development/MARIMO.md
     - Presentation: development/PRESENTATION.md
   - Operations:
+    - CI Enforcement Model: operations/CI_ENFORCEMENT.md
     - Global Patch Workflow: ops/GLOBAL_PATCH.md
     - Changelog Guide: ops/CHANGELOG_GUIDE.md
     - Project Board: ops/PROJECT_BOARD.md

--- a/tests/bundles/test_bundle_test_coverage.py
+++ b/tests/bundles/test_bundle_test_coverage.py
@@ -1,0 +1,145 @@
+"""Completeness gate tying every declared bundle to a behavioural test.
+
+100% docstring/line coverage proves the Python utilities are exercised, but says
+nothing about the *templates*: a new bundle can be added to
+``.rhiza/template-bundles.yml`` and shipped without any test that exercises the
+Makefile targets, workflow stubs, or files it contributes. This module closes
+that gap.
+
+For every bundle declared in ``template-bundles.yml`` we require either:
+
+1. a behavioural test under ``.rhiza/tests/`` or ``tests/`` that references the
+   bundle by name (a quoted string, a ``bundles/<name>`` path, or a
+   ``test_<name>`` / ``<name>_targets`` test module), or
+2. an explicit entry in ``_EXEMPT`` with a documented reason (for static
+   file-only bundles that have no behaviour to drive — their content is already
+   guarded by the bundle content-validity and byte-identity sync tests).
+
+The generic tests that enumerate *all* bundles from the YAML (sync, schema,
+matrix, ...) are deliberately excluded from the scan: they would make every
+bundle look "covered" and defeat the gate.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+_ROOT = Path(__file__).resolve().parents[2]
+_TEMPLATE_BUNDLES = _ROOT / ".rhiza" / "template-bundles.yml"
+
+# Test modules that iterate the full bundle list from template-bundles.yml. They
+# touch every bundle generically, so a mention here is not evidence of a
+# *behavioural* test and must not count as coverage.
+_GENERIC_TESTS = {
+    "test_template_bundles.py",
+    "test_template_bundles_schema.py",
+    "test_bundle_rhiza_sync.py",
+    "test_bundle_sync.py",
+    "test_bundle_matrix.py",
+    "test_bundle_combinations.py",
+    "test_bundle_content_validity.py",
+    "test_bundle_claude_commands_sync.py",
+    "test_doc_consistency.py",
+    "test_bundle_test_coverage.py",  # this module
+}
+
+# Bundles with no behavioural surface to exercise: they contribute only static
+# files (no make targets, no workflow logic). Their content is already verified
+# by test_bundle_content_validity.py and the byte-identity sync tests, so a
+# dedicated behavioural test would have nothing to assert. Keyed to the reason.
+_EXEMPT: dict[str, str] = {
+    "legal": "Static community files (LICENSE, CODE_OF_CONDUCT, ...); no targets "
+    "or workflows. Content is guarded by the bundle content-validity tests.",
+    "renovate": "Static renovate.json config; validated by the 'Validate Renovate "
+    "Config' pre-commit hook and the bundle content-validity tests, no behaviour to drive.",
+}
+
+
+def _bundle_names() -> list[str]:
+    """Return every bundle name declared in template-bundles.yml."""
+    config = yaml.safe_load(_TEMPLATE_BUNDLES.read_text(encoding="utf-8"))
+    return sorted(config["bundles"])
+
+
+def _behavioural_test_files() -> list[Path]:
+    """Return every non-generic test file under .rhiza/tests/ and tests/."""
+    files: list[Path] = []
+    for base in (".rhiza/tests", "tests"):
+        for path in sorted((_ROOT / base).rglob("*.py")):
+            if "__pycache__" in path.parts:
+                continue
+            if path.name in _GENERIC_TESTS:
+                continue
+            files.append(path)
+    return files
+
+
+# Read each behavioural test file once; the scan runs against the cached text.
+_TEST_SOURCES: dict[Path, str] = {p: p.read_text(encoding="utf-8", errors="replace") for p in _behavioural_test_files()}
+
+
+def _bundle_patterns(bundle: str) -> list[str]:
+    """Return the regex fragments that count as a behavioural reference to ``bundle``."""
+    name = re.escape(bundle)
+    snake = re.escape(bundle.replace("-", "_"))
+    return [
+        rf"""["']{name}["']""",  # quoted bundle name
+        rf"/{name}[/.\"']",  # path component, e.g. bundles/<name>/...
+        rf"bundles/{name}\b",
+        rf"{snake}_targets",  # e.g. docker_targets
+        rf"test_{snake}\b",  # e.g. test_lfs
+    ]
+
+
+def _covering_tests(bundle: str) -> list[str]:
+    """Return the behavioural test files that reference ``bundle``, if any."""
+    patterns = [re.compile(p) for p in _bundle_patterns(bundle)]
+    return [
+        path.relative_to(_ROOT).as_posix()
+        for path, text in _TEST_SOURCES.items()
+        if any(p.search(text) for p in patterns)
+    ]
+
+
+class TestBundleTestCoverage:
+    """Every declared bundle must have a behavioural test or a documented exemption."""
+
+    @pytest.mark.parametrize("bundle", _bundle_names())
+    def test_bundle_has_behavioural_test(self, bundle: str) -> None:
+        """A bundle is covered by a behavioural test, or is explicitly exempt."""
+        if bundle in _EXEMPT:
+            return
+        covering = _covering_tests(bundle)
+        assert covering, (
+            f"bundle '{bundle}' is declared in .rhiza/template-bundles.yml but no behavioural "
+            f"test under .rhiza/tests/ or tests/ references it. Add a test that exercises the "
+            f"bundle's targets/workflows/files, or add '{bundle}' to _EXEMPT in this module with a reason."
+        )
+
+    @pytest.mark.parametrize("bundle", sorted(_EXEMPT))
+    def test_exemptions_are_real_bundles(self, bundle: str) -> None:
+        """Every _EXEMPT key must name a bundle that actually exists (no stale exemptions)."""
+        assert bundle in _bundle_names(), (
+            f"_EXEMPT lists '{bundle}', which is not a bundle in .rhiza/template-bundles.yml — remove the stale entry"
+        )
+
+    @pytest.mark.parametrize("bundle", sorted(_EXEMPT))
+    def test_exemptions_are_still_untested(self, bundle: str) -> None:
+        """An exempt bundle that has since gained a behavioural test must leave _EXEMPT."""
+        covering = _covering_tests(bundle)
+        assert not covering, (
+            f"bundle '{bundle}' is in _EXEMPT but is now referenced by {covering}. "
+            "Remove it from _EXEMPT so the bundle is gated by its real test."
+        )
+
+    def test_scanner_finds_known_coverage(self) -> None:
+        """Guard against a scanner regression silently reporting everything as uncovered."""
+        for bundle in ("docker", "marimo", "book", "paper", "lfs"):
+            assert _covering_tests(bundle), (
+                f"scanner found no behavioural test for '{bundle}', which has a known integration "
+                "test — the coverage scan is broken"
+            )

--- a/tests/docs/test_doc_consistency.py
+++ b/tests/docs/test_doc_consistency.py
@@ -186,6 +186,31 @@ class TestBundleDocumentation:
         )
 
 
+_BUNDLE_TAXONOMY = _ROOT / "docs" / "reference" / "BUNDLE_TAXONOMY.md"
+
+
+class TestBundleTaxonomyDoc:
+    """Verify the bundle-taxonomy reference page tracks the authoritative bundle list."""
+
+    @pytest.mark.parametrize("bundle_name", _load_bundle_names())
+    def test_bundle_documented_in_taxonomy(self, bundle_name: str) -> None:
+        """Every bundle defined in template-bundles.yml must appear in BUNDLE_TAXONOMY.md."""
+        taxonomy = _BUNDLE_TAXONOMY.read_text(encoding="utf-8")
+        assert f"`{bundle_name}`" in taxonomy, (
+            f"bundle '{bundle_name}' is defined in .rhiza/template-bundles.yml but not documented in "
+            "docs/reference/BUNDLE_TAXONOMY.md"
+        )
+
+    @pytest.mark.parametrize("profile_name", _load_profile_names())
+    def test_profile_documented_in_taxonomy(self, profile_name: str) -> None:
+        """Every profile defined in template-bundles.yml must appear in BUNDLE_TAXONOMY.md."""
+        taxonomy = _BUNDLE_TAXONOMY.read_text(encoding="utf-8")
+        assert f"`{profile_name}`" in taxonomy, (
+            f"profile '{profile_name}' is defined in .rhiza/template-bundles.yml but not documented in "
+            "docs/reference/BUNDLE_TAXONOMY.md"
+        )
+
+
 class TestReadmeBundleList:
     """Verify the README's bundle/profile tables track the authoritative template-bundles.yml."""
 


### PR DESCRIPTION
## Summary

Addresses documentation/test quality gaps surfaced on the quality-assessment pass.

- **`docs/reference/BUNDLE_TAXONOMY.md`** — maps the bundle/profile model (feature bundles, platform overlays, profiles), wired into the mkdocs nav. A new doc-consistency test asserts every bundle and profile in `.rhiza/template-bundles.yml` is documented here.
- **`docs/operations/CI_ENFORCEMENT.md`** — records which CI checks are blocking merge gates vs report-only, so intent is discoverable rather than buried in workflow headers.
- **`.rhiza/make.d/README.md`** — documents the modular Makefile load order (alphabetical `*.mk` glob), the double-colon hook contract, and adds the `bundles`/`doctor`/`paper` fragments to the table.
- **`tests/bundles/test_bundle_test_coverage.py`** — completeness gate tying every declared bundle to a behavioural test (or an explicit, documented exemption).

## Test plan

- [ ] `make test` — new bundle-coverage and taxonomy doc-consistency tests pass
- [ ] `make book` — taxonomy + CI-enforcement pages render in nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)