### PR TITLE
Fix for Commented-out code

### DIFF
--- a/.rhiza/tests/structure/test_project_layout.py
+++ b/.rhiza/tests/structure/test_project_layout.py
@@ -32,9 +32,7 @@ class TestRootFixture:
         if not any((root / ci_dir).exists() for ci_dir in ci_dirs):
             pytest.fail(f"At least one CI directory from {ci_dirs} must exist")
 
-        # for dirname in optional_dirs:
-        #     if not (root / dirname).exists():
-        #         pytest.skip(f"Optional directory {dirname} not present in this project")
+        # Optional directories are not enforced in this shared layout test.
 
     def test_root_contains_expected_files(self, root):
         """Root should contain all expected configuration files."""

--- a/bundles/tests/.rhiza/tests/structure/test_project_layout.py
+++ b/bundles/tests/.rhiza/tests/structure/test_project_layout.py
@@ -32,9 +32,7 @@ class TestRootFixture:
         if not any((root / ci_dir).exists() for ci_dir in ci_dirs):
             pytest.fail(f"At least one CI directory from {ci_dirs} must exist")
 
-        # for dirname in optional_dirs:
-        #     if not (root / dirname).exists():
-        #         pytest.skip(f"Optional directory {dirname} not present in this project")
+        # Optional directories are not enforced in this shared layout test.
 
     def test_root_contains_expected_files(self, root):
         """Root should contain all expected configuration files."""


### PR DESCRIPTION
To fix this without changing behavior, remove the commented-out code block and keep a concise explanatory comment stating that optional directories are intentionally not enforced. This preserves current test semantics (only required dirs and CI-dir presence are enforced) while eliminating dead/commented code that triggered CodeQL.

**File to change:** `bundles/tests/.rhiza/tests/structure/test_project_layout.py`  
**Region:** inside `test_root_contains_expected_directories`, around current lines 35–37.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._