### PR TITLE
chore: drop make bump/release targets (releasing moves to rhiza-claude /release)

### DIFF
--- a/.rhiza/make.d/README.md
+++ b/.rhiza/make.d/README.md
@@ -173,5 +173,3 @@ Add these to your root `Makefile` using double-colon syntax (`::`):
 - `pre-install` / `post-install`: Runs around `make install`.
 - `pre-sync` / `post-sync`: Runs around repository synchronization.
 - `pre-validate` / `post-validate`: Runs around validation checks.
-- `pre-release` / `post-release`: Runs around release process.
-- `pre-bump` / `post-bump`: Runs around version bumping.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ The root `Makefile` is intentionally thin (~10 lines) and only `include`s `.rhiz
 | `bootstrap.mk` | core | `install`/`uv` bootstrap |
 | `doctor.mk` | core | `make doctor` environment checks |
 | `quality.mk` | core | `fmt`, lint, pre-commit gates |
-| `releasing.mk` | core | `bump`/`release` targets |
+| `releasing.mk` | core | `changelog`/`release-status` helpers |
 | `custom-env.mk` | core | example stub: project variables |
 | `custom-task.mk` | core | example stub: project targets/hooks |
 | `test.mk` | tests | `test`, coverage, typecheck, stress, mutation |

--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ make install         # Install dependencies and setup environment
 make test            # Run test suite with coverage
 make fmt             # Format and lint code
 make todos           # Scan for TODO/FIXME/HACK comments
-make release         # Bump version, tag, and push to publish a new release
+make release-status  # Show release workflow status and latest release
 make marimo          # Start Marimo notebook server
 make book            # Build documentation
 ```

--- a/bundles/core/.rhiza/completions/README.md
+++ b/bundles/core/.rhiza/completions/README.md
@@ -6,7 +6,7 @@ This directory contains shell completion scripts for Bash and Zsh that provide t
 
 - ✅ Tab-complete all available make targets
 - ✅ Show target descriptions in Zsh
-- ✅ Complete common make variables (DRY_RUN, BUMP, ENV, etc.)
+- ✅ Complete common make variables (DRY_RUN, ENV, etc.)
 - ✅ Works with any Rhiza-based project
 - ✅ Auto-discovers targets from Makefile and included .mk files
 
@@ -117,7 +117,7 @@ make <TAB>
 make te<TAB>  # Expands to: make test
 
 # Complete variables
-make BUMP=<TAB>  # Shows: patch, minor, major
+make ENV=<TAB>  # Shows: dev, staging, prod
 
 # Works with any target
 make doc<TAB>  # Shows: docs, docker-build, docker-run, etc.
@@ -144,7 +144,6 @@ The completion scripts understand these common variables:
 | Variable | Values | Description |
 |----------|--------|-------------|
 | `DRY_RUN` | `1` | Preview mode without making changes |
-| `BUMP` | `patch`, `minor`, `major` | Version bump type |
 | `ENV` | `dev`, `staging`, `prod` | Target environment |
 | `COVERAGE_FAIL_UNDER` | (number) | Minimum coverage threshold |
 | `PYTHON_VERSION` | (version) | Override Python version |
@@ -156,10 +155,10 @@ Example usage:
 make DRY_<TAB>     # Expands to: make DRY_RUN=1
 
 # Tab-complete variable values
-make BUMP=<TAB>    # Shows: patch minor major
+make ENV=<TAB>    # Shows: dev staging prod
 
 # Combine with targets
