### PR TITLE
Eliminate C-ranked complexity blocks; document mother-repo coverage (#1372, #1373)

### DIFF
--- a/.rhiza/utils/pip_audit_policy.py
+++ b/.rhiza/utils/pip_audit_policy.py
@@ -40,6 +40,37 @@ def _vuln_ids(vuln: dict) -> str:  # type: ignore[type-arg]
     return ", ".join(ids)
 
 
+def _partition_vulns(deps: list[dict]) -> tuple[list[dict], list[dict]]:  # type: ignore[type-arg]
+    """Split vulnerable dependencies into ``(tooling, runtime)`` groups.
+
+    Args:
+        deps: The ``dependencies`` list from pip-audit's JSON output.
+
+    Returns:
+        A ``(tooling, runtime)`` pair. ``tooling`` holds entries whose name is in
+        :data:`_TOOLING` (CVEs warn only); ``runtime`` holds every other vulnerable
+        entry (CVEs fail the build). Entries without vulnerabilities are dropped.
+    """
+    vulnerable = [d for d in deps if d.get("vulns")]
+    tooling = [d for d in vulnerable if d["name"].lower() in _TOOLING]
+    runtime = [d for d in vulnerable if d["name"].lower() not in _TOOLING]
+    return tooling, runtime
+
+
+def _print_vulns(deps: list[dict], colour: str, label: str, suffix: str = "") -> None:  # type: ignore[type-arg]
+    """Print one coloured line per vulnerability across ``deps``.
+
+    Args:
+        deps: Dependency entries (each with ``name``, ``version``, and ``vulns``).
+        colour: The ANSI colour escape to wrap each line in.
+        label: The bracketed tag to lead each line with (e.g. ``"WARN"`` or ``"FAIL"``).
+        suffix: Optional trailing note appended before the colour reset.
+    """
+    for dep in deps:
+        for v in dep["vulns"]:
+            print(f"{colour}[{label}] {dep['name']}=={dep['version']}: {_vuln_ids(v)}{suffix}{_RESET}")
+
+
 def main() -> int:
     """Run pip-audit and apply the tiered vulnerability policy.
 
@@ -78,22 +109,14 @@ def main() -> int:
         sys.stderr.write(proc.stderr)
         return proc.returncode
 
-    deps = data.get("dependencies", [])
-    tooling_vulns = [d for d in deps if d.get("vulns") and d["name"].lower() in _TOOLING]
-    runtime_vulns = [d for d in deps if d.get("vulns") and d["name"].lower() not in _TOOLING]
+    tooling_vulns, runtime_vulns = _partition_vulns(data.get("dependencies", []))
 
-    for dep in tooling_vulns:
-        for v in dep["vulns"]:
-            print(
-                f"{_YELLOW}[WARN] {dep['name']}=={dep['version']}: {_vuln_ids(v)} (tooling — not failing build){_RESET}"
-            )
+    _print_vulns(tooling_vulns, _YELLOW, "WARN", suffix=" (tooling — not failing build)")
 
     if not runtime_vulns:
         return 0
 
-    for dep in runtime_vulns:
-        for v in dep["vulns"]:
-            print(f"{_RED}[FAIL] {dep['name']}=={dep['version']}: {_vuln_ids(v)}{_RESET}")
+    _print_vulns(runtime_vulns, _RED, "FAIL")
     return 1
 
 

--- a/.rhiza/utils/suppression_parse.py
+++ b/.rhiza/utils/suppression_parse.py
@@ -106,6 +106,31 @@ def _is_rhiza_repo(root: Path) -> bool:
     return not (root / ".rhiza" / "template.yml").exists()
 
 
+def _match_comment(path: Path, line_no: int, comment: str) -> Suppression | None:
+    """Return the :class:`Suppression` for a comment token, or None if it matches none.
+
+    The suppression patterns are tried in order and the first match wins, so each
+    comment line is counted at most once.
+
+    Args:
+        path: The file the comment came from (recorded on the record).
+        line_no: 1-based source line of the comment.
+        comment: The raw comment token text (including the leading ``#``).
+
+    Returns:
+        A :class:`Suppression` for the first matching pattern, or None when the
+        comment carries no recognised suppression.
+    """
+    for kind, pattern in SUPPRESSION_PATTERNS:
+        match = pattern.search(comment)
+        if not match:
+            continue
+        codes_raw = match.group(1) if match.lastindex and match.group(1) else ""
+        codes = [c.strip() for c in codes_raw.split(",") if c.strip()] if codes_raw else []
+        return Suppression(file=str(path), line_no=line_no, kind=kind, codes=codes, raw=comment.strip())
+    return None
+
+
 def scan_file(path: Path) -> list[Suppression]:
     """Scan a single Python file and return all suppressions found.
 
@@ -131,22 +156,9 @@ def scan_file(path: Path) -> list[Suppression]:
         for tok_type, tok_string, tok_start, _tok_end, _line in tokens:
             if tok_type != tokenize.COMMENT:
                 continue
-            line_no = tok_start[0]
-            for kind, pattern in SUPPRESSION_PATTERNS:
-                match = pattern.search(tok_string)
-                if match:
-                    codes_raw = match.group(1) if match.lastindex and match.group(1) else ""
-                    codes = [c.strip() for c in codes_raw.split(",") if c.strip()] if codes_raw else []
-                    suppressions.append(
-                        Suppression(
-                            file=str(path),
-                            line_no=line_no,
-                            kind=kind,
-                            codes=codes,
-                            raw=tok_string.strip(),
-                        )
-                    )
-                    break  # count each comment line once
+            suppression = _match_comment(path, tok_start[0], tok_string)
+            if suppression is not None:
+                suppressions.append(suppression)
     except (tokenize.TokenError, IndentationError):
         pass  # skip files with tokenization errors or bad indentation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,17 @@ Hook targets use double-colon syntax (`pre-install::`, `post-install::`) and can
 - **Test coverage**: 90% minimum
 - **Pre-commit hooks**: `make fmt` runs ruff, markdownlint, bandit, actionlint, interrogate, jsonschema, and uv-lock validation
 
+> **Coverage in this repo (mother-repo specifics).** Rhiza has no `src/`, so `make test`
+> prints `Source folder src not found, running tests without coverage` and the main
+> `tests/` suite runs *without* a Python coverage number — by design. That suite exercises
+> Make targets, YAML, and bundle invariants behaviourally, where there is no Python module
+> to cover. The one piece of shipped Python — `.rhiza/utils/*.py` (sourced from
+> `bundles/core/.rhiza/utils/`) — **is** coverage-enforced at 100% via `make rhiza-test`
+> (run under `make validate`), which points `--cov=.rhiza/utils` at that tree. So "no
+> coverage on `make test`" is expected here and does not mean the shipped code is unmeasured.
+> Downstream consumers that adopt the `tests` bundle *do* have a `src/` and get the full 90%
+> `make test` gate.
+
 ### CI/CD
 
 This repo runs on **GitHub Actions only**: `.github/workflows/` — CI, release, docker, CodeQL, weekly, sync. There is no root `.gitlab-ci.yml` here.

--- a/bundles/core/.rhiza/utils/pip_audit_policy.py
+++ b/bundles/core/.rhiza/utils/pip_audit_policy.py
@@ -40,6 +40,37 @@ def _vuln_ids(vuln: dict) -> str:  # type: ignore[type-arg]
     return ", ".join(ids)
 
 
+def _partition_vulns(deps: list[dict]) -> tuple[list[dict], list[dict]]:  # type: ignore[type-arg]
+    """Split vulnerable dependencies into ``(tooling, runtime)`` groups.
+
+    Args:
+        deps: The ``dependencies`` list from pip-audit's JSON output.
+
+    Returns:
+        A ``(tooling, runtime)`` pair. ``tooling`` holds entries whose name is in
+        :data:`_TOOLING` (CVEs warn only); ``runtime`` holds every other vulnerable
+        entry (CVEs fail the build). Entries without vulnerabilities are dropped.
+    """
+    vulnerable = [d for d in deps if d.get("vulns")]
+    tooling = [d for d in vulnerable if d["name"].lower() in _TOOLING]
+    runtime = [d for d in vulnerable if d["name"].lower() not in _TOOLING]
+    return tooling, runtime
+
+
+def _print_vulns(deps: list[dict], colour: str, label: str, suffix: str = "") -> None:  # type: ignore[type-arg]
+    """Print one coloured line per vulnerability across ``deps``.
+
+    Args:
+        deps: Dependency entries (each with ``name``, ``version``, and ``vulns``).
+        colour: The ANSI colour escape to wrap each line in.
+        label: The bracketed tag to lead each line with (e.g. ``"WARN"`` or ``"FAIL"``).
+        suffix: Optional trailing note appended before the colour reset.
+    """
+    for dep in deps:
+        for v in dep["vulns"]:
+            print(f"{colour}[{label}] {dep['name']}=={dep['version']}: {_vuln_ids(v)}{suffix}{_RESET}")
+
+
 def main() -> int:
     """Run pip-audit and apply the tiered vulnerability policy.
 
@@ -78,22 +109,14 @@ def main() -> int:
         sys.stderr.write(proc.stderr)
         return proc.returncode
 
-    deps = data.get("dependencies", [])
-    tooling_vulns = [d for d in deps if d.get("vulns") and d["name"].lower() in _TOOLING]
-    runtime_vulns = [d for d in deps if d.get("vulns") and d["name"].lower() not in _TOOLING]
+    tooling_vulns, runtime_vulns = _partition_vulns(data.get("dependencies", []))
 
-    for dep in tooling_vulns:
-        for v in dep["vulns"]:
-            print(
-                f"{_YELLOW}[WARN] {dep['name']}=={dep['version']}: {_vuln_ids(v)} (tooling — not failing build){_RESET}"
-            )
+    _print_vulns(tooling_vulns, _YELLOW, "WARN", suffix=" (tooling — not failing build)")
 
     if not runtime_vulns:
         return 0
 
-    for dep in runtime_vulns:
-        for v in dep["vulns"]:
-            print(f"{_RED}[FAIL] {dep['name']}=={dep['version']}: {_vuln_ids(v)}{_RESET}")
+    _print_vulns(runtime_vulns, _RED, "FAIL")
     return 1
 
 

--- a/bundles/core/.rhiza/utils/suppression_parse.py
+++ b/bundles/core/.rhiza/utils/suppression_parse.py
@@ -106,6 +106,31 @@ def _is_rhiza_repo(root: Path) -> bool:
     return not (root / ".rhiza" / "template.yml").exists()
 
 
+def _match_comment(path: Path, line_no: int, comment: str) -> Suppression | None:
+    """Return the :class:`Suppression` for a comment token, or None if it matches none.
+
+    The suppression patterns are tried in order and the first match wins, so each
+    comment line is counted at most once.
+
+    Args:
+        path: The file the comment came from (recorded on the record).
+        line_no: 1-based source line of the comment.
+        comment: The raw comment token text (including the leading ``#``).
+
+    Returns:
+        A :class:`Suppression` for the first matching pattern, or None when the
+        comment carries no recognised suppression.
+    """
+    for kind, pattern in SUPPRESSION_PATTERNS:
+        match = pattern.search(comment)
+        if not match:
+            continue
+        codes_raw = match.group(1) if match.lastindex and match.group(1) else ""
+        codes = [c.strip() for c in codes_raw.split(",") if c.strip()] if codes_raw else []
+        return Suppression(file=str(path), line_no=line_no, kind=kind, codes=codes, raw=comment.strip())
+    return None
+
+
 def scan_file(path: Path) -> list[Suppression]:
     """Scan a single Python file and return all suppressions found.
 
@@ -131,22 +156,9 @@ def scan_file(path: Path) -> list[Suppression]:
         for tok_type, tok_string, tok_start, _tok_end, _line in tokens:
             if tok_type != tokenize.COMMENT:
                 continue
-            line_no = tok_start[0]
-            for kind, pattern in SUPPRESSION_PATTERNS:
-                match = pattern.search(tok_string)
-                if match:
-                    codes_raw = match.group(1) if match.lastindex and match.group(1) else ""
-                    codes = [c.strip() for c in codes_raw.split(",") if c.strip()] if codes_raw else []
-                    suppressions.append(
-                        Suppression(
-                            file=str(path),
-                            line_no=line_no,
-                            kind=kind,
-                            codes=codes,
-                            raw=tok_string.strip(),
-                        )
-                    )
-                    break  # count each comment line once
+            suppression = _match_comment(path, tok_start[0], tok_string)
+            if suppression is not None:
+                suppressions.append(suppression)
     except (tokenize.TokenError, IndentationError):
         pass  # skip files with tokenization errors or bad indentation
 

--- a/utils/link_dogfood.py
+++ b/utils/link_dogfood.py
@@ -166,6 +166,68 @@ def _link_one(root: Path, rel: str, source: Path) -> bool:
     return True
 
 
+def _classify_dogfood(root: Path, rel: str, index: dict[str, list[Path]]) -> tuple[str, Path | None]:
+    """Classify a tracked root path for dogfood linking.
+
+    This is the eligibility decision for a single file, factored out of
+    :func:`relink` so the loop there stays a straight-line consumer of the verdict.
+
+    Args:
+        root: The repository root.
+        rel: A repository-root-relative path (POSIX form, as ``git ls-files`` reports it).
+        index: The bundle index from :func:`_bundle_index`.
+
+    Returns:
+        A ``(kind, source)`` verdict:
+
+        * ``("skip", None)`` — not an eligible dogfood copy: a bundle source itself,
+          a carve-out, a path with no bundle owner, or one that diverges from every
+          owner (an undeclared mother-repo override that must stay a real file);
+        * ``("ambiguous", None)`` — byte-identical to more than one bundle source, so
+          the linker refuses to guess an owner;
+        * ``("link", source)`` — should be a relative symlink to the unique bundle
+          file ``source``.
+    """
+    # Skip bundle sources themselves and every carve-out (declared overrides,
+    # git O_NOFOLLOW files, the .github/ tree, and .rhiza/utils/) — all must stay
+    # real files. See is_dogfood_carveout for the reasoning behind each case.
+    if rel.startswith("bundles/") or is_dogfood_carveout(rel):
+        return ("skip", None)
+    owners = index.get(rel)
+    if not owners:
+        return ("skip", None)
+    root_bytes = (root / rel).read_bytes()
+    identical = [o for o in owners if o.read_bytes() == root_bytes]
+    if not identical:
+        return ("skip", None)  # diverges from every owner — an (undeclared) override; leave it real
+    if len(identical) > 1:
+        return ("ambiguous", None)
+    return ("link", identical[0])
+
+
+def _report(*, check: bool, linked: int, unchanged: int, ambiguous: list[str], pending: list[str]) -> int:
+    """Print the run summary and return the process exit code.
+
+    Args:
+        check: Whether the run was a non-writing drift check.
+        linked: Number of symlinks created (write mode).
+        unchanged: Number of files already correct.
+        ambiguous: Paths that matched more than one bundle source.
+        pending: Paths a check-mode run found not yet linked.
+
+    Returns:
+        ``0`` on success, ``1`` if anything was ambiguous or (in check mode) pending.
+    """
+    verb = "would link" if check else "linked"
+    count = len(pending) if check else linked
+    print(f"\n{BLUE}sync-self:{RESET} {count} {verb}, {unchanged} already correct, {len(ambiguous)} ambiguous")
+    for rel in ambiguous:
+        print(f"  {YELLOW}ambiguous{RESET} {rel} matches multiple bundles — link it by hand")
+    if pending:
+        print(f"{YELLOW}Dogfood symlinks are out of date — run 'make sync-self' and commit the result.{RESET}")
+    return 1 if (ambiguous or pending) else 0
+
+
 def relink(root: Path, *, check: bool = False) -> int:
     """Convert every eligible root dogfood copy into a relative symlink.
 
@@ -197,43 +259,25 @@ def relink(root: Path, *, check: bool = False) -> int:
     pending: list[str] = []
 
     for rel in _tracked_files(root):
-        # Skip bundle sources themselves and every carve-out (declared overrides,
-        # git O_NOFOLLOW files, the .github/ tree, and .rhiza/utils/) — all must stay
-        # real files. See is_dogfood_carveout for the reasoning behind each case.
-        if rel.startswith("bundles/") or is_dogfood_carveout(rel):
-            continue
-        owners = index.get(rel)
-        if not owners:
-            continue
-        root_bytes = (root / rel).read_bytes()
-        identical = [o for o in owners if o.read_bytes() == root_bytes]
-        if not identical:
-            continue  # diverges from every owner — an (undeclared) override; leave it real
-        if len(identical) > 1:
+        kind, source = _classify_dogfood(root, rel, index)
+        if kind == "ambiguous":
             ambiguous.append(rel)
             continue
-        source = identical[0]
+        if kind == "skip" or source is None:
+            continue
         if check:
-            if not _link_is_current(root, rel, source):
+            if _link_is_current(root, rel, source):
+                unchanged += 1
+            else:
                 print(f"  {YELLOW}would link{RESET} {rel} {DIM}->{RESET} {source.relative_to(root)}")
                 pending.append(rel)
-            else:
-                unchanged += 1
         elif _link_one(root, rel, source):
             print(f"  {GREEN}linked{RESET}    {rel} {DIM}->{RESET} {source.relative_to(root)}")
             linked += 1
         else:
             unchanged += 1
 
-    verb = "would link" if check else "linked"
-    count = len(pending) if check else linked
-    print(f"\n{BLUE}sync-self:{RESET} {count} {verb}, {unchanged} already correct, {len(ambiguous)} ambiguous")
-    if ambiguous:
-        for rel in ambiguous:
-            print(f"  {YELLOW}ambiguous{RESET} {rel} matches multiple bundles — link it by hand")
-    if pending:
-        print(f"{YELLOW}Dogfood symlinks are out of date — run 'make sync-self' and commit the result.{RESET}")
-    return 1 if (ambiguous or pending) else 0
+    return _report(check=check, linked=linked, unchanged=unchanged, ambiguous=ambiguous, pending=pending)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #1372, closes #1373.

## #1372 — Cyclomatic complexity

Reduced every C-or-worse `radon cc` block in the Python surface to **B or better**. (The original issue misattributed `scan_file` and `main` to `link_dogfood.py`; they actually live in the shipped bundle utils — all three are fixed here.)

| Function | File | Before | After | How |
|---|---|---|---|---|
| `relink` | `utils/link_dogfood.py` | C (20) | **B (9)** | Extracted `_classify_dogfood` (per-file eligibility verdict) and `_report` (summary + exit code); the loop is now a straight-line consumer |
| `scan_file` | `suppression_parse.py` | C (12) | **B (6)** | Extracted `_match_comment` (first-pattern-wins per comment) out of the nested loop |
| `main` | `pip_audit_policy.py` | C (15) | **A (5)** | Extracted `_partition_vulns` (tooling/runtime split) and `_print_vulns` (dedup'd the two reporting loops) |

The two bundle-source edits (`bundles/core/.rhiza/utils/*`) are mirrored to their real-copy carve-outs under `.rhiza/utils/` — those are byte-identical copies guarded by `test_bundle_rhiza_sync.py`, not symlinks.

**Acceptance:** `radon cc` shows no C-or-worse block anywhere in the touched files; worst is now B(9).

## #1373 — Coverage invariant

Added a note under *Code Quality Requirements* in `CLAUDE.md` explaining that `make test` runs without a Python coverage number by design (no `src/`), that `.rhiza/utils/*.py` **is** enforced at 100% via `make rhiza-test`, and that downstream consumers with a `src/` get the full 90% gate.

## Verification (all green)

- `make fmt` ✅
- `make typecheck` ✅ (ty + mypy strict)
- `make validate` ✅ — **100.0%** coverage on `.rhiza/utils` (new helpers all covered)
- `make test` ✅ — **1194 passed**
- `radon cc` ✅ — no C-or-worse block remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)