### PR TITLE
chore(pyproject): declare explicit Python version classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,6 @@ classifiers = [
     # Deliberate PyPI kill-switch: rhiza_release.yml skips publish when this classifier is present.
     # Remove it to enable publishing (after configuring PyPI Trusted Publisher for the repository).
     "Private :: Do Not Upload",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",


### PR DESCRIPTION
One trove classifier per supported Python version instead of the generic `Programming Language :: Python :: 3` rows.

- `requires-python` is 3.11", so the classifiers are: **3.11,3.12,3.13,3.14**
- removed `Programming Language :: Python :: 3` and `Programming Language :: Python :: 3 :: Only`

Metadata only — no source, dependency, or tooling changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