-make bump BUMP=<TAB>
+make deploy ENV=<TAB>
 ```
 
 ## Troubleshooting

--- a/bundles/core/.rhiza/completions/rhiza-completion.bash
+++ b/bundles/core/.rhiza/completions/rhiza-completion.bash
@@ -56,7 +56,7 @@ _rhiza_make_completion() {
     fi
 
     # Add common make variables that can be overridden
-    local vars="DRY_RUN=1 BUMP=patch BUMP=minor BUMP=major ENV=dev ENV=staging ENV=prod"
+    local vars="DRY_RUN=1 ENV=dev ENV=staging ENV=prod"
     opts="$opts $vars"
 
     # Generate completions

--- a/bundles/core/.rhiza/completions/rhiza-completion.zsh
+++ b/bundles/core/.rhiza/completions/rhiza-completion.zsh
@@ -92,9 +92,6 @@ _rhiza_make() {
     # Common make variables
     variables=(
         'DRY_RUN=1:preview mode without making changes'
-        'BUMP=patch:bump patch version'
-        'BUMP=minor:bump minor version'
-        'BUMP=major:bump major version'
         'ENV=dev:development environment'
         'ENV=staging:staging environment'
         'ENV=prod:production environment'

--- a/bundles/core/.rhiza/make.d/releasing.mk
+++ b/bundles/core/.rhiza/make.d/releasing.mk
@@ -1,43 +1,16 @@
 ## .rhiza/make.d/releasing.mk - Releasing and Versioning
-# This file provides targets for version bumping and release management.
+# This file provides changelog and release-status helpers.
+#
+# Version bumping and release tagging are NOT make targets. Releasing is driven
+# by the rhiza-claude `/release` command, which derives the next version, bumps
+# pyproject.toml, regenerates CHANGELOG.md, and creates the tag locally. Pushing
+# that tag triggers the release workflow (rhiza_release.yml).
+# See https://github.com/Jebel-Quant/rhiza-claude.
 
 # Declare phony targets (they don't produce files)
-.PHONY: bump release release-status changelog pre-bump post-bump pre-release post-release
-
-# Hook targets (double-colon rules allow multiple definitions)
-pre-bump:: ; @:
-post-bump:: ; @:
-pre-release:: ; @:
-post-release:: ; @:
-
-# DRY_RUN support: pass DRY_RUN=1 to preview changes without applying them
-_DRY_RUN_FLAG := $(if $(DRY_RUN),--dry-run,)
-# BUMP support: pass BUMP=major|minor|patch to choose the bump type explicitly
-# (omit BUMP to select the bump type interactively, the default behaviour)
-_BUMP_FLAG := $(if $(BUMP),--bump $(BUMP),)
-# PUSH support: pass PUSH=1 to push the tag without the interactive y/N prompt
-# (omit PUSH to be prompted before the tag is pushed, the default behaviour)
-_PUSH_FLAG := $(if $(PUSH),--push,)
-_VERSION=0.7.1
+.PHONY: release-status changelog
 
 ##@ Releasing and Versioning
-bump: pre-bump ## bump version of the project (supports DRY_RUN=1, BUMP=major|minor|patch)
-	@if [ -f "pyproject.toml" ]; then \
-		$(MAKE) install; \
-		PATH="$(abspath ${VENV})/bin:$$PATH" ${UVX_BIN} "rhiza-tools>=$(_VERSION)" bump $(_DRY_RUN_FLAG) $(_BUMP_FLAG); \
-		if [ -z "$(DRY_RUN)" ]; then \
-			printf "${BLUE}[INFO] Checking uv.lock file...${RESET}\n"; \
-			${UV_BIN} lock; \
-		fi; \
-	else \
-		printf "${YELLOW}[WARN] No pyproject.toml found, skipping bump${RESET}\n"; \
-	fi
-	@$(MAKE) post-bump
-
-release: pre-release install-uv ## bump version, create tag and push to trigger the release workflow (supports DRY_RUN=1, BUMP=major|minor|patch, PUSH=1)
-	${UVX_BIN} "rhiza-tools>=$(_VERSION)" release $(_DRY_RUN_FLAG) $(_BUMP_FLAG) $(_PUSH_FLAG);
-	@$(MAKE) post-release
-
 release-status: ## show release workflow status and latest release information
 ifeq ($(FORGE_TYPE),github)
 	@{ $(MAKE) --no-print-directory workflow-status; printf "\n"; $(MAKE) --no-print-directory latest-release; } 2>&1 | $${PAGER:-less -R}
@@ -52,6 +25,3 @@ changelog: install-uv ## generate/update CHANGELOG.md from git history using git
 	@printf "${BLUE}[INFO] Generating CHANGELOG.md with git-cliff...${RESET}\n"
 	@${UVX_BIN} git-cliff --output CHANGELOG.md
 	@printf "${GREEN}[OK] CHANGELOG.md updated.${RESET}\n"
-
-
-

--- a/bundles/core/.rhiza/rhiza.mk
+++ b/bundles/core/.rhiza/rhiza.mk
@@ -55,12 +55,8 @@ RESET := \033[0m
 # Declare phony targets (they don't produce files)
 .PHONY: \
 	help \
-	post-bump \
 	post-install \
-	post-release \
-	pre-bump \
 	pre-install \
-	pre-release \
 	print-logo \
 	readme \
 	version-matrix \

--- a/bundles/presentation/docs/development/PRESENTATION.md
+++ b/bundles/presentation/docs/development/PRESENTATION.md
@@ -200,9 +200,9 @@ make docs         # Generate API documentation
 make book         # Build companion book
 make presentation # Generate slides from PRESENTATION.md
 make marimo       # Launch Marimo notebook server
-make bump         # Interactive version bump
-make release      # Tag and release
 ```
