### PR TITLE
Add opt-in quality-review bundles: advisory Claude design review on PRs/MRs (GitHub + GitLab)

### DIFF
--- a/.github/workflows/rhiza_quality_review.yml
+++ b/.github/workflows/rhiza_quality_review.yml
@@ -1,0 +1,114 @@
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
+#
+# Workflow: Quality Review (Claude, reusable)
+#
+# Purpose: Run the agentic `/rhiza_quality` scorecard on a pull request using
+#          Claude Code in headless mode, and post the result as a PR comment.
+#          This SUPPLEMENTS the deterministic make-based quality gates (see
+#          rhiza_ci.yml); it adds a qualitative scorecard across lint, types,
+#          docs, deps, security, tests, complexity and architecture. It is
+#          ADVISORY: do NOT add it to a branch-protection required-checks set.
+#
+#          Cost & privacy: this workflow spends Anthropic API tokens on every
+#          run and sends repo context to the Anthropic API. It is therefore
+#          STRICTLY OPT-IN, gated twice:
+#            1. the repo must include the `github-quality-review` bundle
+#               (so the calling stub exists at all), AND
+#            2. the repo (or org) must set the `CLAUDE_QUALITY_REVIEW_ENABLED`
+#               variable to 'true' AND provide the `ANTHROPIC_API_KEY` secret.
+#          If either the variable or the secret is missing, the job no-ops.
+#
+#          Thin-stub consumers live in the `github-quality-review` bundle and
+#          delegate here via `uses:` on pull_request.
+#
+# Trigger: workflow_call (invoked by the downstream stub).
+
+name: "(RHIZA) QUALITY REVIEW"
+
+# Cancel superseded in-progress runs for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_call:
+    secrets:
+      ANTHROPIC_API_KEY:
+        required: false
+      GH_PAT:
+        required: false
+      UV_EXTRA_INDEX_URL:
+        required: false
+
+permissions:
+  contents: read
+  pull-requests: write   # post the scorecard as a PR comment
+
+jobs:
+  quality-review:
+    # Opt-in gate #2: the repo/org must explicitly enable the review.
+    if: ${{ vars.CLAUDE_QUALITY_REVIEW_ENABLED == 'true' }}
+    name: Claude quality scorecard (advisory)
+    # Generous budget: an agentic run that shells out to the make quality gates.
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          lfs: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          version: "0.11.16"
+
+      - name: Configure git auth for private packages
+        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v0.19.9
+        with:
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Guard on ANTHROPIC_API_KEY presence
+        id: guard
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [[ -z "${ANTHROPIC_API_KEY}" ]]; then
+            echo "::notice::ANTHROPIC_API_KEY not configured; skipping the Claude quality review."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run /rhiza_quality (Claude Code)
+        if: steps.guard.outputs.enabled == 'true'
+        # TODO(pin): pin anthropics/claude-code-action to a commit SHA to match
+        # this repo's harden-runner SHA-pinning policy once a release SHA is chosen.
+        uses: anthropics/claude-code-action@v1
+        env:
+          UV_EXTRA_INDEX_URL: ${{ secrets.UV_EXTRA_INDEX_URL }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Invoke the synced /rhiza_quality command, but force a non-interactive,
+          # report-only run: the command normally ends with an AskUserQuestion
+          # issue-filing menu, which cannot run in CI.
+          prompt: |
+            /rhiza_quality
+
+            CI mode — this is a non-interactive run. Run every quality gate and
+            output a concise PASS/FAIL scorecard as your final message. Do NOT
+            use AskUserQuestion and do NOT create or file any issues; stop after
+            the scorecard.
+          # Read-only inspection plus the make quality gates. Deliberately no
+          # `gh issue` / `glab issue` tools so the run cannot file issues.
+          claude_args: >-
+            --max-turns 30
+            --allowedTools "Read,Grep,Glob,Bash(make *),Bash(git status),Bash(git diff *),Bash(git log *),Bash(uvx *),Bash(find *),Bash(wc *),Bash(sed *),Bash(sort *),Bash(uniq *)"

--- a/.github/workflows/rhiza_quality_review.yml
+++ b/.github/workflows/rhiza_quality_review.yml
@@ -84,9 +84,7 @@ jobs:
 
       - name: Review the PR diff (Claude Code)
         if: steps.guard.outputs.enabled == 'true'
-        # TODO(pin): pin anthropics/claude-code-action to a commit SHA to match
-        # this repo's harden-runner SHA-pinning policy once a release SHA is chosen.
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@f87768c6d25f92ae6efa7175e223ef77d4cbf97f # v1.0.166
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rhiza_quality_review.yml
+++ b/.github/workflows/rhiza_quality_review.yml
@@ -3,16 +3,24 @@
 #
 # Workflow: Quality Review (Claude, reusable)
 #
-# Purpose: Run the agentic `/rhiza_quality` scorecard on a pull request using
-#          Claude Code in headless mode, and post the result as a PR comment.
-#          This SUPPLEMENTS the deterministic make-based quality gates (see
-#          rhiza_ci.yml); it adds a qualitative scorecard across lint, types,
-#          docs, deps, security, tests, complexity and architecture. It is
-#          ADVISORY: do NOT add it to a branch-protection required-checks set.
+# Purpose: Advisory, agentic *design review* of a pull request's diff, posted as
+#          a PR comment. It deliberately does NOT re-run the deterministic
+#          quality gates (fmt / lint / typecheck / deptry / docs-coverage /
+#          security / tests) — those are already run for free by rhiza_ci
+#          (and the GitLab quality pipeline). Re-running them here would just
+#          burn Anthropic tokens duplicating a signal CI already gives you.
 #
-#          Cost & privacy: this workflow spends Anthropic API tokens on every
-#          run and sends repo context to the Anthropic API. It is therefore
-#          STRICTLY OPT-IN, gated twice:
+#          Instead it focuses only on the judgment a linter cannot produce:
+#            - architecture / design fit of the change
+#            - unnecessary complexity and simpler alternatives
+#            - test-coverage gaps introduced by the diff
+#          If a deterministic gate is red, it defers to CI rather than re-judging.
+#
+#          Advisory: do NOT add it to a branch-protection required-checks set.
+#
+#          Cost & privacy: it spends Anthropic API tokens on every run and sends
+#          diff/context to the Anthropic API. It is therefore STRICTLY OPT-IN,
+#          gated twice:
 #            1. the repo must include the `github-quality-review` bundle
 #               (so the calling stub exists at all), AND
 #            2. the repo (or org) must set the `CLAUDE_QUALITY_REVIEW_ENABLED`
@@ -36,22 +44,18 @@ on:
     secrets:
       ANTHROPIC_API_KEY:
         required: false
-      GH_PAT:
-        required: false
-      UV_EXTRA_INDEX_URL:
-        required: false
 
 permissions:
   contents: read
-  pull-requests: write   # post the scorecard as a PR comment
+  pull-requests: write   # post the review as a PR comment
 
 jobs:
   quality-review:
     # Opt-in gate #2: the repo/org must explicitly enable the review.
     if: ${{ vars.CLAUDE_QUALITY_REVIEW_ENABLED == 'true' }}
-    name: Claude quality scorecard (advisory)
-    # Generous budget: an agentic run that shells out to the make quality gates.
-    timeout-minutes: 20
+    name: Claude design review (advisory)
+    # A diff review reads code; it does not build or run gates, so it is quick.
+    timeout-minutes: 10
     runs-on: ubuntu-latest
 
     steps:
@@ -63,17 +67,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          lfs: true
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
-        with:
-          version: "0.11.16"
-
-      - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v0.19.9
-        with:
-          token: ${{ secrets.GH_PAT }}
+          # Full history so the review can diff the PR against its base branch.
+          fetch-depth: 0
 
       - name: Guard on ANTHROPIC_API_KEY presence
         id: guard
@@ -81,34 +76,43 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           if [[ -z "${ANTHROPIC_API_KEY}" ]]; then
-            echo "::notice::ANTHROPIC_API_KEY not configured; skipping the Claude quality review."
+            echo "::notice::ANTHROPIC_API_KEY not configured; skipping the Claude design review."
             echo "enabled=false" >> "$GITHUB_OUTPUT"
           else
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Run /rhiza_quality (Claude Code)
+      - name: Review the PR diff (Claude Code)
         if: steps.guard.outputs.enabled == 'true'
         # TODO(pin): pin anthropics/claude-code-action to a commit SHA to match
         # this repo's harden-runner SHA-pinning policy once a release SHA is chosen.
         uses: anthropics/claude-code-action@v1
-        env:
-          UV_EXTRA_INDEX_URL: ${{ secrets.UV_EXTRA_INDEX_URL }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          # Invoke the synced /rhiza_quality command, but force a non-interactive,
-          # report-only run: the command normally ends with an AskUserQuestion
-          # issue-filing menu, which cannot run in CI.
+          # Non-interactive design review. Explicitly NOT the /rhiza_quality
+          # command — that re-runs the make gates, which rhiza_ci already covers.
           prompt: |
-            /rhiza_quality
+            Review this pull request's diff against its base branch
+            (`git diff origin/${{ github.base_ref }}...HEAD`).
 
-            CI mode — this is a non-interactive run. Run every quality gate and
-            output a concise PASS/FAIL scorecard as your final message. Do NOT
-            use AskUserQuestion and do NOT create or file any issues; stop after
-            the scorecard.
-          # Read-only inspection plus the make quality gates. Deliberately no
-          # `gh issue` / `glab issue` tools so the run cannot file issues.
+            Do NOT run make/lint/typecheck/test/deptry/security gates — the CI
+            workflow (rhiza_ci) already runs those deterministically. If you
+            suspect a gate would fail, defer to CI and do not re-judge it.
+
+            Focus ONLY on what those gates cannot assess, scoped to the changed
+            lines:
+              1. Architecture & design fit — does the change belong where it is;
+                 does it respect the repo's conventions in CLAUDE.md?
+              2. Unnecessary complexity — call out anything with a materially
+                 simpler equivalent, with a concrete suggestion.
+              3. Test-coverage gaps — new/changed behaviour left unexercised.
+
+            Be concise. If there is nothing material to flag, say so in one line.
+            Post your review as a single PR comment. This is a non-interactive
+            run: do NOT use AskUserQuestion and do NOT create issues.
+          # Read-only inspection plus git history for diffing. No `make`, no
+          # issue-filing tools.
           claude_args: >-
-            --max-turns 30
-            --allowedTools "Read,Grep,Glob,Bash(make *),Bash(git status),Bash(git diff *),Bash(git log *),Bash(uvx *),Bash(find *),Bash(wc *),Bash(sed *),Bash(sort *),Bash(uniq *)"
+            --max-turns 15
+            --allowedTools "Read,Grep,Glob,Bash(git diff *),Bash(git log *),Bash(git show *),Bash(git status)"

--- a/.rhiza/template-bundles.yml
+++ b/.rhiza/template-bundles.yml
@@ -250,15 +250,17 @@ bundles:
   # GITHUB-QUALITY-REVIEW - Advisory agentic quality scorecard (Claude Code)
   # ============================================================================
   github-quality-review:
-    description: "GitHub Actions workflow stub for the advisory Claude quality scorecard (runs /rhiza_quality on PRs)"
+    description: "GitHub Actions workflow stub for an advisory Claude design review of PR diffs (opt-in)"
     standalone: true
     requires: [core, github]
     notes: |
-      Opt-in only, and deliberately NOT part of any profile. This workflow runs
-      the /rhiza_quality command via Claude Code on each pull request and posts
-      the result as an advisory PR comment — it supplements, and never replaces,
-      the deterministic make gates in rhiza_ci.
-      Cost & privacy: it spends Anthropic API tokens on every run and sends repo
+      Opt-in only, and deliberately NOT part of any profile. On each pull
+      request this runs an advisory Claude design review of the diff — covering
+      only what the deterministic gates cannot: architecture/design fit,
+      unnecessary complexity, and test-coverage gaps. It deliberately does NOT
+      re-run fmt/lint/typecheck/test/deptry/security; rhiza_ci already runs those
+      deterministically, so re-running them here would only waste tokens.
+      Cost & privacy: it spends Anthropic API tokens on every run and sends diff
       context to the Anthropic API. It stays dormant until BOTH the
       CLAUDE_QUALITY_REVIEW_ENABLED variable is 'true' AND the ANTHROPIC_API_KEY
       secret is set (an org-level secret is the cleanest distribution).

--- a/.rhiza/template-bundles.yml
+++ b/.rhiza/template-bundles.yml
@@ -178,6 +178,27 @@ bundles:
     requires: [book, gitlab]
 
   # ============================================================================
+  # GITLAB-QUALITY-REVIEW - Advisory agentic design review (Claude Code, GitLab)
+  # ============================================================================
+  gitlab-quality-review:
+    description: "GitLab CI job for an advisory Claude design review of MR diffs (opt-in)"
+    standalone: true
+    requires: [core, gitlab]
+    notes: |
+      GitLab counterpart of github-quality-review. Opt-in only, and deliberately
+      NOT part of any profile. On merge-request pipelines it runs an advisory
+      Claude design review of the diff via the headless claude CLI — covering
+      only what the deterministic gates cannot: architecture/design fit,
+      unnecessary complexity, and test-coverage gaps. It does NOT re-run
+      fmt/typecheck/deptry/security/validate/test; the CI + quality pipelines
+      already run those. The review is written to the job log and the job is
+      allow_failure so it never blocks the MR.
+      Cost & privacy: spends Anthropic API tokens per run and sends diff context
+      to the Anthropic API. Stays dormant until BOTH the
+      CLAUDE_QUALITY_REVIEW_ENABLED CI/CD variable is 'true' AND the
+      ANTHROPIC_API_KEY CI/CD variable is set (masked).
+
+  # ============================================================================
   # TESTS - Testing infrastructure with pytest, coverage, and type checking
   # ============================================================================
   tests:

--- a/.rhiza/template-bundles.yml
+++ b/.rhiza/template-bundles.yml
@@ -191,7 +191,9 @@ bundles:
       only what the deterministic gates cannot: architecture/design fit,
       unnecessary complexity, and test-coverage gaps. It does NOT re-run
       fmt/typecheck/deptry/security/validate/test; the CI + quality pipelines
-      already run those. The review is written to the job log and the job is
+      already run those. The review is posted as a merge-request note when a
+      token with `api` scope is available (CLAUDE_REVIEW_GITLAB_TOKEN, falling
+      back to CI_JOB_TOKEN), and always echoed to the job log. The job is
       allow_failure so it never blocks the MR.
       Cost & privacy: spends Anthropic API tokens per run and sends diff context
       to the Anthropic API. Stays dormant until BOTH the

--- a/.rhiza/template-bundles.yml
+++ b/.rhiza/template-bundles.yml
@@ -246,6 +246,24 @@ bundles:
     standalone: true
     requires: [book, github]
 
+  # ============================================================================
+  # GITHUB-QUALITY-REVIEW - Advisory agentic quality scorecard (Claude Code)
+  # ============================================================================
+  github-quality-review:
+    description: "GitHub Actions workflow stub for the advisory Claude quality scorecard (runs /rhiza_quality on PRs)"
+    standalone: true
+    requires: [core, github]
+    notes: |
+      Opt-in only, and deliberately NOT part of any profile. This workflow runs
+      the /rhiza_quality command via Claude Code on each pull request and posts
+      the result as an advisory PR comment — it supplements, and never replaces,
+      the deterministic make gates in rhiza_ci.
+      Cost & privacy: it spends Anthropic API tokens on every run and sends repo
+      context to the Anthropic API. It stays dormant until BOTH the
+      CLAUDE_QUALITY_REVIEW_ENABLED variable is 'true' AND the ANTHROPIC_API_KEY
+      secret is set (an org-level secret is the cleanest distribution).
+      Do not add it to a branch-protection required-checks set — it is advisory.
+
 # ==============================================================================
 # PROFILE DEFINITIONS
 #

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ The core abstraction is the **bundle** — a named group of configuration files.
 - `paper`: LaTeX paper compilation
 - `lfs`, `legal`, `renovate`: miscellaneous tooling
 
-**Platform overlay bundles** — CI workflow stubs that pair a feature with a platform: `github-tests`, `github-book`, `github-marimo`, `github-docker`, `github-devcontainer`, `github-paper`, `github-quality-review`, `gitlab-tests`, `gitlab-book`, `gitlab-marimo`.
+**Platform overlay bundles** — CI workflow stubs that pair a feature with a platform: `github-tests`, `github-book`, `github-marimo`, `github-docker`, `github-devcontainer`, `github-paper`, `github-quality-review`, `gitlab-tests`, `gitlab-book`, `gitlab-marimo`, `gitlab-quality-review`.
 
 **Meta-bundles** — curated compositions of other bundles: `github-project`, `gitlab-project`, `local` (no hosted CI).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ The core abstraction is the **bundle** — a named group of configuration files.
 - `paper`: LaTeX paper compilation
 - `lfs`, `legal`, `renovate`: miscellaneous tooling
 
-**Platform overlay bundles** — CI workflow stubs that pair a feature with a platform: `github-tests`, `github-book`, `github-marimo`, `github-docker`, `github-devcontainer`, `github-paper`, `gitlab-tests`, `gitlab-book`, `gitlab-marimo`.
+**Platform overlay bundles** — CI workflow stubs that pair a feature with a platform: `github-tests`, `github-book`, `github-marimo`, `github-docker`, `github-devcontainer`, `github-paper`, `github-quality-review`, `gitlab-tests`, `gitlab-book`, `gitlab-marimo`.
 
 **Meta-bundles** — curated compositions of other bundles: `github-project`, `gitlab-project`, `local` (no hosted CI).
 

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Any bundle can be selected on its own — its dependencies are resolved and inst
 | `github-docker` | GitHub Actions workflow for Docker image building and publishing | `github`, `docker`, `core` |
 | `github-devcontainer` | GitHub Actions workflow for DevContainer image publishing | `github`, `devcontainer`, `core` |
 | `github-paper` | GitHub Actions workflow for LaTeX paper compilation and PDF publishing | `github`, `paper`, `core` |
-| `github-quality-review` | Advisory Claude quality scorecard on PRs (opt-in; runs `/rhiza_quality`) | `github`, `core` |
+| `github-quality-review` | Advisory Claude design review of PR diffs — architecture, complexity, test gaps (opt-in) | `github`, `core` |
 
 **Platform bundles — GitLab**
 

--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ Any bundle can be selected on its own — its dependencies are resolved and inst
 | `github-docker` | GitHub Actions workflow for Docker image building and publishing | `github`, `docker`, `core` |
 | `github-devcontainer` | GitHub Actions workflow for DevContainer image publishing | `github`, `devcontainer`, `core` |
 | `github-paper` | GitHub Actions workflow for LaTeX paper compilation and PDF publishing | `github`, `paper`, `core` |
+| `github-quality-review` | Advisory Claude quality scorecard on PRs (opt-in; runs `/rhiza_quality`) | `github`, `core` |
 
 **Platform bundles — GitLab**
 

--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ Any bundle can be selected on its own — its dependencies are resolved and inst
 | `gitlab-tests` | GitLab CI pipeline for test automation | `gitlab`, `tests`, `core` |
 | `gitlab-marimo` | GitLab CI pipeline for Marimo notebook execution | `gitlab`, `marimo`, `book`, `core` |
 | `gitlab-book` | GitLab CI pipeline for documentation publishing to GitLab Pages | `gitlab`, `book`, `core` |
+| `gitlab-quality-review` | Advisory Claude design review of MR diffs — architecture, complexity, test gaps (opt-in) | `gitlab`, `core` |
 
 For a complete reference of every file included in each bundle, see [`.rhiza/template-bundles.yml`](.rhiza/template-bundles.yml).
 

--- a/bundles/github-quality-review/.github/workflows/rhiza_quality_review.yml
+++ b/bundles/github-quality-review/.github/workflows/rhiza_quality_review.yml
@@ -1,0 +1,37 @@
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
+#
+# Workflow: Quality Review (Claude)
+#
+# Purpose: Advisory, agentic code-quality scorecard for pull requests. Runs the
+#          synced `/rhiza_quality` command via Claude Code and posts the result
+#          as a PR comment. SUPPLEMENTS the deterministic make gates in the CI
+#          workflow — it is not a replacement and MUST NOT be a required check.
+#
+#          Thin stub: all logic, cost gating, and the enablement gate live in
+#          the reusable workflow in jebel-quant/rhiza; this file only wires up
+#          the pull_request trigger and inherits secrets.
+#
+# Setup (required — the workflow no-ops until both are present):
+#   1. Set the repository (or org) variable CLAUDE_QUALITY_REVIEW_ENABLED=true.
+#   2. Provide the ANTHROPIC_API_KEY secret — cleanest as an organisation
+#      secret so every opted-in repo inherits it.
+#   NOTE: this workflow spends Anthropic API tokens on every PR and sends repo
+#         context to the Anthropic API. Enable it only where that is acceptable.
+#
+# Trigger: On pull_request (opened / synchronize / reopened).
+
+name: "(RHIZA) QUALITY REVIEW"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  quality-review:
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_quality_review.yml@v1.0.2
+    secrets: inherit

--- a/bundles/github-quality-review/.github/workflows/rhiza_quality_review.yml
+++ b/bundles/github-quality-review/.github/workflows/rhiza_quality_review.yml
@@ -3,10 +3,11 @@
 #
 # Workflow: Quality Review (Claude)
 #
-# Purpose: Advisory, agentic code-quality scorecard for pull requests. Runs the
-#          synced `/rhiza_quality` command via Claude Code and posts the result
-#          as a PR comment. SUPPLEMENTS the deterministic make gates in the CI
-#          workflow — it is not a replacement and MUST NOT be a required check.
+# Purpose: Advisory, agentic *design review* of a pull request's diff, posted as
+#          a PR comment. It covers only what the deterministic gates cannot —
+#          architecture/design fit, unnecessary complexity, and test-coverage
+#          gaps. It deliberately does NOT re-run fmt/lint/typecheck/test/deptry/
+#          security; rhiza_ci already runs those. MUST NOT be a required check.
 #
 #          Thin stub: all logic, cost gating, and the enablement gate live in
 #          the reusable workflow in jebel-quant/rhiza; this file only wires up
@@ -16,7 +17,7 @@
 #   1. Set the repository (or org) variable CLAUDE_QUALITY_REVIEW_ENABLED=true.
 #   2. Provide the ANTHROPIC_API_KEY secret — cleanest as an organisation
 #      secret so every opted-in repo inherits it.
-#   NOTE: this workflow spends Anthropic API tokens on every PR and sends repo
+#   NOTE: this workflow spends Anthropic API tokens on every PR and sends diff
 #         context to the Anthropic API. Enable it only where that is acceptable.
 #
 # Trigger: On pull_request (opened / synchronize / reopened).

--- a/bundles/gitlab-quality-review/.gitlab/workflows/rhiza_quality_review.yml
+++ b/bundles/gitlab-quality-review/.gitlab/workflows/rhiza_quality_review.yml
@@ -12,7 +12,11 @@
 #          test) — the GitLab quality + CI pipelines already run those. It
 #          focuses only on what a linter cannot judge, scoped to the changed
 #          lines: architecture/design fit, unnecessary complexity, and
-#          test-coverage gaps. The review is written to the job log.
+#          test-coverage gaps.
+#
+#          Output: posts the review as a merge-request note (comment) when a
+#          token with API scope is available, and always echoes it to the job
+#          log as a fallback.
 #
 #          Advisory: `allow_failure: true` so it never blocks the pipeline.
 #
@@ -23,6 +27,12 @@
 #            2. set the CLAUDE_QUALITY_REVIEW_ENABLED CI/CD variable to 'true'
 #               AND provide the ANTHROPIC_API_KEY CI/CD variable (masked).
 #          If ANTHROPIC_API_KEY is absent the job exits early without spending.
+#
+#          MR-note posting needs an API token. It prefers the
+#          CLAUDE_REVIEW_GITLAB_TOKEN CI/CD variable (a project/group access
+#          token with `api` scope), falling back to CI_JOB_TOKEN where the
+#          instance permits it. If neither can post, the review stays in the
+#          job log.
 #
 # Trigger: merge request pipelines only (wired in .gitlab-ci.yml).
 
@@ -49,6 +59,8 @@ quality-review:claude:
     - npm install -g @anthropic-ai/claude-code
     - git fetch --depth=0 origin "${CI_MERGE_REQUEST_TARGET_BRANCH_NAME}"
     - |
+      echo "### 🤖 Claude design review (advisory)" > review.md
+      echo "" >> review.md
       claude -p "Review this merge request's diff against its target branch (git diff origin/${CI_MERGE_REQUEST_TARGET_BRANCH_NAME}...HEAD).
 
       Do NOT run make/lint/typecheck/test/deptry/security gates — the GitLab CI pipeline already runs those deterministically. If you suspect a gate would fail, defer to CI and do not re-judge it.
@@ -60,4 +72,24 @@ quality-review:claude:
 
       Be concise. If there is nothing material to flag, say so in one line. This is a non-interactive run: do NOT ask any questions and do NOT create issues." \
         --max-turns 15 \
-        --allowedTools "Read,Grep,Glob,Bash(git diff *),Bash(git log *),Bash(git show *),Bash(git status)"
+        --allowedTools "Read,Grep,Glob,Bash(git diff *),Bash(git log *),Bash(git show *),Bash(git status)" \
+        | tee -a review.md
+    - |
+      # Post the review as an MR note when possible; otherwise it stays in the
+      # job log above. Prefer a dedicated API-scoped token; fall back to the
+      # job token where the instance allows it.
+      GL_TOKEN="${CLAUDE_REVIEW_GITLAB_TOKEN:-${CI_JOB_TOKEN:-}}"
+      if [ -n "${CI_MERGE_REQUEST_IID:-}" ] && [ -n "${GL_TOKEN}" ]; then
+        if curl --silent --show-error --fail \
+             --request POST \
+             --header "PRIVATE-TOKEN: ${GL_TOKEN}" \
+             --data-urlencode "body@review.md" \
+             --output /dev/null \
+             "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/merge_requests/${CI_MERGE_REQUEST_IID}/notes"; then
+          echo "Posted the review as an MR note."
+        else
+          echo "WARNING: could not post the MR note (token may lack 'api' scope); the review is in the job log above."
+        fi
+      else
+        echo "No MR context or token available; the review is in the job log above."
+      fi

--- a/bundles/gitlab-quality-review/.gitlab/workflows/rhiza_quality_review.yml
+++ b/bundles/gitlab-quality-review/.gitlab/workflows/rhiza_quality_review.yml
@@ -1,0 +1,63 @@
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
+#
+# Workflow: Quality Review (Claude, GitLab CI)
+#
+# Purpose: Advisory, agentic *design review* of a merge request's diff, run via
+#          the headless Claude Code CLI. GitLab equivalent of the GitHub
+#          rhiza_quality_review workflow.
+#
+#          It deliberately does NOT re-run the deterministic quality gates
+#          (fmt / typecheck / docs-coverage / deptry / security / validate /
+#          test) — the GitLab quality + CI pipelines already run those. It
+#          focuses only on what a linter cannot judge, scoped to the changed
+#          lines: architecture/design fit, unnecessary complexity, and
+#          test-coverage gaps. The review is written to the job log.
+#
+#          Advisory: `allow_failure: true` so it never blocks the pipeline.
+#
+#          Cost & privacy: spends Anthropic API tokens on every run and sends
+#          diff context to the Anthropic API. STRICTLY OPT-IN, gated twice:
+#            1. include the `gitlab-quality-review` bundle (ships this file, so
+#               the base .gitlab-ci.yml `exists`-include picks it up), AND
+#            2. set the CLAUDE_QUALITY_REVIEW_ENABLED CI/CD variable to 'true'
+#               AND provide the ANTHROPIC_API_KEY CI/CD variable (masked).
+#          If ANTHROPIC_API_KEY is absent the job exits early without spending.
+#
+# Trigger: merge request pipelines only (wired in .gitlab-ci.yml).
+
+quality-review:claude:
+  # CI budget: ≤10 min (reads the diff; runs no gates).
+  timeout: 10m
+  stage: test
+  needs: []
+  image: node:22-bookworm
+  # Advisory only — must never block the merge request.
+  allow_failure: true
+  variables:
+    # Full history so the review can diff against the MR target branch.
+    GIT_DEPTH: "0"
+  rules:
+    # Opt-in gate #2: MRs only, and only when explicitly enabled.
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event" && $CLAUDE_QUALITY_REVIEW_ENABLED == "true"
+  script:
+    - |
+      if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+        echo "ANTHROPIC_API_KEY not configured; skipping the Claude design review."
+        exit 0
+      fi
+    - npm install -g @anthropic-ai/claude-code
+    - git fetch --depth=0 origin "${CI_MERGE_REQUEST_TARGET_BRANCH_NAME}"
+    - |
+      claude -p "Review this merge request's diff against its target branch (git diff origin/${CI_MERGE_REQUEST_TARGET_BRANCH_NAME}...HEAD).
+
+      Do NOT run make/lint/typecheck/test/deptry/security gates — the GitLab CI pipeline already runs those deterministically. If you suspect a gate would fail, defer to CI and do not re-judge it.
+
+      Focus ONLY on what those gates cannot assess, scoped to the changed lines:
+        1. Architecture & design fit — does the change belong where it is; does it respect the repo's conventions in CLAUDE.md?
+        2. Unnecessary complexity — call out anything with a materially simpler equivalent, with a concrete suggestion.
+        3. Test-coverage gaps — new/changed behaviour left unexercised.
+
+      Be concise. If there is nothing material to flag, say so in one line. This is a non-interactive run: do NOT ask any questions and do NOT create issues." \
+        --max-turns 15 \
+        --allowedTools "Read,Grep,Glob,Bash(git diff *),Bash(git log *),Bash(git show *),Bash(git status)"

--- a/bundles/gitlab/.gitlab-ci.yml
+++ b/bundles/gitlab/.gitlab-ci.yml
@@ -55,6 +55,15 @@ include:
       - if: $CI_PIPELINE_SOURCE == "merge_request_event"
       - if: $CI_COMMIT_BRANCH
 
+  # Quality Review - Advisory Claude design review of the MR diff (opt-in).
+  # `exists` keeps this a no-op unless the gitlab-quality-review bundle is
+  # synced; the job itself further gates on CLAUDE_QUALITY_REVIEW_ENABLED.
+  - local: '.gitlab/workflows/rhiza_quality_review.yml'
+    rules:
+      - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+        exists:
+          - '.gitlab/workflows/rhiza_quality_review.yml'
+
   # Marimo Notebooks - Run and publish notebook artefacts
   - local: '.gitlab/workflows/rhiza_marimo.yml'
     rules:

--- a/docs/reference/BUNDLE_TAXONOMY.md
+++ b/docs/reference/BUNDLE_TAXONOMY.md
@@ -65,6 +65,7 @@ that matches your platform *and* the feature bundle it pairs with.
 | `github-docker` | `docker` → GitHub Actions lint/build/scan |
 | `github-devcontainer` | `devcontainer` → GitHub Actions image build validation |
 | `github-paper` | `paper` → GitHub Actions LaTeX build + PDF publishing |
+| `github-quality-review` | `core` → GitHub Actions advisory Claude design review of PR diffs (opt-in) |
 | `gitlab-tests` | `tests` → GitLab CI |
 | `gitlab-book` | `book` → GitLab Pages publishing |
 | `gitlab-marimo` | `marimo` → GitLab CI notebook execution |

--- a/docs/reference/BUNDLE_TAXONOMY.md
+++ b/docs/reference/BUNDLE_TAXONOMY.md
@@ -69,6 +69,7 @@ that matches your platform *and* the feature bundle it pairs with.
 | `gitlab-tests` | `tests` → GitLab CI |
 | `gitlab-book` | `book` → GitLab Pages publishing |
 | `gitlab-marimo` | `marimo` → GitLab CI notebook execution |
+| `gitlab-quality-review` | `core` → GitLab CI advisory Claude design review of MR diffs (opt-in) |
 
 ## Profiles (meta-presets)
 

--- a/docs/reference/GLOSSARY.md
+++ b/docs/reference/GLOSSARY.md
@@ -76,6 +76,7 @@ flowchart LR
         gitlab_tests["gitlab-tests"]
         gitlab_marimo["gitlab-marimo"]
         gitlab_book["gitlab-book"]
+        gitlab_quality_review["gitlab-quality-review"]
     end
 
     github --> core
@@ -106,6 +107,8 @@ flowchart LR
     gitlab_marimo --> gitlab
     gitlab_book --> book
     gitlab_book --> gitlab
+    gitlab_quality_review --> core
+    gitlab_quality_review --> gitlab
     presentation -.-> marimo
     book -.-> tests
     book -.-> marimo

--- a/docs/reference/GLOSSARY.md
+++ b/docs/reference/GLOSSARY.md
@@ -68,6 +68,7 @@ flowchart LR
         github_tests["github-tests"]
         github_marimo["github-marimo"]
         github_book["github-book"]
+        github_quality_review["github-quality-review"]
     end
 
     subgraph GitLab["GitLab base and overlays"]
@@ -97,6 +98,8 @@ flowchart LR
     github_marimo --> github
     github_book --> book
     github_book --> github
+    github_quality_review --> core
+    github_quality_review --> github
     gitlab_tests --> tests
     gitlab_tests --> gitlab
     gitlab_marimo --> marimo

--- a/tests/bundles/test_bundle_combinations.py
+++ b/tests/bundles/test_bundle_combinations.py
@@ -57,6 +57,18 @@ def _gitlab_jobs_from_includes(project: Path) -> dict[str, dict]:
         local_path = include.get("local") if isinstance(include, dict) else None
         if not local_path:
             continue
+        # Honour GitLab `exists:` include rules: an include guarded by an
+        # `exists` clause is a no-op when the referenced file is absent (used by
+        # opt-in overlay bundles such as gitlab-quality-review). Skip it here so
+        # the profile-sync assertions match what GitLab would actually run.
+        skip = False
+        for rule in include.get("rules", []) if isinstance(include, dict) else []:
+            exists = rule.get("exists") if isinstance(rule, dict) else None
+            if exists and not any((project / candidate).exists() for candidate in exists):
+                skip = True
+                break
+        if skip:
+            continue
         workflow = _load_yaml(project / local_path)
         for name, job in workflow.items():
             if isinstance(job, dict) and not name.startswith("."):

--- a/tests/bundles/test_overlay_bundles.py
+++ b/tests/bundles/test_overlay_bundles.py
@@ -131,6 +131,12 @@ _OVERLAYS: tuple[OverlaySpec, ...] = (
         feature="marimo",
         workflows=("rhiza_marimo.yml",),
     ),
+    OverlaySpec(
+        bundle="gitlab-quality-review",
+        platform="gitlab",
+        feature="core",
+        workflows=("rhiza_quality_review.yml",),
+    ),
 )
 
 _OVERLAY_IDS = tuple(spec.bundle for spec in _OVERLAYS)

--- a/tests/bundles/test_overlay_bundles.py
+++ b/tests/bundles/test_overlay_bundles.py
@@ -107,6 +107,13 @@ _OVERLAYS: tuple[OverlaySpec, ...] = (
         feature_workflows=("rhiza_paper.yml",),
     ),
     OverlaySpec(
+        bundle="github-quality-review",
+        platform="github",
+        feature="core",
+        workflows=("rhiza_quality_review.yml",),
+        feature_workflows=("rhiza_quality_review.yml",),
+    ),
+    OverlaySpec(
         bundle="gitlab-tests",
         platform="gitlab",
         feature="tests",


### PR DESCRIPTION
## Summary

Adds **opt-in** overlay bundles that run an **advisory Claude design review** of a pull/merge request's diff and surface it to the author — on **both GitHub (`github-quality-review`) and GitLab (`gitlab-quality-review`)**.

It deliberately does **not** re-run the deterministic quality gates (`fmt`, `typecheck`, `docs-coverage`, `deptry`, `security`, `validate`, `test`) — `rhiza_ci` / the GitLab CI+quality pipelines already run those for free, so re-running them via an agent would just burn Anthropic tokens duplicating a signal CI already provides.

Instead it reviews only what those gates cannot assess, scoped to the changed lines:
1. **Architecture / design fit** — does the change belong where it is; does it respect `CLAUDE.md` conventions?
2. **Unnecessary complexity** — flags anything with a materially simpler equivalent.
3. **Test-coverage gaps** — new/changed behaviour left unexercised.

## What's included

**GitHub**
- Reusable workflow `.github/workflows/rhiza_quality_review.yml` (`workflow_call`): hardened runner → checkout (full history) → `anthropics/claude-code-action` reviewing the diff and posting a **PR comment**.
- Thin stub in `bundles/github-quality-review/` delegating to it on `pull_request`.

**GitLab**
- `bundles/gitlab-quality-review/.gitlab/workflows/rhiza_quality_review.yml`: a `node` job that installs the headless `claude` CLI and reviews the MR diff, writing the review to the **job log**. `allow_failure: true` so it never blocks the MR.
- Base `.gitlab-ci.yml` gains an **`exists`-gated include** so it is a no-op unless the overlay is synced — `gitlab`/`gitlab-project` repos without the overlay are unaffected.

**Both**
- `template-bundles.yml` entries (`requires: [core, <platform>]`), deliberately **not part of any profile** — opt-in only.
- Registered where the test suite enumerates bundles: overlay spec table, `README.md`, `GLOSSARY.md` map, `BUNDLE_TAXONOMY.md`, `CLAUDE.md`.
- Taught `_gitlab_jobs_from_includes` to honour `exists:` include rules (matches real GitLab: a guarded include is a no-op when the file is absent).

## Design decisions

- **Non-overlapping with CI.** Reviews design/complexity/test-gaps only; defers to CI for any deterministic gate.
- **Opt-in and cost-gated (twice).** Dormant unless the repo includes the bundle **and** sets `CLAUDE_QUALITY_REVIEW_ENABLED=true` **and** provides `ANTHROPIC_API_KEY` (org/group-level secret is cleanest). Missing key → the job no-ops instead of failing red.
- **Advisory only.** GitHub: keep out of required checks. GitLab: `allow_failure: true`.
- **CI-safe.** Non-interactive: no `AskUserQuestion`, no issue-filing tools, read-only + git-diff tools only.
- **Pinned action.** `anthropics/claude-code-action` pinned to commit `f87768c` (v1.0.166) per the repo's SHA-pinning policy.

## Open items before merge

- [x] **Pin `anthropics/claude-code-action`** — pinned to commit `f87768c` (v1.0.166).
- [x] **GitLab parity** — added `gitlab-quality-review`.
- [ ] **Validate the GitLab job on a real MR pipeline.** The `node`-image + headless-CLI path is new to this repo and untested against a live runner; the GitHub side uses the official action. Consider dogfooding on one repo before wider rollout.
- [x] **GitLab MR-note posting** — the review is posted as an MR note via the GitLab API (prefers `CLAUDE_REVIEW_GITLAB_TOKEN`, falls back to `CI_JOB_TOKEN`), with the job log as fallback.

## Testing

- `uv run pytest tests/bundles tests/docs/test_doc_consistency.py tests/sync tests/api/test_workflow_stubs.py .rhiza/tests/api/test_github_targets.py` → **1030 passed**
- `actionlint` clean on the GitHub workflows
- Full pre-commit suite passed (template-bundles + workflow validation/lint, markdownlint, secret detection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)