### PR TITLE
feat(bundles): drop claude bundle from local/github-project/gitlab-project profiles

### DIFF
--- a/.rhiza/template-bundles.yml
+++ b/.rhiza/template-bundles.yml
@@ -339,7 +339,6 @@ profiles:
       No .github/workflows/* files are synced.
     bundles:
       - core
-      - claude
       - book
       - marimo
       - tests
@@ -355,7 +354,6 @@ profiles:
       testing tooling, documentation, notebooks, and hosted CI workflows.
     bundles:
       - core
-      - claude
       - github
       - book
       - marimo
@@ -375,7 +373,6 @@ profiles:
       and GitLab CI pipelines. No .github/ files are synced.
     bundles:
       - core
-      - claude
       - gitlab
       - book
       - marimo

--- a/README.md
+++ b/README.md
@@ -189,9 +189,9 @@ Rhiza provides **profiles** — named presets that select a sensible set of bund
 
 | Profile | Description | Includes |
 |---------|-------------|---------|
-| `local` | Local-first development with no hosted CI/CD workflow files | `core`, `claude`, `book`, `marimo`, `tests` |
-| `github-project` | GitHub-hosted project with CI/CD and release automation | `core`, `claude`, `github`, `book`, `marimo`, `tests`, `github-book`, `github-marimo`, `github-tests` |
-| `gitlab-project` | GitLab-hosted project with GitLab CI/CD pipelines | `core`, `claude`, `gitlab`, `book`, `marimo`, `tests`, `gitlab-book`, `gitlab-marimo`, `gitlab-tests` |
+| `local` | Local-first development with no hosted CI/CD workflow files | `core`, `book`, `marimo`, `tests` |
+| `github-project` | GitHub-hosted project with CI/CD and release automation | `core`, `github`, `book`, `marimo`, `tests`, `github-book`, `github-marimo`, `github-tests` |
+| `gitlab-project` | GitLab-hosted project with GitLab CI/CD pipelines | `core`, `gitlab`, `book`, `marimo`, `tests`, `gitlab-book`, `gitlab-marimo`, `gitlab-tests` |
 
 Declare a profile in `.rhiza/template.yml`:
 

--- a/docs/reference/BUNDLE_TAXONOMY.md
+++ b/docs/reference/BUNDLE_TAXONOMY.md
@@ -79,7 +79,7 @@ context and Rhiza expands it to a sensible bundle set.
 
 | Profile | Expands to | Use when |
 |---------|-----------|----------|
-| `local` | `core`, `claude`, `tests`, `book`, `marimo` | Local-first work with no hosted CI (experiments, private/other-host repos). |
+| `local` | `core`, `tests`, `book`, `marimo` | Local-first work with no hosted CI (experiments, private/other-host repos). |
 | `github-project` | the `local` set + `github` and the `github-*` overlays | A standard GitHub-hosted project. |
 | `gitlab-project` | the `local` set + `gitlab` and the `gitlab-*` overlays | A standard GitLab-hosted project. |
 


### PR DESCRIPTION
## Summary

Removes the `claude` bundle (Claude Code slash commands) from the default bundle set of all three profiles: `local`, `github-project`, and `gitlab-project`.

The `claude` bundle is untouched as a definition — it remains `standalone: true, requires: [core]`, so projects can still adopt it explicitly. Its slash commands continue to dogfood in this repo.

## Changes

- **`.rhiza/template-bundles.yml`** — dropped `claude` from the `bundles:` list of `local`, `github-project`, and `gitlab-project`.
- **`README.md`** — updated the profiles table.
- **`docs/reference/BUNDLE_TAXONOMY.md`** — updated the `local` profile expansion (github/gitlab rows reference "the `local` set", so they update transitively).

## Notes

- The GLOSSARY mermaid diagram edges (`claude --> core`, `claude -.-> book`) depict bundle-level dependencies, not profile membership, so they were left as-is.
- No symlink/dogfood implications: profiles are not materialized files.

## Testing

`tests/docs/test_doc_consistency.py` and `tests/bundles/test_bundle_combinations.py` — 435 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)