+
+**Note**: Releasing is driven by the rhiza-claude `/release` command, which bumps the version, regenerates the changelog, and creates the tag.
 
 **Tip**: Run `make help` to see all available targets
 
@@ -229,25 +229,17 @@ Notebooks stored in `docs/notebooks/` with inline dependency management.
 
 ## 🚀 Release Workflow
 
-### Release (bump + tag + push)
+### Release (via rhiza-claude `/release`)
 
-```bash
-make release
-# → Interactive prompt for patch/minor/major
-# → Bumps version (and folds CHANGELOG.md into the bump commit)
-# → Creates and pushes the git tag
-# → Triggers release workflow
+```text
+/release
+# → Derives the next version
+# → Bumps pyproject.toml
+# → Regenerates CHANGELOG.md
+# → Creates the git tag locally
 ```
 
-A release always bumps the version — there is no tag-only release.
-
-### Bump Without Releasing
-
-```bash
-make bump
-# → Interactive prompt for patch/minor/major
-# → Updates pyproject.toml (and CHANGELOG.md), commits — no tag/push
-```
+Pushing the tag triggers the release workflow. Releasing is not a `make` target.
 
 ### Check Status
 
@@ -567,9 +559,8 @@ make docs                      # API documentation
 make book                      # Companion book
 make presentation              # Generate slides
 
-# Release
-make bump                      # Bump version
-make release                   # Create release
+# Release (driven by the rhiza-claude /release command)
+make release-status            # Show release workflow status
 
 # Notebooks
 make marimo                    # Interactive notebooks

--- a/docs/guides/CUSTOMIZATION.md
+++ b/docs/guides/CUSTOMIZATION.md
@@ -38,8 +38,6 @@ You can hook into standard workflows using double-colon syntax (`::`) in your ro
 - `pre-install / post-install` - Runs around `make install`
 - `pre-sync / post-sync` - Runs around repository synchronization
 - `pre-validate / post-validate` - Runs around validation checks
-- `pre-release / post-release` - Runs around release process
-- `pre-bump / post-bump` - Runs around version bumping
 
 ### Example: Installing System Dependencies
 
@@ -55,18 +53,21 @@ pre-install::
 
 This hook runs automatically before `make install`, ensuring graphviz is available.
 
-### Example: Post-Release Tasks
+### Example: Post-Sync Tasks
 
 Add to your root `Makefile`:
 
 ```makefile
-post-release::
-	@echo "Running post-release tasks..."
+post-sync::
+	@echo "Running post-sync tasks..."
 	@./scripts/notify-team.sh
