### PR TITLE
chore: remove all rhiza-tools usage from the template

### DIFF
--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -15,9 +15,10 @@
 #   7. 🐳 Publish Devcontainer - Build and publish devcontainer image (conditional)
 #   8. ✅ Finalize Release - Publish the GitHub release with links
 #
-# 📄 CHANGELOG: not updated here. The rhiza-tools `bump` command folds a freshly
-# generated CHANGELOG.md into the version-bump commit (git-cliff pre-commit hook),
-# so the tagged commit already carries the changelog — no separate post-tag commit.
+# 📄 CHANGELOG: not updated here. The release process (rhiza-claude `/release`)
+# folds a freshly generated CHANGELOG.md into the version-bump commit before the
+# tag is pushed, so the tagged commit already carries the changelog — no separate
+# post-tag commit.
 #
 # 📦 SBOM Generation:
 #   - Generated using CycloneDX format (industry standard for software supply chain security)

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -8,7 +8,6 @@
 #                     runs the full test suite to catch newly-released packages
 #                     that break compatibility before Renovate picks them up.
 #   semgrep         — static analysis with project-specific rules.
-#   pip-audit       — dependency vulnerability scan.
 #   link-check      — verifies all hyperlinks in README.md are reachable.
 #
 # Trigger: Weekly schedule (Monday 08:00 UTC) and manual dispatch.
@@ -110,26 +109,6 @@ jobs:
         env:
           UV_EXTRA_INDEX_URL: ${{ secrets.UV_EXTRA_INDEX_URL }}
         run: make semgrep
