### PR TITLE
test: forbid deprecated License classifier in pyproject

### DIFF
--- a/bundles/tests/.rhiza/tests/test_pyproject.py
+++ b/bundles/tests/.rhiza/tests/test_pyproject.py
@@ -157,6 +157,18 @@ class TestProjectClassifiers:
             "classifiers must include at least one 'Programming Language :: Python :: 3.X' entry"
         )
 
+    def test_no_license_classifier(self, project: dict) -> None:
+        """No deprecated 'License :: ' classifier may be present.
+
+        PyPI has deprecated the ``License ::`` trove classifiers in favor of the SPDX
+        ``license`` expression field, so the shipped pyproject must not declare one.
+        """
+        classifiers = project.get("classifiers", [])
+        license_classifiers = [c for c in classifiers if c.startswith("License ::")]
+        assert not license_classifiers, (
+            f"classifiers must not include any deprecated 'License :: ' entry; found {license_classifiers}"
+        )
+
 
 class TestDependencyGroups:
     """Tests for [dependency-groups] — ensures required groups are declared."""

--- a/bundles/tests/.rhiza/tests/test_pyproject.py
+++ b/bundles/tests/.rhiza/tests/test_pyproject.py
@@ -140,7 +140,7 @@ class TestProjectUrls:
 
 
 class TestProjectClassifiers:
-    """Tests for [project].classifiers — Python version and licence entries."""
+    """Tests for [project].classifiers — Python version entries."""
 
     @pytest.fixture
     def classifiers(self, project: dict) -> list[str]:
@@ -156,11 +156,6 @@ class TestProjectClassifiers:
         assert len(python_classifiers) >= 1, (
             "classifiers must include at least one 'Programming Language :: Python :: 3.X' entry"
         )
-
-    def test_license_classifier_present(self, classifiers: list[str]) -> None:
-        """At least one 'License :: ' classifier must be present."""
-        license_classifiers = [c for c in classifiers if c.startswith("License ::")]
-        assert len(license_classifiers) >= 1, "classifiers must include at least one 'License :: ' entry"
 
 
 class TestDependencyGroups:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.2.1"
 description = "Reusable configuration templates for modern Python projects"
 readme = "README.md"
 requires-python = ">=3.11"
-license = { text = "MIT" }
+license = "MIT"
 authors = [
   { name = "Thomas Schmelzer" }
 ]
@@ -19,7 +19,6 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
-    "License :: OSI Approved :: MIT License",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Build Tools",
 ]


### PR DESCRIPTION
## Summary

Follow-up to #1429, which dropped the test that *required* a `License ::` trove classifier (PyPI has deprecated them in favor of the SPDX `license` expression field).

This adds the inverse guard so a `License ::` classifier cannot creep back in.

- Add `test_no_license_classifier` to the `tests` bundle, asserting `[project].classifiers` contains no `License :: ` entry.
- Reads `project.get("classifiers", [])` directly (rather than the skip-on-empty fixture) so the assertion holds even when no classifiers are declared.

Edited the bundle source (single source of truth); the root `.rhiza/tests/` symlink reflects it automatically, so downstream consumers adopting the `tests` bundle get this guard too.

## Test plan

- `make rhiza-test` → passes (`test_no_license_classifier` PASSED against the root pyproject).

🤖 Generated with [Claude Code](https://claude.com/claude-code)