### PR TITLE
fix: self-provision ty/mypy in typecheck + harmonize GitLab CI (#1381)

### DIFF
--- a/bundles/gitlab-tests/.gitlab/workflows/rhiza_ci.yml
+++ b/bundles/gitlab-tests/.gitlab/workflows/rhiza_ci.yml
@@ -26,8 +26,10 @@ ci:test:
   script:
     - echo "Testing with Python $PYTHON_VERSION"
     - export UV_EXTRA_INDEX_URL="${UV_EXTRA_INDEX_URL}"
-    - uv venv --python ${PYTHON_VERSION}
-    - make -f .rhiza/rhiza.mk test
+    # `make test` bootstraps its own environment via the `install` target, which
+    # creates the venv with PYTHON_VERSION (a `?=` default the matrix env var
+    # overrides) and provisions test tooling on the fly — no explicit `uv venv`.
+    - make test
 
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
@@ -40,8 +42,7 @@ ci:docs-coverage:
   image: ghcr.io/astral-sh/uv:0.9.30-bookworm
   script:
     - export UV_EXTRA_INDEX_URL="${UV_EXTRA_INDEX_URL}"
-    - uv venv
-    - make -f .rhiza/rhiza.mk docs-coverage
+    - make docs-coverage
 
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
@@ -55,7 +56,6 @@ ci:typecheck:
   image: ghcr.io/astral-sh/uv:0.9.30-bookworm
   script:
     - export UV_EXTRA_INDEX_URL="${UV_EXTRA_INDEX_URL}"
-    - uv venv
     - make typecheck
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
@@ -105,7 +105,6 @@ ci:security:
   image: ghcr.io/astral-sh/uv:0.9.30-bookworm
   script:
     - export UV_EXTRA_INDEX_URL="${UV_EXTRA_INDEX_URL}"
-    - uv venv
     - make security
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
@@ -119,7 +118,6 @@ ci:license:
   image: ghcr.io/astral-sh/uv:0.9.30-bookworm
   script:
     - export UV_EXTRA_INDEX_URL="${UV_EXTRA_INDEX_URL}"
-    - uv venv
     - make license
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"

--- a/bundles/gitlab/.gitlab/workflows/rhiza_weekly.yml
+++ b/bundles/gitlab/.gitlab/workflows/rhiza_weekly.yml
@@ -19,7 +19,6 @@ weekly:semgrep:
   image: ghcr.io/astral-sh/uv:0.9.30-bookworm
   script:
     - export UV_EXTRA_INDEX_URL="${UV_EXTRA_INDEX_URL}"
-    - uv venv
     - make semgrep
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"

--- a/bundles/tests/.rhiza/make.d/test.mk
+++ b/bundles/tests/.rhiza/make.d/test.mk
@@ -92,17 +92,17 @@ typecheck: install ## run ty and/or mypy type checking (TYPECHECKER=ty|mypy|both
 	case "${TYPECHECKER}" in \
 	  ty) \
 	    printf "${BLUE}[INFO] Running ty type checking in:$${typecheck_paths}${RESET}\n"; \
-	    ${UV_BIN} run ty check $${typecheck_paths} \
+	    ${UV_BIN} run --with ty ty check $${typecheck_paths} \
 	    ;; \
 	  mypy) \
 	    printf "${BLUE}[INFO] Running mypy strict type checking in:$${typecheck_paths}${RESET}\n"; \
-	    ${UV_BIN} run mypy --strict $${typecheck_paths} \
+	    ${UV_BIN} run --with mypy mypy --strict $${typecheck_paths} \
 	    ;; \
 	  both) \
 	    printf "${BLUE}[INFO] Running ty type checking in:$${typecheck_paths}${RESET}\n"; \
-	    ${UV_BIN} run ty check $${typecheck_paths} && \
+	    ${UV_BIN} run --with ty ty check $${typecheck_paths} && \
 	    printf "${BLUE}[INFO] Running mypy strict type checking in:$${typecheck_paths}${RESET}\n"; \
-	    ${UV_BIN} run mypy --strict $${typecheck_paths} \
+	    ${UV_BIN} run --with mypy mypy --strict $${typecheck_paths} \
 	    ;; \
 	  *) \
 	    printf "${RED}[ERROR] Invalid TYPECHECKER='${TYPECHECKER}' (expected: ty, mypy, or both)${RESET}\n"; \

--- a/tests/api/test_make_variable_overrides.py
+++ b/tests/api/test_make_variable_overrides.py
@@ -114,10 +114,10 @@ class TestSourceFolderVariable:
         assert 'typecheck_paths="mypackage"' in proc.stdout, (
             "typecheck should include SOURCE_FOLDER in computed path list; got:\n" + proc.stdout[:400]
         )
