### PR TITLE
fix(github): reference own composite action by local path

### DIFF
--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -49,7 +49,7 @@ jobs:
           version: "0.11.16"
 
       - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v1.2.3
+        uses: ./.github/actions/configure-git-auth
         with:
           token: ${{ secrets.GH_PAT }}
 

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -63,7 +63,7 @@ jobs:
           version: "0.11.16"
 
       - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v1.2.3
+        uses: ./.github/actions/configure-git-auth
         with:
           token: ${{ secrets.GH_PAT }}
 

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -112,7 +112,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v1.2.3
+        uses: ./.github/actions/configure-git-auth
         with:
           token: ${{ secrets.GH_PAT }}
 
@@ -172,7 +172,7 @@ jobs:
           version: "0.11.16"
 
       - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v1.2.3
+        uses: ./.github/actions/configure-git-auth
         with:
           token: ${{ secrets.GH_PAT }}
 
@@ -212,7 +212,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v1.2.3
+        uses: ./.github/actions/configure-git-auth
         with:
           token: ${{ secrets.GH_PAT }}
 
@@ -244,7 +244,7 @@ jobs:
           version: "0.11.16"
 
       - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v1.2.3
+        uses: ./.github/actions/configure-git-auth
         with:
           token: ${{ secrets.GH_PAT }}
 
@@ -266,7 +266,7 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v1.2.3
+        uses: ./.github/actions/configure-git-auth
         with:
           token: ${{ secrets.GH_PAT }}
 
@@ -301,7 +301,7 @@ jobs:
           version: "0.11.16"
 
       - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v1.2.3
+        uses: ./.github/actions/configure-git-auth
         with:
           token: ${{ secrets.GH_PAT }}
 
@@ -331,7 +331,7 @@ jobs:
           version: "0.11.16"
 
       - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v1.2.3
+        uses: ./.github/actions/configure-git-auth
         with:
           token: ${{ secrets.GH_PAT }}
 
@@ -360,7 +360,7 @@ jobs:
           version: "0.11.16"
 
       - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v1.2.3
+        uses: ./.github/actions/configure-git-auth
         with:
           token: ${{ secrets.GH_PAT }}
 

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -85,7 +85,7 @@ jobs:
       uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
     - name: Configure git auth for private packages
-      uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v1.2.3
+      uses: ./.github/actions/configure-git-auth
       with:
         token: ${{ secrets.GH_PAT }}
 

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -102,7 +102,7 @@ jobs:
           version: "0.11.16"
 
       - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v1.2.3
+        uses: ./.github/actions/configure-git-auth
         with:
           token: ${{ secrets.GH_PAT }}
 

--- a/.github/workflows/rhiza_mutation.yml
+++ b/.github/workflows/rhiza_mutation.yml
@@ -219,7 +219,7 @@ jobs:
           version: "0.11.16"
 
       - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v1.2.3
+        uses: ./.github/actions/configure-git-auth
         with:
           token: ${{ secrets.GH_PAT }}
 

--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -221,7 +221,7 @@ jobs:
           version: "0.11.16"
 
       - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v1.2.3
+        uses: ./.github/actions/configure-git-auth
         with:
           token: ${{ secrets.GH_PAT }}
 

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -61,7 +61,7 @@ jobs:
           version: "0.11.16"
 
       - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v1.2.3
+        uses: ./.github/actions/configure-git-auth
         with:
           token: ${{ secrets.GH_PAT }}
 
@@ -101,7 +101,7 @@ jobs:
           version: "0.11.16"
 
       - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v1.2.3
+        uses: ./.github/actions/configure-git-auth
         with:
           token: ${{ secrets.GH_PAT }}
 

--- a/bundles/core/.rhiza/.cfg.toml
+++ b/bundles/core/.rhiza/.cfg.toml
@@ -28,10 +28,22 @@ values = [
     "prod"
 ]
 
+# Anchored to the [project] table on purpose. `search`/`replace` are applied to
+# EVERY occurrence in the file, so the obvious `version = "{current_version}"`
+# also rewrites any [tool.*] table that happens to share the current number.
+# Dependency pins (httpx>=1.2.0, rich==1.2.0) are never at risk either way —
+# they are not line-anchored `version = ` assignments — but a second table is.
 [[tool.bumpversion.files]]
 filename = "pyproject.toml"
-search = 'version = "{current_version}"'
-replace = 'version = "{new_version}"'
+regex = true
+search = '(?ms)^\[project\]((?:(?!^\[)[\s\S])*?)^version = "{current_version}"'
+replace = '[project]\1version = "{new_version}"'
+
+# NOTE for downstream projects: do NOT add a glob over your own
+# .github/workflows/*.yml here. Those stubs pin jebel-quant/rhiza's version
+# (the template you sync from), not your project's, so rewriting them with your
+# version would point them at a rhiza tag that does not exist. The template ref
+# is managed by /rhiza:update via .rhiza/template.yml instead.
 
 # Keep the reusable-workflow stubs in the bundles pinned to the current release.
 # These stubs are synced into downstream repos and must reference an existing tag.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,19 +88,17 @@ regex = true
 search = '(?ms)^\[project\]((?:(?!^\[)[\s\S])*?)^version = "{current_version}"'
 replace = '[project]\1version = "{new_version}"'
 
