### PR TITLE
docs: correct GitLab-CI claim in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,5 +89,6 @@ Hook targets use double-colon syntax (`pre-install::`, `post-install::`) and can
 
 ### CI/CD
 
-- **GitHub Actions** (primary): `.github/workflows/` — CI, release, docker, CodeQL, weekly, sync
-- **GitLab CI** (parallel): `.gitlab-ci.yml` — mirrors GitHub Actions coverage
+This repo runs on **GitHub Actions only**: `.github/workflows/` — CI, release, docker, CodeQL, weekly, sync. There is no root `.gitlab-ci.yml` here.
+
+GitLab support ships as a **template for downstream consumers**, not as active CI in this repo: the `gitlab` bundle (`bundles/gitlab/`) materializes a `.gitlab-ci.yml` plus `.gitlab/` pipelines into projects that adopt the `gitlab-project` profile, mirroring the GitHub Actions coverage there.


### PR DESCRIPTION
## Summary

Fixes the inaccurate CI/CD description in `CLAUDE.md`. The mother repo runs on **GitHub Actions only** — there is no root `.gitlab-ci.yml`. The previous text claimed GitLab CI runs "in parallel" and "mirrors GitHub Actions coverage" *here*, which is misleading.

GitLab support actually ships as a **template** via `bundles/gitlab/` (`.gitlab-ci.yml` + `.gitlab/` pipelines), materialized into downstream projects that adopt the `gitlab-project` profile.

## Acceptance criterion (from #1345)

- [x] CI/CD section states the mother repo runs on GitHub Actions only
- [x] `.gitlab-ci.yml` documented as a downstream template via `bundles/gitlab/` (gitlab-project profile), not active CI here
- [x] No remaining claim of a root `.gitlab-ci.yml` "mirroring GitHub Actions in parallel"

## Verification

`make fmt` passes (markdownlint clean).

Closes #1345

🤖 Generated with [Claude Code](https://claude.com/claude-code)