### PR TITLE
ci: drop mother-repo-only dogfood symlink guard from reusable CI

### DIFF
--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -321,38 +321,6 @@ jobs:
         run: |
           make docs-coverage
 
-  dogfood-symlinks:
-    name: Dogfood symlink drift guard
-    # Mother-repo-only: the bundles/ single-source-of-truth tree exists only here, so
-    # this guard fails a PR that adds a bundle file (or lets a copy reappear) without
-    # running `make sync-self`. Downstream projects have no bundles/ dir and never run it.
-    # CI budget: ≤5 min (single dry-run check). Last measured: 2026-07-06.
-    if: github.repository == 'jebel-quant/rhiza'
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
-        with:
-          version: "0.11.16"
-
-      - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v0.19.9
-        with:
-          token: ${{ secrets.GH_PAT }}
-
-      - name: Check dogfood symlinks are up to date
-        run: make sync-self-check
-
   validation:
     # CI budget: ≤5 min (validation quality gate). Last measured: 2026-05-28.
     timeout-minutes: 5


### PR DESCRIPTION
## Why

The `dogfood-symlinks` job in the reusable `rhiza_ci.yml` is gated by:

```yaml
if: github.repository == 'jebel-quant/rhiza'
```

Because this workflow is consumed by downstream projects (jquantstats, etc.), GitHub lists **every** job of the called workflow — including this one — so downstream repos see a permanently-**skipped** `Dogfood symlink drift guard` job on every push/PR. It can never do anything there (they have no `bundles/` tree), so it's pure noise in their CI job list.

Example downstream skip: https://github.com/Jebel-Quant/jquantstats/actions/runs/29019523589/job/86122464389

## What

Delete the job. The invariant it guarded — root dogfood copies are byte-identical **symlinks** into `bundles/`, carve-outs stay real files — is already enforced, more thoroughly, by:

- `tests/bundles/test_bundle_dogfood_symlinks.py`

which drives the very same `utils/link_dogfood.py` helpers and runs in the normal `test` matrix. `tests/bundles/` ships in **no** bundle, so it stays mother-repo-only — exactly the scoping the `if:` gate was emulating.

Net effect: the drift guard lives where it belongs (the test suite), and downstream projects stop seeing a skipped job.

## Verification

- `pytest tests/bundles/test_bundle_dogfood_symlinks.py` → **82 passed**
- No bundle ships a copy of this workflow carrying the job (`grep -rln 'dogfood-symlinks|sync-self-check' bundles/` → empty)
- `ci-gate` `needs:` does not reference `dogfood-symlinks`, so the required check is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)