-# Self-references: the live workflows call this repo's OWN composite action, so
-# the pin must move with the release or the published tag ships workflows that
-# invoke the previous version. The search matches ANY prior version (not just
-# {current_version}) so a stub left behind in an earlier release is repaired
-# rather than silently drifting. Third-party pins (actions/checkout@v5) and
-# floating refs (@main) do not match and are never rewritten.
-[[tool.bumpversion.files]]
-glob = ".github/workflows/*.yml"
-regex = true
-search = '(jebel-quant/rhiza/[^@\s]+)@v\d+\.\d+\.\d+'
-replace = '\1@v{new_version}'
-ignore_missing_version = true
-
+# The live workflows under .github/workflows/ are deliberately NOT listed. They
+# reference this repo's own composite action by local path (./.github/actions/...),
+# which needs no version and cannot go stale. Pinning them to a tag of this same
+# repo made every release self-blocking: the branch push published workflows
+# referencing a tag that did not exist yet, so they failed at `Set up job`, and a
+# release PR could never turn its required checks green.
+#
+# The versioned example in the action's README is documentation for downstream
+# consumers, who DO need a cross-repo pin, so it moves with the release. The
+# search matches ANY prior version (not just {current_version}) so a reference
+# left behind by an earlier release is repaired rather than drifting further.
 [[tool.bumpversion.files]]
 filename = ".github/actions/configure-git-auth/README.md"
 regex = true


### PR DESCRIPTION
## Problem

The live workflows pinned this repo's **own** composite action by version tag:

```yaml
uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v1.2.3
```

A cross-repo `uses:` must resolve at `Set up job`, **before checkout**. So every release broke itself: pushing the release commit published workflows referencing a tag that did not exist yet. During the v1.2.3 release, three runs on `main` died instantly:

```
##[error]Unable to resolve action `jebel-quant/rhiza@v1.2.3`, unable to find version `v1.2.3`
```

`(RHIZA) CI` #30455777979, `(RHIZA) CODEQL` #30455778133 and `(RHIZA) BENCHMARK` #30455777988 — none of which are tag-dependent. They only became so via the action pin. The one workflow that genuinely needs the tag, `RELEASE`, runs on `push: tags` and was fine.

**The worse consequence:** `rhiza_ci.yml` runs on `pull_request`, so a release PR carries pins to a tag that doesn't exist yet, its 6 required checks can never go green, and it can never merge. The only way to land a release was to **bypass branch protection**. That is why v1.2.2 shipped with its bundle stubs still pinned to v1.2.1.

## Fix

```yaml
uses: ./.github/actions/configure-git-auth
```

16 call sites across 8 workflows. All 16 already run `actions/checkout` earlier in the same job, so the local path resolves. This ref needs no version, cannot drift, and exercises the action **at the commit under test** rather than the previous release's copy — better dogfooding than the pin was.

Also in this PR:

- Drop the now-dead `.github/workflows/*.yml` glob from `[tool.bumpversion]`. The versioned example in the action's README stays — it is documentation for downstream consumers, who do need a cross-repo pin.
- Port the anchored `[project]` pattern to the downstream template `bundles/core/.rhiza/.cfg.toml`, which still had the naive `search = 'version = "{current_version}"'` form that rewrites any `[tool.*]` table sharing the number.
- Add a note there that consumers must **not** glob their own workflow stubs: those pin *rhiza's* version, not the consumer's, so rewriting them would point at a rhiza tag that does not exist.

## Verification

- `tests/bundles` + `tests/api`: 738 passed, 1 skipped (opt-in GitLab Docker job)
- actionlint passes, which is the check that matters — it validates local action paths resolve
- `bump-my-version --dry-run` now touches exactly `pyproject.toml`, the action README, and the 16 bundle stubs; no live workflow
- No sync test breaks: `test_bundle_github_sync.py` explicitly excludes live workflows, and the `jebel-quant/rhiza` substring assertion in `test_workflow_stubs.py` is satisfied by the boilerplate header comment

**This PR is its own proof** — if its required checks go green, the bypass trap is closed and the next release can be cut through a reviewed PR.

## Still open

`.rhiza/.cfg.toml` is not a filename `bump-my-version` auto-discovers, and nothing passes `--config-file`, so downstream consumers still have no working version-bump config. Fixing that means shipping a root `.bumpversion.toml` from `bundles/core`, which changes what every synced project receives — left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)