-        assert " run ty check ${typecheck_paths}" in proc.stdout, (
+        assert " run --with ty ty check ${typecheck_paths}" in proc.stdout, (
             "typecheck should pass computed path list to ty; got:\n" + proc.stdout[:400]
         )
-        assert " run mypy --strict ${typecheck_paths}" in proc.stdout, (
+        assert " run --with mypy mypy --strict ${typecheck_paths}" in proc.stdout, (
             "typecheck should pass computed path list to mypy; got:\n" + proc.stdout[:400]
         )
 
@@ -153,8 +153,8 @@ class TestTypecheckerVariable:
         """With no override, typecheck must run both ty and mypy."""
         proc = run_make(logger, ["typecheck"])
         assert 'case "both" in' in proc.stdout
-        assert "run ty check" in proc.stdout
-        assert "run mypy --strict" in proc.stdout
+        assert "run --with ty ty check" in proc.stdout
+        assert "run --with mypy mypy --strict" in proc.stdout
 
     def test_ty_only_selects_ty_branch(self, logger) -> None:
         """TYPECHECKER=ty must select the ty-only case branch."""

--- a/tests/api/test_makefile_targets.py
+++ b/tests/api/test_makefile_targets.py
@@ -123,12 +123,13 @@ class TestMakefile:
         assert_uvx_command_uses_version(out, tmp_path, "deptry src")
 
     def test_typecheck_target_dry_run(self, logger):
-        """Typecheck target should invoke ty and mypy via uv run."""
+        """Typecheck target should invoke ty and mypy via uv run, self-provisioned with --with."""
         proc = run_make(logger, ["typecheck"])
         out = proc.stdout
-        # Both type checkers are invoked
-        assert "uv run ty check" in out
-        assert "uv run mypy --strict" in out
+        # Both type checkers are invoked, each provisioned on the fly so a clean
+        # .venv (lockfile only, no pre-installed ty/mypy) still runs the gate.
+        assert "uv run --with ty ty check" in out
+        assert "uv run --with mypy mypy --strict" in out
 
     def test_test_target_dry_run(self, logger):
         """Test target should invoke pytest via uv with coverage and HTML outputs in dry-run output."""


### PR DESCRIPTION
Closes #1381

## 1. typecheck self-provisioning (the reported bug)

The `typecheck` target in `bundles/tests/.rhiza/make.d/test.mk` invoked `ty`/`mypy` with bare `uv run`, which only runs a tool already installed in the project env — it does **not** auto-install. Neither is a declared dependency, so on a clean CI runner (`.venv` rebuilt from the lockfile only) it fails with `Failed to spawn: ty/mypy`. It "passed" locally only when a stale `.venv` retained the tools.

**Fix:** mirror the `test` target — provision each checker on the fly across all three `TYPECHECKER` branches (`ty`, `mypy`, `both`):

```make
${UV_BIN} run --with ty ty check $${typecheck_paths}
${UV_BIN} run --with mypy mypy --strict $${typecheck_paths}
```

Updated `test_typecheck_target_dry_run` to assert the new invocation strings. This one edit fixes **both GitHub and GitLab**, since both platforms call the same shared Makefile target.

## 2. GitLab CI harmonization (follow-up)

While confirming GitLab wasn't independently broken, found the GitLab pipelines diverged from the GitHub reference in two ways — both from not trusting the Makefile's own bootstrapping:

- **Redundant `uv venv`:** run before `make {test,docs-coverage,typecheck,security,license,semgrep}` but not before `make {deptry,fmt,validate}`. Every target already self-bootstraps: venv-needing targets depend on `install` (runs `uv venv`, honouring `PYTHON_VERSION` — a `?=` default the test matrix env var overrides), uvx-only targets depend on `install-uv`. GitHub CI runs none of these. Removed.
- **`make -f .rhiza/rhiza.mk <target>`** for test/docs-coverage vs plain `make <target>` elsewhere. Normalized to plain `make`, routing through the consumer's root Makefile (project hooks) as GitHub does.

Every GitLab quality job is now uniformly `export UV_EXTRA_INDEX_URL` (only where deps are installed/audited, matching GitHub) + `make <target>`.

Note: `.rhiza/requirements` is **not** referenced anywhere in `bundles/` — that was fully removed in #1380; no GitLab file assumes it.

## Verification

- `test_makefile_targets.py`, `test_ci_workflow.py`, `test_workflow_stubs.py`, `test_overlay_bundles.py`, `test_template_bundles.py` — all pass.
- Proven end-to-end on a clean, project-free env: `uv run --no-project --with ty ty check src` and `--with mypy mypy --strict src` both download and run the checker with nothing pre-installed.
- Edited GitLab YAML validated with PyYAML.

Bundle-source edits only; the root `.rhiza/make.d/test.mk` symlink reflects the typecheck change automatically. GitLab bundle files are real (GitLab is not active CI in the mother repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)