-	@./scripts/update-changelog.sh
 ```
 
-This runs automatically after `make release` completes.
+This runs automatically after repository synchronization completes.
+
+> Releasing is not a `make` hook. Releases are driven by the rhiza-claude
+> `/release` command, which bumps the version, regenerates `CHANGELOG.md`, and
+> creates the tag locally; pushing the tag triggers the release workflow.
 
 ### Example: Custom Build Steps
 

--- a/docs/guides/DEMO.md
+++ b/docs/guides/DEMO.md
@@ -49,8 +49,8 @@ make fmt
 # 5. Check dependencies
 make deptry
 
-# 6. Show version bump options
-make bump BUMP=patch --dry-run
+# 6. Check release status (releasing itself is driven by the rhiza-claude /release command)
+make release-status
 
 # 7. Validate project structure
 make validate

--- a/docs/guides/EXTENDING_RHIZA.md
+++ b/docs/guides/EXTENDING_RHIZA.md
@@ -167,10 +167,6 @@ Hooks allow you to inject custom logic into standard workflows using double-colo
 | `post-sync` | After template sync | Regenerate files, apply local patches |
 | `pre-validate` | Before project validation | Custom checks, pre-validation setup |
 | `post-validate` | After project validation | Additional validation steps |
-| `pre-bump` | Before version bump | Update version in additional files |
-| `post-bump` | After version bump | Generate changelogs, update documentation |
-| `pre-release` | Before creating release | Final checks, build artifacts |
-| `post-release` | After creating release | Deploy, notify team, update external systems |
 
 #### Hook Syntax
 

--- a/docs/guides/QUICK_REFERENCE.md
+++ b/docs/guides/QUICK_REFERENCE.md
@@ -16,12 +16,9 @@ A concise reference for common Rhiza operations.
 
 | Command | Description |
 |---------|-------------|
-| `make release` | Bump version, create tag and push to trigger the release workflow (prompts for major/minor/patch) |
-| `make bump` | Bump version only, without releasing (prompts for major/minor/patch) |
-| `make bump BUMP=patch` | Bump patch version directly |
-| `make bump BUMP=minor` | Bump minor version directly |
-| `make bump BUMP=major` | Bump major version directly |
 | `make release-status` | Show release workflow status and latest release |
+
+> Releasing is driven by the rhiza-claude `/release` command, which derives the next version, bumps `pyproject.toml`, regenerates `CHANGELOG.md`, and creates the git tag locally. Pushing that tag triggers the release workflow.
 
 ## Code Quality
 
@@ -102,10 +99,6 @@ Extend these with `::` syntax in `local.mk` or `.rhiza/make.d/`:
 | `post-sync::` | After template sync |
 | `pre-validate::` | Before project validation |
 | `post-validate::` | After project validation |
-| `pre-release::` | Before release creation |
-| `post-release::` | After release creation |
-| `pre-bump::` | Before version bump |
-| `post-bump::` | After version bump |
 
 ## Key Files
 

--- a/docs/reference/ARCHITECTURE.md
+++ b/docs/reference/ARCHITECTURE.md
@@ -105,23 +105,15 @@ flowchart LR
         post_install[post-install::]
         pre_sync[pre-sync::]
         post_sync[post-sync::]
-        pre_release[pre-release::]
-        post_release[post-release::]
-        pre_bump[pre-bump::]
-        post_bump[post-bump::]
     end
 
     subgraph Targets["Main Targets"]
         install[make install]
         sync[make sync]
-        release[make release]
-        bump[make bump]
     end
 
     pre_install --> install --> post_install
     pre_sync --> sync --> post_sync
-    pre_release --> release --> post_release
-    pre_bump --> bump --> post_bump
 ```
 
 ## Release Pipeline
@@ -414,8 +406,6 @@ pre-install::    # Runs before make install
 post-install::   # Runs after make install
 pre-sync::       # Runs before make sync
 post-sync::      # Runs after make sync
-pre-release::    # Runs before make release
-post-release::   # Runs after make release
 ```
 
 **Key principles**:

--- a/docs/reference/GLOSSARY.md
+++ b/docs/reference/GLOSSARY.md
@@ -145,8 +145,6 @@ Extension points in the Makefile system. Available hooks:
 - `pre-install::` / `post-install::` - Before/after dependency installation
 - `pre-sync::` / `post-sync::` - Before/after template sync
 - `pre-validate::` / `post-validate::` - Before/after project validation
-- `pre-release::` / `post-release::` - Before/after release creation
-- `pre-bump::` / `post-bump::` - Before/after version bump
 
 ### Make Target
 A named command in the Makefile (e.g., `make test`, `make fmt`). Rhiza provides 40+ targets out of the box.
@@ -265,8 +263,6 @@ Workflow running security scans (pip-audit, bandit) on the codebase.
 | `make test` | Run pytest with coverage |
 | `make fmt` | Format and lint code with ruff |
 | `make sync` | Sync templates from upstream |
-| `make bump` | Bump version number only, without releasing |
-| `make release` | Bump version, create tag and push to trigger the release workflow |
 | `make release-status` | Show release workflow status and latest release |
 | `make doctor` | Validate tools and environment — start here when something is wrong |
 | `make validate` | Validate project structure against `.rhiza/template.yml` |

--- a/docs/reference/TOOLS_REFERENCE.md
+++ b/docs/reference/TOOLS_REFERENCE.md
@@ -80,9 +80,9 @@ These are the commands you'll use most frequently:
 
 | Command | Description | Options |
 |---------|-------------|---------|
-| `make release` | Bump version, tag, and push to trigger the release workflow (prompts for level) | `DRY_RUN=1` for preview |
-| `make bump` | Bump version only, without releasing (prompts for level) | `BUMP=major/minor/patch` |
 | `make release-status` | Show release workflow status | |
+
+> Releasing is driven by the rhiza-claude `/release` command, which derives the next version, bumps `pyproject.toml`, regenerates `CHANGELOG.md`, and creates the git tag locally. Pushing that tag triggers the release workflow.
 
 ### Docker
 
@@ -395,34 +395,13 @@ interrogate src/ --fail-under 80
 
 ## Release Management
 
-### Version Bumping
-
-```bash
-# Bump version (interactive prompt)
-make bump
-
-# Bump patch version (0.0.X)
-make bump BUMP=patch
-
-# Bump minor version (0.X.0)
-make bump BUMP=minor
-
-# Bump major version (X.0.0)
-make bump BUMP=major
-
-# Preview without making changes
-make bump DRY_RUN=1
-```
-
 ### Creating Releases
 
+Releasing is driven by the rhiza-claude `/release` command: it derives the next
+version, bumps `pyproject.toml`, regenerates `CHANGELOG.md`, and creates the git
+tag locally. Pushing that tag triggers the release workflow (`rhiza_release.yml`).
+
 ```bash
