### PR TITLE
security: pin required checks to GitHub Actions and protect v* tags

### DIFF
--- a/.github/rulesets/main-branch-protection.json
+++ b/.github/rulesets/main-branch-protection.json
@@ -27,12 +27,12 @@
       "parameters": {
         "strict_required_status_checks_policy": false,
         "required_status_checks": [
-          { "context": "Pre-commit hooks" },
-          { "context": "Check dependencies with deptry" },
-          { "context": "docs-coverage" },
-          { "context": "Security scanning" },
-          { "context": "License compliance scan" },
-          { "context": "CI gate" }
+          { "context": "Pre-commit hooks", "integration_id": 15368 },
+          { "context": "Check dependencies with deptry", "integration_id": 15368 },
+          { "context": "docs-coverage", "integration_id": 15368 },
+          { "context": "Security scanning", "integration_id": 15368 },
+          { "context": "License compliance scan", "integration_id": 15368 },
+          { "context": "CI gate", "integration_id": 15368 }
         ]
       }
     }

--- a/.github/rulesets/tag-protection.json
+++ b/.github/rulesets/tag-protection.json
@@ -1,0 +1,24 @@
+{
+  "name": "version-tag-protection",
+  "target": "tag",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/tags/v*"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "creation" },
+    { "type": "update" },
+    { "type": "deletion" },
+    { "type": "non_fast_forward" }
+  ],
+  "bypass_actors": [
+    {
+      "actor_type": "RepositoryRole",
+      "actor_id": 5,
+      "bypass_mode": "always"
+    }
+  ]
+}

--- a/bundles/github/.github/rulesets/main-branch-protection.json
+++ b/bundles/github/.github/rulesets/main-branch-protection.json
@@ -27,12 +27,12 @@
       "parameters": {
         "strict_required_status_checks_policy": false,
         "required_status_checks": [
-          { "context": "Pre-commit hooks" },
-          { "context": "Check dependencies with deptry" },
-          { "context": "docs-coverage" },
-          { "context": "Security scanning" },
-          { "context": "License compliance scan" },
-          { "context": "CI gate" }
+          { "context": "Pre-commit hooks", "integration_id": 15368 },
+          { "context": "Check dependencies with deptry", "integration_id": 15368 },
+          { "context": "docs-coverage", "integration_id": 15368 },
+          { "context": "Security scanning", "integration_id": 15368 },
+          { "context": "License compliance scan", "integration_id": 15368 },
+          { "context": "CI gate", "integration_id": 15368 }
         ]
       }
     }

--- a/bundles/github/.github/rulesets/tag-protection.json
+++ b/bundles/github/.github/rulesets/tag-protection.json
@@ -1,0 +1,24 @@
+{
+  "name": "version-tag-protection",
+  "target": "tag",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/tags/v*"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "creation" },
+    { "type": "update" },
+    { "type": "deletion" },
+    { "type": "non_fast_forward" }
+  ],
+  "bypass_actors": [
+    {
+      "actor_type": "RepositoryRole",
+      "actor_id": 5,
+      "bypass_mode": "always"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Hardens the shared rulesets that rhiza syncs into downstream repos.

- **`main-branch-protection.json`** — pins each required status check to the GitHub Actions app (`integration_id: 15368`). Checks otherwise match by **name only**, so a status of the same name posted by a different app/integration could satisfy the merge gate.
- **`tag-protection.json`** (new) — a `tag`-target ruleset restricting `creation` / `update` / `deletion` of `refs/tags/v*` to the admin bypass. Release tags trigger the publish pipeline, so only maintainers should be able to create them. Branch and tag protections must live in separate rulesets — a ruleset has a single `target`.

## Notes for reviewers
- `main` bypass stays `bypass_mode: "always"` so the local `rhiza bump` (which pushes the version-bump commit directly to `main`) keeps working. If the bump moves to a PR flow, this can tighten to `"pull_request"`.
- The tag ruleset keeps `always` bypass because tags cannot be created via a PR.
- **Verify before merge:** confirm all six required checks are emitted by GitHub Actions (id `15368`). If any is posted by a third-party app, that entry needs that app's id instead, or the check will never turn green.
- Both files fan out to downstream repos via the rhiza sync, so this applies fleet-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)