### PR TITLE
chore: release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com),
 and entries are generated from [Conventional Commits](https://www.conventionalcommits.org).
 
+## [1.2.0] - 2026-07-16
+
+### New Features
+- *(bundles)* Remove the claude bundle and its slash commands (#1396)
+
+### Bug Fixes
+- Dockerfile CMD, CHANGELOG duplicate, lazy test sources, NPX guard, git init commit, regex escape (#1395)
+
+### Dependencies
+- *(deps)* Lock file maintenance (#1402)
+- *(deps)* Update dependency typer to v0.26.8 (#1407)
+- *(deps)* Update pre-commit hook astral-sh/uv-pre-commit to v0.11.28 (#1405)
+- *(deps)* Update pre-commit hook astral-sh/ruff-pre-commit to v0.15.21 (#1404)
+- *(deps)* Update dependency mypy to v2.3.0 (#1406)
+
+### Maintenance
+- Remove the automated rhiza_sync feature (sync is now manual) (#1403)
+- Chore(deps)(deps): bump the github-actions group with 6 updates (#1409)
+- De-CLI make sync/validate — drop the rhiza-cli dependency (#1408)
+- Drop make bump/release targets — releasing moves to rhiza-claude /release (#1411)
+- Derive reusable Python matrix from BAIPP classifiers (#1414)
+- Remove rhiza-tools usage from make.d (suppression-audit, pip-audit, analyze-benchmarks) (#1416)
+- Remove all rhiza-tools usage from the template (#1415)
+
+### Other Changes
+- Fix for Module is imported more than once (#1397)
+- Fix for Module is imported more than once (#1398)
+- Fix latent helper hazards and harden dogfood linking path (#1399)
+- Apply suggested fix to tests/bundles/test_bundle_combinations.py from Copilot Autofix (#1400)
+- Potential fix for 1 code quality finding (#1401)
+- Pin required checks to GitHub Actions and protect v* tags (#1410)
+
 ## [1.1.3] - 2026-07-10
 
 ### New Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rhiza"
-version = "1.1.3"
+version = "1.2.0"
 description = "Reusable configuration templates for modern Python projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1077,7 +1077,7 @@ wheels = [
 
 [[package]]
 name = "rhiza"
-version = "1.1.3"
+version = "1.2.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Release v1.2.0

Bumps `1.1.3 → 1.2.0` (pyproject + uv.lock) and adds the CHANGELOG entry.

### Headline
- **rhiza-tools fully removed from the template**; the CI Python-version matrix is now derived from pyproject classifiers by `build-and-inspect-python-package` (#1414, #1415, #1416).
- sync/validate and releasing **de-CLI'd** — drop the rhiza-cli dependency; releasing moves to rhiza-claude `/release` (#1408, #1411).
- Automated `rhiza_sync` removed — sync is now manual (#1403).
- `claude` bundle removed (#1396).
- v* tags protected + required checks pinned to SHAs (#1410).
- Dependency bumps (typer, mypy, ruff/uv pre-commit hooks, github-actions group).

### ⚠️ Adopter-facing note
The reusable CI `generate-matrix` job now uses **BAIPP, which builds the package** to read classifiers — repos that aren't buildable Python packages will fail that job and need an alternative matrix path.

### After merge
Tag `v1.2.0` to trigger the release workflow. Managed repos then bump their `ref:` / workflow `@vX` pins and re-sync; only after that is it safe to publish a `version-matrix`-less rhiza-tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)