-# Full release: bump + tag + push (interactive bump-level prompt)
-make release
-
-# Preview release
-make release DRY_RUN=1
-
 # Check release status
 make release-status
 
@@ -636,8 +615,10 @@ make all          # Run all CI checks
 ```bash
 make test         # Verify tests pass
 make all          # Run all CI checks
-make release      # Bump, tag, and push
 ```
+
+Then run the rhiza-claude `/release` command to bump the version, regenerate the
+changelog, and create the tag; pushing the tag triggers the release workflow.
 
 ### Adding Dependencies
 

--- a/tests/api/test_makefile_targets.py
+++ b/tests/api/test_makefile_targets.py
@@ -13,9 +13,7 @@ changes.
 from __future__ import annotations
 
 import os
-import re
 import sys
-from pathlib import Path
 
 import pytest
 
@@ -327,93 +325,3 @@ class TestMakefileRootFixture:
         expected_targets = ["install", "fmt", "test", "deptry", "help"]
         for target in expected_targets:
             assert f"{target}:" in content or f".PHONY: {target}" in content
-
-
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="drives 'make bump' through shebang uv/uvx mocks via a POSIX shell; unsupported on Windows",
-)
-class TestMakeBump:
-    """Tests for the 'make bump' target."""
-
-    @pytest.fixture
-    def mock_bin(self, tmp_path):
-        """Create mock uv and uvx scripts in ./bin."""
-        bin_dir = tmp_path / "bin"
-        bin_dir.mkdir(exist_ok=True)
-
-        uv = bin_dir / "uv"
-        uv.write_text('#!/bin/sh\necho "[MOCK] uv $@"\n')
-        uv.chmod(0o755)
-
-        # Mock uvx to simulate version bump if arguments match
-        uvx = bin_dir / "uvx"
-        uvx_script = """#!/usr/bin/env python3
-import sys
-import re
-from pathlib import Path
-
-args = sys.argv[1:]
-print(f"[MOCK] uvx {' '.join(args)}")
-
-# Check if this is the bump command: "rhiza-tools>=0.7.0" bump
-if "bump" in args:
-    # Simulate bumping version in pyproject.toml
-    pyproject = Path("pyproject.toml")
-    if pyproject.exists():
-        content = pyproject.read_text()
-        # Simple regex replacement for version
-        # Assuming version = "0.1.0" -> "0.1.1"
-        new_content = re.sub(r'version = "([0-9.]+)"', lambda m: f'version = "{m.group(1)[:-1]}{int(m.group(1)[-1]) + 1}"', content)
-        pyproject.write_text(new_content)
-        print(f"[MOCK] Bumped version in {pyproject}")
-"""  # noqa: E501
-        uvx.write_text(uvx_script)
-        uvx.chmod(0o755)
-
-        return bin_dir
-
-    def test_bump_execution(self, logger, mock_bin, tmp_path):
-        """Test 'make bump' execution with mocked tools and verify version change."""
-        # Create dummy pyproject.toml with initial version
-        pyproject = tmp_path / "pyproject.toml"
-        pyproject.write_text('version = "0.1.0"\n[project]\nname = "test"\n')
-
-        uv_bin = mock_bin / "uv"
-        uvx_bin = mock_bin / "uvx"
-
-        # Run make bump with dry_run=False to actually execute the shell commands
-        result = run_make(logger, ["bump", f"UV_BIN={uv_bin}", f"UVX_BIN={uvx_bin}"], dry_run=False)
-
-        # Verify that the mock tools were called. The rhiza-tools pin tracks _VERSION
-        # in releasing.mk, so read it from the copied makefile rather than hardcoding.
-        releasing_mk = Path(".rhiza/make.d/releasing.mk").read_text()
-        version = re.search(r"^_VERSION=(\S+)", releasing_mk, re.MULTILINE).group(1)
-        assert f"[MOCK] uvx rhiza-tools>={version} bump" in result.stdout
-        assert "[MOCK] uv lock" in result.stdout
-
-        # Verify that 'make install' was called (which calls uv sync)
-        assert "[MOCK] uv sync" in result.stdout
-
-        # Verify that the version was actually bumped by our mock
-        new_content = pyproject.read_text()
-        assert 'version = "0.1.1"' in new_content
-
-    def test_bump_no_pyproject(self, logger, mock_bin, tmp_path):
-        """Test 'make bump' execution without pyproject.toml."""
-        # Ensure pyproject.toml does not exist
-        pyproject = tmp_path / "pyproject.toml"
-        if pyproject.exists():
-            pyproject.unlink()
-
-        uv_bin = mock_bin / "uv"
-        uvx_bin = mock_bin / "uvx"
-
-        result = run_make(logger, ["bump", f"UV_BIN={uv_bin}", f"UVX_BIN={uvx_bin}"], dry_run=False)
-
-        # Check for warning message
-        assert "No pyproject.toml found, skipping bump" in result.stdout
-
-        # Ensure bump commands are NOT executed
-        assert "[MOCK] uvx" not in result.stdout
-        assert "[MOCK] uv lock" not in result.stdout


