### PR TITLE
Fix for Module is imported more than once

### DIFF
--- a/tests/bundles/test_bundle_combinations.py
+++ b/tests/bundles/test_bundle_combinations.py
@@ -450,8 +450,6 @@ class TestRenovateBundleSync:
 
     def test_renovate_json_has_extends(self) -> None:
         """renovate.json must declare 'extends' with at least one Renovate preset."""
-        import json
-
         parsed = json.loads((self.project / "renovate.json").read_text(encoding="utf-8"))
         assert "extends" in parsed, "renovate.json missing 'extends' key"
         assert isinstance(parsed["extends"], list), "renovate.json 'extends' must be a list"


### PR DESCRIPTION
To fix this, remove the redundant in-function `import json` from `test_renovate_json_has_extends` and use the already imported module-level `json`.

Best single fix without changing functionality:
- Edit `tests/bundles/test_bundle_combinations.py`
- In `TestRenovateBundleSync.test_renovate_json_has_extends`, delete the local `import json` line.
- Keep all parsing/assertion logic unchanged.

No new imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._