### PR TITLE
chore: stop requiring deprecated License classifier

### DIFF
--- a/bundles/tests/.rhiza/tests/test_pyproject.py
+++ b/bundles/tests/.rhiza/tests/test_pyproject.py
@@ -140,7 +140,7 @@ class TestProjectUrls:
 
 
 class TestProjectClassifiers:
-    """Tests for [project].classifiers — Python version and licence entries."""
+    """Tests for [project].classifiers — Python version entries."""
 
     @pytest.fixture
     def classifiers(self, project: dict) -> list[str]:
@@ -156,11 +156,6 @@ class TestProjectClassifiers:
         assert len(python_classifiers) >= 1, (
             "classifiers must include at least one 'Programming Language :: Python :: 3.X' entry"
         )
-
-    def test_license_classifier_present(self, classifiers: list[str]) -> None:
-        """At least one 'License :: ' classifier must be present."""
-        license_classifiers = [c for c in classifiers if c.startswith("License ::")]
-        assert len(license_classifiers) >= 1, "classifiers must include at least one 'License :: ' entry"
 
 
 class TestDependencyGroups:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.2.1"
 description = "Reusable configuration templates for modern Python projects"
 readme = "README.md"
 requires-python = ">=3.11"
-license = { text = "MIT" }
+license = "MIT"
 authors = [
   { name = "Thomas Schmelzer" }
 ]
@@ -19,7 +19,6 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
-    "License :: OSI Approved :: MIT License",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Build Tools",
 ]


### PR DESCRIPTION
## What

PyPI has [deprecated](https://packaging.python.org/en/latest/specifications/license-expression/) the `License ::` trove classifiers in favor of the SPDX `license` expression field. This drops the requirement (and the mother-repo's own usage) accordingly.

- Remove `test_license_classifier_present` from the `tests` bundle (`bundles/tests/.rhiza/tests/test_pyproject.py`) — downstream projects are no longer forced to carry a deprecated classifier.
- Remove `"License :: OSI Approved :: MIT License"` from the root `pyproject.toml` classifiers.
- Modernize the root `license` field from the deprecated table form `{ text = "MIT" }` to the SPDX string `"MIT"` (PEP 639).

## Notes

- The MIT license is still declared via the `license` field, so no license metadata is lost.
- The shipped `test_pyproject.py` still requires the `license` field to be present; the SPDX string satisfies it.
- The python-version classifier check is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)