### PR TITLE
fix(tests): reword dry-run docstring in test_releasing_targets

### DIFF
--- a/.rhiza/tests/api/test_releasing_targets.py
+++ b/.rhiza/tests/api/test_releasing_targets.py
@@ -23,7 +23,7 @@ class TestReleasingTargets:
     """Smoke tests for the releasing.mk targets."""
 
     def test_changelog_target_dry_run(self, logger):
-        """Changelog target should generate CHANGELOG.md via git-cliff in dry-run output."""
+        """Changelog target should generate CHANGELOG.md via git-cliff in dry run output."""
         proc = run_make(logger, ["changelog"])
         out = proc.stdout
         assert "no rule to make target" not in proc.stderr.lower()

--- a/bundles/tests/.rhiza/tests/api/test_releasing_targets.py
+++ b/bundles/tests/.rhiza/tests/api/test_releasing_targets.py
@@ -23,7 +23,7 @@ class TestReleasingTargets:
     """Smoke tests for the releasing.mk targets."""
 
     def test_changelog_target_dry_run(self, logger):
-        """Changelog target should generate CHANGELOG.md via git-cliff in dry-run output."""
+        """Changelog target should generate CHANGELOG.md via git-cliff in dry run output."""
         proc = run_make(logger, ["changelog"])
         out = proc.stdout
         assert "no rule to make target" not in proc.stderr.lower()


### PR DESCRIPTION
Rewords the changelog dry-run test docstring (`dry-run output` → `dry run output`) to address a Copilot code-quality finding.

Applied to **both** copies so they stay in sync:
- `bundles/tests/.rhiza/tests/api/test_releasing_targets.py` (authoritative source)
- `.rhiza/tests/api/test_releasing_targets.py` (rhiza's self-synced copy)

### Why upstream

This originated as a downstream autofix in [jebel-quant/rhiza-tools#302](https://github.com/Jebel-Quant/rhiza-tools/pull/302). Since `.rhiza/tests/**` is a Rhiza-managed file, a downstream-only change would be overwritten on the next `rhiza sync`. Making it here lets it propagate to all managed projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)