### PR DESCRIPTION
First step of Jebel-Quant/rhiza-tools#327 (see also the principle in Jebel-Quant/rhiza-tools#328).

## Why
Releasing is now agent-driven via the rhiza-claude `/release` command, which derives the next version, bumps `pyproject.toml`, regenerates `CHANGELOG.md`, and creates the tag locally; pushing that tag triggers `rhiza_release.yml`. The `make bump`/`make release` targets were the *only* callers of `uvx rhiza-tools bump|release`, and they are developer-initiated (invoked in no CI workflow). Removing them lets rhiza-tools shed its release commands and keep only headless CI/CD tools.

## What changed
- **`releasing.mk`** — remove the `bump` and `release` targets, their `pre-/post-bump` and `pre-/post-release` hooks, and the `DRY_RUN`/`BUMP`/`PUSH`/`_VERSION` plumbing. **`changelog` and `release-status` are unchanged.**
- **`rhiza.mk`** — drop the removed hooks from `.PHONY`.
- **tests** — remove `TestMakeBump` from `test_makefile_targets.py` (and two now-unused imports). `test_releasing_targets.py` was already scoped to `changelog`/`release-status`, so it needed no change.
- **docs & completions** — remove `make bump`/`make release`/`BUMP=` references and point releasing at `/release`, across: root `README`, `CLAUDE.md`, `QUICK_REFERENCE`, `GLOSSARY`, `TOOLS_REFERENCE`, `DEMO`, `CUSTOMIZATION`, `ARCHITECTURE` (mermaid diagram), `EXTENDING_RHIZA`, `.rhiza/make.d/README`, the presentation bundle, and the bash/zsh completion scripts + their README.

## Impact
Breaking for the template's public surface: downstream repos lose `make bump`/`make release` on their next sync. The release **pipeline** is unaffected — `rhiza_release.yml` still fires on a pushed `v*` tag (now created by `/release`). `make release-status` and `make changelog` remain.

## Verification
- `make help` shows `changelog`/`release-status`, no `bump`/`release`.
- 470 tests pass across the release/makefile/docs/completions/bundle-sync suites (`test_releasing_targets`, `test_makefile_targets`, `test_makefile_api`, `test_doc_consistency`, `test_docs_targets`, `test_completions`, `test_bundle_content_validity`, `test_bundle_sync`).
- markdownlint (repo config, `--disable MD013`, pinned v0.49.0): 0 violations on all changed files (baseline also 0).

## Sequencing
Per #327, the rhiza-tools deletion of `bump`/`release`/`rollback` should land **after** this is merged and downstream repos have re-synced.

> ⚠️ The `.github/workflows/rhiza_codeql.yml` CodeQL manual-build placeholder still contains an illustrative `echo '  make release'`. It's generic "replace-me" boilerplate in a build mode rhiza doesn't use (it `exit 1`s), not a reference to the release feature, so it was intentionally left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)