### PR TITLE
fix: repair stale uv Docker image tags (gitlab + docker bundles)

### DIFF
--- a/bundles/docker/Dockerfile
+++ b/bundles/docker/Dockerfile
@@ -10,7 +10,7 @@ ARG PYTHON_VERSION=3.12
 # ================================
 # Stage 1: Builder
 # ================================
-FROM ghcr.io/astral-sh/uv:0.9.24-python${PYTHON_VERSION}-bookworm-slim AS builder
+FROM ghcr.io/astral-sh/uv:0.11.16-python${PYTHON_VERSION}-trixie-slim AS builder
 
 WORKDIR /app
 

--- a/bundles/gitlab/.gitlab-ci.yml
+++ b/bundles/gitlab/.gitlab-ci.yml
@@ -150,7 +150,7 @@ variables:
   # Single source of truth for the uv/Python CI image. Every job references
   # `image: $UV_IMAGE`; bump the tag here to move the whole pipeline. Kept in
   # step with the uv version GitHub Actions pins in .github/workflows/.
-  UV_IMAGE: "ghcr.io/astral-sh/uv:0.11.16-bookworm"
+  UV_IMAGE: "ghcr.io/astral-sh/uv:0.11.16-debian"
 
   # Redirect uv's caches under the git-ignored .cache/ dir so GitLab (which only
   # caches paths inside $CI_PROJECT_DIR) can persist them — see default: cache:.


### PR DESCRIPTION
## Problem

Astral stopped publishing OS-codename Docker tags (`-bookworm`) in newer uv releases; Debian images are now tagged `-debian` (generic) or `-trixie` (Debian 13). Two bundle pins used the old convention:

1. **`bundles/gitlab/.gitlab-ci.yml`** — `ghcr.io/astral-sh/uv:0.11.16-bookworm` **does not exist** (404), breaking every GitLab pipeline job (all reference `image: $UV_IMAGE`).
2. **`bundles/docker/Dockerfile`** — pinned a stale `0.9.24-python${PYTHON_VERSION}-bookworm-slim` builder.

Because this repo runs **GitHub-only** CI, a nonexistent GitLab image tag slipped through undetected — nothing here ever pulled it.

## Fix

```diff
# bundles/gitlab/.gitlab-ci.yml (UV_IMAGE — single source of truth)
-  UV_IMAGE: "ghcr.io/astral-sh/uv:0.11.16-bookworm"
+  UV_IMAGE: "ghcr.io/astral-sh/uv:0.11.16-debian"

# bundles/docker/Dockerfile (builder stage)
-FROM ghcr.io/astral-sh/uv:0.9.24-python${PYTHON_VERSION}-bookworm-slim AS builder
+FROM ghcr.io/astral-sh/uv:0.11.16-python${PYTHON_VERSION}-trixie-slim AS builder
```

Both stay pinned to uv `0.11.16` (aligned with GitHub Actions) on a Debian base. Docker uses `-trixie-slim` because the python-pinned slim images are published only with explicit codenames — `-debian-slim` isn't published at 0.11.16, and trixie **is** Debian (13, successor to bookworm/Debian 12).

Verified against ghcr: `uv:0.11.16-bookworm` → 404; `uv:0.11.16-debian` → 200; `uv:0.11.16-python{3.11..3.14}-trixie-slim` → 200.

## Regression test

The guard that would have caught this lives in a separate PR — **#1394** — so the fix and its test can be reviewed independently. That PR is intentionally red against `main` until this fix lands (its image-existence check flags the `-bookworm` 404); merge this one first.

## Notes

- No root `Dockerfile`/`.gitlab-ci.yml` in the mother repo → no dogfood symlinks affected.
- `node:22-bookworm` (gitlab-quality-review) is a Node image, unrelated and valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)