-
-  pip-audit:
-    name: Dependency vulnerability scan
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
-        with:
-          version: "0.11.16"
-
-      - name: Run pip-audit
-        run: uvx pip-audit
 
   link-check:
     name: Check links in README.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,9 +124,8 @@ Hook targets use double-colon syntax (`pre-install::`, `post-install::`) and can
 > coverage` and the main `tests/` suite runs *without* a Python coverage number — by design.
 > Both that suite and `make rhiza-test` (which runs the shipped `.rhiza/tests/` suite) exercise
 > Make targets, YAML, and bundle invariants behaviourally, where there is no Python module to
-> cover. (The former suppression/pip-audit utilities that once lived in `.rhiza/utils/` and were
-> coverage-gated here have moved into the `rhiza-tools` package, which owns their tests.) So "no
-> coverage on `make test`" is expected here and does not mean anything is unmeasured. Downstream
+> cover. So "no coverage on `make test`" is expected here and does not mean anything is
+> unmeasured. Downstream
 > consumers that adopt the `tests` bundle *do* have a `src/` and get the full 90% `make test` gate.
 
 ### CI/CD

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Adopt a Rhiza bundle and your project immediately gains:
 - **pytest** with coverage, benchmarks, and property-based testing via Hypothesis
 - **Documentation** via MkDocs + zensical, with optional Marimo notebook exports
 - **Release automation** — version bumping, OIDC PyPI publishing, optional grayskull conda recipe generation (`vars.PUBLISH_CONDA`, defaults to `true`), SLSA provenance
-- **Security scanning** — CodeQL, pip-audit, bandit, secret scanning, Dependabot
+- **Security scanning** — CodeQL, bandit, secret scanning, Dependabot
 - **Shell completions** for bash and zsh (tab-complete all `make` targets)
 
 ## 📝 Architecture Decision Records
@@ -390,7 +390,6 @@ Targets:
 Rhiza Workflows
   sync                  sync with template repository as defined in .rhiza/template.yml
   validate              validate project structure against template repository as defined in .rhiza/template.yml
-  readme                update README.md with current Makefile help output
 
 Bootstrap
   install-uv            ensure uv/uvx is installed
@@ -407,7 +406,6 @@ Releasing and Versioning
 
 Meta
   help                  Display this help message
-  version-matrix        Emit the list of supported Python versions from pyproject.toml
 
 Development and Testing
   test                  run all tests

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -69,7 +69,6 @@ This project implements several security measures:
 ### Code Scanning
 - **CodeQL**: Automated code scanning for Python and GitHub Actions
 - **Bandit**: Python security linter integrated in CI and pre-commit
-- **pip-audit**: Dependency vulnerability scanning
 - **Secret Scanning**: GitHub secret scanning enabled on this repository
 - **Fuzzing**: ClusterFuzzLite exercises Atheris-based fuzz targets on pull requests and scheduled batch runs
 

--- a/bundles/core/.rhiza/rhiza.mk
+++ b/bundles/core/.rhiza/rhiza.mk
@@ -139,9 +139,6 @@ help: print-logo ## Display this help message
 	+@awk 'BEGIN {FS = ":.*##"; printf ""} /^[a-zA-Z_-]+:.*?##/ { printf "  $(BLUE)%-20s$(RESET) %s\n", $$1, $$2 } /^##@/ { printf "\n$(BOLD)%s$(RESET)\n", substr($$0, 5) }' $(MAKEFILE_LIST)
 	+@printf "\n"
 
-version-matrix: install-uv ## Emit the list of supported Python versions from pyproject.toml
-	@${UVX_BIN} "rhiza-tools>=0.2.2" version-matrix
-
 ci-os-matrix: ## Emit GitHub CI OSes (RHIZA_CI_OS_MATRIX as JSON array, default ["ubuntu-latest"])
 	@$(info $(or $(RHIZA_CI_OS_MATRIX),["ubuntu-latest"]))
 

--- a/bundles/github/.github/workflows/rhiza_release.yml
+++ b/bundles/github/.github/workflows/rhiza_release.yml
@@ -26,9 +26,10 @@
 #   7. 🐳 Publish Devcontainer - Build and publish devcontainer image (conditional)
 #   8. ✅ Finalize Release - Publish the GitHub release with links
 #
-# 📄 CHANGELOG: not updated here. The rhiza-tools `bump` command folds a freshly
-# generated CHANGELOG.md into the version-bump commit (git-cliff pre-commit hook),
-# so the tagged commit already carries the changelog — no separate post-tag commit.
+# 📄 CHANGELOG: not updated here. The release process (rhiza-claude `/release`)
+# folds a freshly generated CHANGELOG.md into the version-bump commit before the
+# tag is pushed, so the tagged commit already carries the changelog — no separate
+# post-tag commit.
 #
 # 📦 SBOM Generation:
 #   - Generated using CycloneDX format (industry standard for software supply chain security)

--- a/bundles/gitlab/.gitlab/workflows/rhiza_weekly.yml
+++ b/bundles/gitlab/.gitlab/workflows/rhiza_weekly.yml
@@ -6,7 +6,6 @@
 # Purpose: Slower checks deferred to a weekly schedule:
 #
 #   weekly:semgrep    — Semgrep static analysis (numpy rules).
-#   weekly:pip-audit  — Dependency vulnerability scan.
 #   weekly:link-check — Verifies hyperlinks in README.md are reachable.
 #                       Also runs on push/MR when README.md changes.
 #
@@ -20,18 +19,6 @@ weekly:semgrep:
   script:
     - export UV_EXTRA_INDEX_URL="${UV_EXTRA_INDEX_URL}"
     - make semgrep
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-    - if: $CI_PIPELINE_SOURCE == "web"
-      when: manual
-      allow_failure: true
-
-weekly:pip-audit:
-  stage: test
-  needs: []
-  image: $UV_IMAGE
-  script:
-    - uvx pip-audit
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_PIPELINE_SOURCE == "web"

--- a/bundles/legal/SECURITY.md
+++ b/bundles/legal/SECURITY.md
@@ -70,7 +70,6 @@ This project implements several security measures:
 ### Code Scanning
 - **CodeQL**: Automated code scanning for Python and GitHub Actions
 - **Bandit**: Python security linter integrated in CI and pre-commit
-- **pip-audit**: Dependency vulnerability scanning
 - **Secret Scanning**: GitHub secret scanning enabled on this repository
 - **Fuzzing**: ClusterFuzzLite exercises Atheris-based fuzz targets on pull requests and scheduled batch runs
 

--- a/bundles/tests/.rhiza/make.d/test.mk
+++ b/bundles/tests/.rhiza/make.d/test.mk
@@ -110,15 +110,9 @@ typecheck: install ## run ty and/or mypy type checking (TYPECHECKER=ty|mypy|both
 	    ;; \
 	esac
 
-# Extra flags forwarded to pip-audit (e.g. --ignore-vuln CVE-XXXX-YYYY)
-PIP_AUDIT_ARGS ?=
-
-# The 'security' target performs security vulnerability scans.
-# 1. Runs pip-audit to scan installed dependencies for known vulnerabilities.
-# 2. Runs bandit to find common security issues in Python source folders that exist.
-security: install ## run security scans (pip-audit and bandit)
-	@printf "${BLUE}[INFO] Running pip-audit for dependency vulnerabilities...${RESET}\n"
-	@${UVX_BIN} pip-audit ${PIP_AUDIT_ARGS}
+# The 'security' target runs bandit to find common security issues in the
+# Python source folders that exist.
+security: install ## run security scans (bandit)
 	@bandit_paths=""; \
 	if [ -d "${SOURCE_FOLDER}" ]; then \
 	  bandit_paths="${SOURCE_FOLDER}"; \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,7 @@ docs = [
 ]
 typecheck = [
     # Type checkers for `make typecheck` (uv run ty / mypy). Formerly shipped in
-    # .rhiza/requirements/tools.txt; kept here as a group pending migration into the
-    # rhiza-tools package (which will own the type-checking tooling downstream).
+    # .rhiza/requirements/tools.txt; kept here as a dependency group.
     "ty>=0.0.30",
     "mypy==2.3.0",
     "typer==0.26.8",

--- a/tests/api/test_makefile_api.py
+++ b/tests/api/test_makefile_api.py
@@ -127,6 +127,7 @@ def test_minimal_setup_works(logger, setup_api_env):
 
     # Check that core rhiza targets exist
     assert "Rhiza Workflows" in result.stdout
+    assert "rhiza-test" in result.stdout
 
     # Note: docker-build and other targets from .rhiza/make.d/ are always present
     # but they gracefully skip if their respective folders/files don't exist.

--- a/tests/api/test_makefile_targets.py
+++ b/tests/api/test_makefile_targets.py
@@ -167,11 +167,12 @@ class TestMakefile:
         out = proc.stdout
         assert "uv run --with interrogate interrogate" in out
 
-    def test_security_target_runs_pip_audit_and_bandit(self, logger):
-        """Security target should run pip-audit and bandit (or skip warning)."""
+    def test_security_target_runs_bandit(self, logger):
+        """Security target should run bandit (or skip with a warning)."""
         proc = run_make(logger, ["security"])
         out = proc.stdout
-        assert "pip-audit" in out
+        assert "rhiza-tools" not in out
+        assert "pip-audit" not in out
         assert "Running bandit security scan in:" in out
         assert "No bandit scan folders found" in out
 
@@ -223,7 +224,7 @@ class TestMakefile:
         assert "pre-commit run --all-files" in out  # fmt
         assert "uv run --with pytest" in out  # test / rhiza-test
         assert "uv run --with interrogate interrogate" in out  # docs-coverage
-        assert "pip-audit" in out  # security
+        assert "Running bandit security scan in:" in out  # security
 
     def test_python_version_defaults_to_3_13_if_missing(self, logger, tmp_path):
         """`PYTHON_VERSION` should default to `3.13` if .python-version is missing."""

--- a/tests/api/test_release_workflow.py
+++ b/tests/api/test_release_workflow.py
@@ -1,9 +1,9 @@
 """Tests for the rhiza_release.yml workflow configuration.
 
 Validates that the release workflow is correctly defined. CHANGELOG.md is
-folded into the version-bump commit by the rhiza-tools ``bump`` command (via a
-git-cliff pre-commit hook), so the tagged commit already carries the changelog
-and the workflow no longer commits it separately.
+folded into the version-bump commit by the release process (rhiza-claude
+``/release``) before the tag is pushed, so the tagged commit already carries
+the changelog and the workflow no longer commits it separately.
 """
 
 from __future__ import annotations

--- a/tests/api/test_weekly_workflow.py
+++ b/tests/api/test_weekly_workflow.py
@@ -18,7 +18,7 @@ import yaml
 from tests.util import run_make
 
 WORKFLOW_PATH = Path(".github") / "workflows" / "rhiza_weekly.yml"
-EXPECTED_JOBS = {"dep-compat-test", "semgrep", "pip-audit", "link-check"}
+EXPECTED_JOBS = {"dep-compat-test", "semgrep", "link-check"}
 
 
 # ---------------------------------------------------------------------------
@@ -126,24 +126,12 @@ class TestWeeklyWorkflowMakeTargets:
         result = run_make(logger, ["test"])
         assert result.returncode == 0
 
-    def test_security_target_invokes_pip_audit(self, logger):
-        """Make security dry-run must include a pip-audit invocation."""
-        result = run_make(logger, ["security"])
-        assert result.returncode == 0
-        assert "pip-audit" in result.stdout
-
     def test_security_target_scans_existing_python_or_warns(self, logger):
         """Make security must not silently pass when the default source folder is missing."""
         result = run_make(logger, ["security"])
         assert result.returncode == 0
         assert "Running bandit security scan in:" in result.stdout
         assert "No bandit scan folders found" in result.stdout
-
-    def test_pip_audit_args_forwarded(self, logger):
-        """PIP_AUDIT_ARGS variable must be forwarded to the pip-audit call."""
-        result = run_make(logger, ["security", "PIP_AUDIT_ARGS=--ignore-vuln TEST-0001"])
-        assert result.returncode == 0
-        assert "--ignore-vuln TEST-0001" in result.stdout
 
     def test_semgrep_target_in_help(self, logger):
         """Semgrep target must appear in make help output."""

--- a/tests/security/test_security_md_claims.py
+++ b/tests/security/test_security_md_claims.py
@@ -35,7 +35,6 @@ def _make_fragments_text() -> str:
 _CLAIM_EVIDENCE = {
     "CodeQL": lambda: (_ROOT / ".github" / "workflows" / "rhiza_codeql.yml").is_file(),
     "Bandit": lambda: "bandit" in _read(".pre-commit-config.yaml"),
-    "pip-audit": lambda: "pip-audit" in _make_fragments_text(),
     "Secret Scanning": lambda: (_ROOT / ".github" / "secret_scanning.yml").is_file(),
     "Fuzzing": lambda: (
         (_ROOT / ".github" / "workflows" / "rhiza_fuzzing.yml").is_file()


### PR DESCRIPTION
## Summary

`rhiza-tools` has been reduced to a single command upstream, so this removes **every `uvx rhiza-tools` invocation** from the Rhiza template. Per the retire-all-scanning decision, it also drops the dependency-vulnerability and suppression-density gates.

## Changes

**CI Python matrix (the one replacement, not a deletion)**
- The reusable `generate-matrix` job no longer runs `make version-matrix`. It now uses [`build-and-inspect-python-package`](https://github.com/hynek/build-and-inspect-python-package) (BAIPP, SHA-pinned to v2.18.0), whose `supported_python_classifiers_json_array` output derives the versions from the `Programming Language :: Python :: X.Y` classifiers — the same source of truth. The `version-matrix` make target is removed.

**Pure removals (`uvx rhiza-tools` calls for already-removed commands)**
- `readme` (update-readme) make target
- `suppression-audit` make target + the CI "Fail stale CVE suppressions" step
- `pip-audit` from `make security` (bandit stays); `PIP_AUDIT_ARGS` dropped
- the standalone weekly `uvx pip-audit` job (GitHub `rhiza_weekly.yml` + GitLab bundle)
- the `analyze-benchmarks` reporting step from `make benchmark` (the pytest-benchmark run itself stays)

**Docs & tests**
- `SECURITY.md` (both copies): drop the pip-audit claim
- Updated the contract tests in `tests/api`, `tests/bundles`, `tests/integration`, `tests/security`

## ⚠️ Fleet-wide behavior changes (please review carefully)

1. **BAIPP builds the package** to read classifiers, so the matrix job now **requires a buildable Python package**. Repos Rhiza manages that aren't pip-installable packages (Go, notebook/book/paper, unpackaged apps) will fail the `generate-matrix` job. Deliberate choice over inline classifier parsing.
2. **No dependency-vulnerability (pip-audit) or suppression scanning remains** anywhere in the template. `bandit`, CodeQL, secret scanning, and Dependabot are unaffected.

## Testing

Full suite: **1242 passed, 3 skipped** (skips are env-only: GitLab-docker opt-in, git-lfs absent).

## Related

- rhiza-tools command removals: jebel-quant/rhiza-tools#339, #341 (and #333/#334/#335)
- Cutover hazard this resolves: #1413
- Matrix source-of-truth discussion: #1412
- Not covered: `rhiza_release.yml` still has stale comments referencing the removed `bump` command (tracked in #1413).

🤖 Generated with [Claude Code](https://claude.com/claude-code)