### PR TITLE
Fix for Module is imported more than once

### DIFF
--- a/tests/bundles/test_bundle_combinations.py
+++ b/tests/bundles/test_bundle_combinations.py
@@ -442,8 +442,6 @@ class TestRenovateBundleSync:
 
     def test_renovate_json_is_valid(self) -> None:
         """renovate.json must be valid JSON."""
-        import json
-
         content = (self.project / "renovate.json").read_text(encoding="utf-8")
         parsed = json.loads(content)
         assert isinstance(parsed, dict), "renovate.json must be a JSON object"


### PR DESCRIPTION
Remove the redundant `import json` inside `TestRenovateBundleSync.test_renovate_json_is_valid` and rely on the existing top-level `import json` (line 10).

Concretely, in `tests/bundles/test_bundle_combinations.py`, edit the method `test_renovate_json_is_valid` by deleting only the local import line and keeping the rest of the logic unchanged. No additional imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._