### PR TITLE
fix(release): retry grayskull while PyPI metadata propagates

### DIFF
--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -490,7 +490,21 @@ jobs:
           mkdir -p /tmp/conda-recipe
           cd /tmp/conda-recipe
 
-          grayskull pypi "$PACKAGE_NAME" --strict-conda-forge
+          # PyPI metadata for a just-published release — especially the first
+          # release of a new package — can lag the upload by several minutes,
+          # so retry before giving up.
+          MAX_ATTEMPTS=5
+          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+            if grayskull pypi "$PACKAGE_NAME" --strict-conda-forge; then
+              break
+            fi
+            if [[ "$attempt" -eq "$MAX_ATTEMPTS" ]]; then
+              echo "::error::grayskull failed after $MAX_ATTEMPTS attempts — PyPI metadata for $PACKAGE_NAME may not be available yet"
+              exit 1
+            fi
+            echo "grayskull attempt $attempt/$MAX_ATTEMPTS failed — waiting 60s for PyPI metadata to propagate"
+            sleep 60
+          done
 
           RECIPE_PATH=$(find . -type f -path "*/meta.yaml" | head -n 1)
           if [[ -z "$RECIPE_PATH" ]]; then

--- a/bundles/github/.github/workflows/rhiza_release.yml
+++ b/bundles/github/.github/workflows/rhiza_release.yml
@@ -483,7 +483,21 @@ jobs:
           mkdir -p /tmp/conda-recipe
           cd /tmp/conda-recipe
 
-          grayskull pypi "$PACKAGE_NAME" --strict-conda-forge
+          # PyPI metadata for a just-published release — especially the first
+          # release of a new package — can lag the upload by several minutes,
+          # so retry before giving up.
+          MAX_ATTEMPTS=5
+          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+            if grayskull pypi "$PACKAGE_NAME" --strict-conda-forge; then
+              break
+            fi
+            if [[ "$attempt" -eq "$MAX_ATTEMPTS" ]]; then
+              echo "::error::grayskull failed after $MAX_ATTEMPTS attempts — PyPI metadata for $PACKAGE_NAME may not be available yet"
+              exit 1
+            fi
+            echo "grayskull attempt $attempt/$MAX_ATTEMPTS failed — waiting 60s for PyPI metadata to propagate"
+            sleep 60
+          done
 
           RECIPE_PATH=$(find . -type f -path "*/meta.yaml" | head -n 1)
           if [[ -z "$RECIPE_PATH" ]]; then


### PR DESCRIPTION
## Summary

The `conda` job in the release workflow runs `grayskull pypi` immediately after the PyPI publish. PyPI metadata for a just-published release — especially the first release of a new package — can lag the upload by several minutes, making the step fail spuriously.

This wraps the `grayskull` call in a retry loop: up to 5 attempts with a 60s pause between them, emitting a `::error::` annotation if all attempts fail.

Applied to both the bundle source (`bundles/github/.github/workflows/rhiza_release.yml`) and the root dogfood carve-out copy (`.github/workflows/rhiza_release.yml`), keeping the two in sync.

## Test plan

- [x] Pre-commit hooks pass (yaml check, GitHub workflow validation, actionlint)
- [ ] Verified on the next release run of the conda job

🤖 Generated with [Claude Code](https://claude.com/claude-code)