### PR TITLE
feat(rust): add the rust-core language layer and a rust-local profile

### DIFF
--- a/.rhiza/template-bundles.schema.json
+++ b/.rhiza/template-bundles.schema.json
@@ -26,6 +26,11 @@
           "standalone": {
             "type": "boolean"
           },
+          "layer": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Names a mutually-exclusive group (e.g. 'language'). Bundles sharing a layer are alternatives: they may claim the same deployment paths, and a profile must select at most one of them."
+          },
           "requires": {
             "type": "array",
             "items": {"type": "string"},

--- a/.rhiza/template-bundles.yml
+++ b/.rhiza/template-bundles.yml
@@ -9,7 +9,7 @@
 #    jebel-quant/rhiza) live in dedicated github-<feature> overlay bundles.
 #
 #    File ownership is expressed through the filesystem: each bundle has a
-#    corresponding directory under bundles/<name>/ in this repository (27 bundles).
+#    corresponding directory under bundles/<name>/ in this repository (28 bundles).
 #    Symlinks point to the real files; overlay bundles (github-*, gitlab-*)
 #    contain the actual injection files directly.
 #
@@ -57,6 +57,7 @@ bundles:
   python-core:
     description: "Python toolchain layer: virtualenv, uv sync, ruff/bandit config, deptry"
     standalone: true
+    layer: language
     requires: [core]
     notes: |
       The Python half of what used to be `core`: `.python-version`, `ruff.toml`,
@@ -69,6 +70,27 @@ bundles:
       know the language. Sibling layers claim the same deployment paths on
       purpose: selecting two at once is a file-ownership conflict, which is the
       intended way for "one language per repo" to fail loudly.
+
+  rust-core:
+    description: "Rust toolchain layer: rustup/cargo, clippy, nextest, llvm-cov, cargo-deny"
+    standalone: true
+    layer: language
+    requires: [core]
+    notes: |
+      The Rust sibling of `python-core`. Ships `rust-toolchain.toml`,
+      `rustfmt.toml`, `clippy.toml`, `deny.toml`, a Rust pre-commit config, a
+      bump-my-version config pointing at `Cargo.toml`/`Cargo.lock`, and
+      `.rhiza/make.d/rust.mk`.
+
+      It carries the test targets too, unlike Python — where pytest, coverage and
+      type checking need their own configuration and get a `tests` bundle. In Rust
+      all four are cargo subcommands with nothing to configure, so splitting them
+      out would create a bundle with no files of its own.
+
+      `typecheck` is clippy: rustc already type-checks, so the analogous gate is
+      the lint pass that runs after it. `docs-coverage` is `RUSTDOCFLAGS`
+      `-D missing_docs`, which is pass/fail rather than a percentage — there is no
+      Rust interrogate, so COVERAGE-style thresholds do not apply.
 
   github:
     description: "GitHub repository configuration (actions, dependabot, templates, rulesets, core workflows)"
@@ -360,6 +382,26 @@ profiles:
       - book
       - marimo
       - tests
+
+  # ============================================================================
+  # RUST-LOCAL - Local-first Rust development
+  # ============================================================================
+  rust-local:
+    description: |
+      Local-first Rust setup with no hosted CI/CD workflow files.
+      The Rust counterpart of `local`: core infrastructure, the Rust toolchain
+      layer (cargo, clippy, nextest, llvm-cov, cargo-deny) and documentation.
+
+      There is deliberately no `rust-github-project` or `rust-gitlab-project`
+      yet. Those profiles are made almost entirely of CI workflows, and the
+      `github`/`gitlab` bundles currently ship Python ones — a release job that
+      runs `uv build` and publishes to PyPI, and a Dependabot config declaring
+      the `uv` ecosystem. Adding them to a Rust profile would deliver CI that
+      fails on the first run, so they arrive together with the Rust workflows.
+    bundles:
+      - core
+      - rust-core
+      - book
 
   # ============================================================================
   # GITHUB-PROJECT - Standard GitHub-hosted project

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,10 @@ The core abstraction is the **bundle** — a named group of configuration files.
 - `python-core` (the Python **language layer**): `.python-version`, `ruff.toml`,
   `.bandit`, the pre-commit config, the bump-my-version config, and
   `.rhiza/make.d/python.mk` (`install`, `all`, `deptry`, `license`, `rhiza-test`)
-- `tests`: pytest, coverage, type checking
+- `rust-core` (the Rust **language layer**): `rust-toolchain.toml`, `rustfmt.toml`,
+  `clippy.toml`, `deny.toml`, a Rust pre-commit config, and `.rhiza/make.d/rust.mk`.
+  Carries its own test targets, unlike Python — see **Language layers**.
+- `tests`: pytest, coverage, type checking (Python; requires `python-core`)
 - `benchmarks`: pytest-benchmark infrastructure and reporting
 - `github`: GitHub repository configuration (actions, dependabot, core workflows)
 - `gitlab`: GitLab CI/CD pipeline configuration and core workflows
@@ -88,7 +91,7 @@ Plus intentional mother-repo overrides that deliberately diverge from their bund
 
 `core` used to be a Python project in disguise: it created a virtualenv, ran `uv sync`
 and named Python gates in `all`. That half now lives in a **language layer** bundle,
-and every profile pairs `core` with exactly one — today only `python-core`.
+and every profile pairs `core` with exactly one: `python-core` or `rust-core`.
 
 The contract between them is a set of **target names**. `book.mk`, `test.mk`, the CI
 workflows and the release pipeline all call `make install` without knowing what the
@@ -101,10 +104,30 @@ project is written in, so a layer must define:
 | `install-uv`, `fmt`, `todos`, `semgrep`, `doctor`, `clean` | core | language-neutral, whatever the project is |
 
 Two rules follow. **Core must never define `install` or `all`** — `tests/api/test_language_layer.py`
-asserts both halves behaviourally. And **layers claim the same deployment paths on
-purpose**: a second layer shipping `.rhiza/make.d/rust.mk` is fine, but two layers in
-one repo is a file-ownership conflict the bundle tests reject, which is how "one
-language per repo" fails loudly rather than silently.
+asserts both halves behaviourally, for both layers. And **layers claim the same
+deployment paths on purpose**: `.pre-commit-config.yaml` and `.rhiza/.cfg.toml` exist
+in both, because those paths are fixed by the tools that read them. A bundle declares
+`layer: language` in `template-bundles.yml` to say so; the ownership tests then permit
+overlap *within* a layer and still reject it everywhere else, and a separate test
+fails any profile that selects two layers at once.
+
+**Gate parity between layers.** Same target names, different engines:
+
+| target | python-core | rust-core |
+| --- | --- | --- |
+| `install` | `uv venv` + `uv sync` | `rustup show` + `cargo fetch` |
+| `test` | pytest | `cargo nextest` + doctests |
+| `coverage` | pytest-cov | `cargo llvm-cov` (same `_tests/coverage.xml` path) |
+| `typecheck` | ty / mypy | `cargo clippy -D warnings` (rustc already type-checks) |
+| `docs-coverage` | interrogate (%) | `RUSTDOCFLAGS=-D missing_docs` (pass/fail) |
+| `security` | bandit + pip-audit | `cargo deny check advisories` |
+| `license` | pip-licenses | `cargo deny check licenses` |
+| unused deps | `deptry` | `deps` → `cargo machete` |
+
+The Rust layer also carries `test`/`coverage`/`typecheck`, which on the Python side
+live in the separate `tests` bundle. That is not an inconsistency: pytest, coverage
+and mypy each need configuration files worth bundling, while their cargo counterparts
+need none, so a `rust-tests` bundle would own no files.
 
 `uv` sits in core, not in the Python layer, because rhiza runs pre-commit, mkdocs and
 semgrep through `uvx` regardless of the project's language. What moved is the
@@ -120,6 +143,7 @@ The root `Makefile` is intentionally thin (~10 lines) and only `include`s `.rhiz
 | --- | --- | --- |
 | `bootstrap.mk` | core | `install-uv` tool bootstrap, install hooks, `clean` |
 | `python.mk` | python-core | `install`, `all`, `deptry`, `license`, `rhiza-test` |
+| `rust.mk` | rust-core | `install`, `all`, and the cargo-backed gates |
 | `doctor.mk` | core | `make doctor` environment checks |
 | `quality.mk` | core | `fmt`, `todos`, `semgrep` — the language-neutral gates |
 | `custom-env.mk` | core | example stub: project variables |

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Rhiza provides **profiles** — named presets that select a sensible set of bund
 | Profile | Description | Includes |
 |---------|-------------|---------|
 | `local` | Local-first development with no hosted CI/CD workflow files | `core`, `python-core`, `book`, `marimo`, `tests` |
+| `rust-local` | Local-first Rust development, no hosted CI/CD (hosted profiles arrive with the Rust workflows) | `core`, `rust-core`, `book` |
 | `github-project` | GitHub-hosted project with CI/CD and release automation | `core`, `python-core`, `github`, `book`, `marimo`, `tests`, `github-book`, `github-marimo`, `github-tests` |
 | `gitlab-project` | GitLab-hosted project with GitLab CI/CD pipelines | `core`, `python-core`, `gitlab`, `book`, `marimo`, `tests`, `gitlab-book`, `gitlab-marimo`, `gitlab-tests` |
 
@@ -227,6 +228,7 @@ Any bundle can be selected on its own — its dependencies are resolved and inst
 |--------|-------------|---------------|
 | `core` | Core Rhiza infrastructure, language-neutral (Makefile, help, uv as tool runner) | — |
 | `python-core` | Python language layer (`install`/`all`, virtualenv, ruff, bandit, deptry) | `core` |
+| `rust-core` | Rust language layer (`install`/`all`, cargo, clippy, nextest, llvm-cov, cargo-deny) | `core` |
 | `tests` | Local testing infrastructure with pytest, coverage, and type checking | `book`, `core`, `python-core` |
 | `book` | Comprehensive documentation book (API docs, coverage, notebooks) | `core` |
 | `marimo` | Interactive Marimo notebooks for data exploration and documentation | `book`, `core`, `python-core` |

--- a/bundles/core/.gitignore
+++ b/bundles/core/.gitignore
@@ -120,3 +120,9 @@ local.mk
 
 .bandit-baseline.json
 
+
+# Rust (rust-core bundle). Kept in core rather than the language layer because
+# .gitignore has one owner and git opens it with O_NOFOLLOW, so it cannot be a
+# per-layer file. These entries are inert in a Python repo.
+target/
+**/*.rs.bk

--- a/bundles/rust-core/.pre-commit-config.yaml
+++ b/bundles/rust-core/.pre-commit-config.yaml
@@ -1,0 +1,93 @@
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
+#
+# The Rust counterpart of python-core's config. Same path on purpose — pre-commit
+# hard-codes `.pre-commit-config.yaml`, so the two language layers are alternatives
+# rather than files that could coexist.
+#
+# The neutral hooks (markdownlint, actionlint, schema validation, secret scanning,
+# the rhiza hooks) are identical in both. What differs: ruff/bandit/interrogate and
+# the uv lock check are replaced by rustfmt, clippy and a Cargo.lock check.
+#
+# Pin node so pre-commit provisions a compatible runtime instead of using the
+# system node. Some npm-based hooks (markdownlint-cli) pull transitive deps that
+# reject odd-numbered current node releases (e.g. v25), failing on EBADENGINE.
+default_language_version:
+  node: "24.12.0"
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-toml
+      - id: check-yaml
+        args: ['--unsafe']
+
+  - repo: local
+    hooks:
+      - id: no-rej-files
+        name: Reject .rej files
+        entry: "bash -c 'find . -type f -name \"*.rej\" | grep -q . && { echo \"ERROR: .rej files detected\"; find . -type f -name \"*.rej\"; exit 1; } || exit 0'"
+        language: system
+        pass_filenames: false
+
+      # `language: system` rather than pre-commit's built-in rust support: the
+      # toolchain is already pinned by rust-toolchain.toml, and letting pre-commit
+      # provision a second one would let the hook and `make typecheck` disagree.
+      - id: cargo-fmt
+        name: cargo fmt
+        entry: cargo fmt --all --
+        language: system
+        types: [rust]
+        pass_filenames: false
+
+      - id: cargo-clippy
+        name: cargo clippy (warnings as errors)
+        entry: cargo clippy --all-targets -- -D warnings
+        language: system
+        types: [rust]
+        pass_filenames: false
+
+      # The analogue of python-core's uv-lock hook: a Cargo.toml change that does
+      # not update Cargo.lock leaves a tree that dirties itself on the next build.
+      - id: cargo-lock-is-current
+        name: Cargo.lock is up to date
+        entry: cargo metadata --locked --format-version 1
+        language: system
+        files: ^(Cargo\.toml|Cargo\.lock)$
+        pass_filenames: false
+
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.49.0
+    hooks:
+      - id: markdownlint
+        args: ["--disable", "MD013"]
+
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.37.4
+    hooks:
+      - id: check-renovate
+        args: [ "--verbose" ]
+
+      - id: check-github-workflows
+        args: ["--verbose"]
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
+
+  - repo: https://github.com/betterleaks/betterleaks
+    rev: v1.7.2
+    hooks:
+      - id: betterleaks
+
+  - repo: https://github.com/Jebel-Quant/rhiza-hooks
+    rev: v0.7.0  # Use the latest release
+    hooks:
+      - id: check-rhiza-workflow-names
+      - id: update-readme-help
+      - id: check-rhiza-config
+      - id: check-makefile-targets
+      # check-python-version-consistency is deliberately absent: there is no
+      # .python-version in a Rust repo for it to reconcile.

--- a/bundles/rust-core/.rhiza/.cfg.toml
+++ b/bundles/rust-core/.rhiza/.cfg.toml
@@ -1,0 +1,47 @@
+[tool.bumpversion]
+parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:-(?P<release>[a-z]+)\\.(?P<pre_n>\\d+))?"
+serialize = ["{major}.{minor}.{patch}-{release}.{pre_n}", "{major}.{minor}.{patch}"]
+search = "{current_version}"
+replace = "{new_version}"
+regex = false
+ignore_missing_version = false
+ignore_missing_files = false
+tag = true
+sign_tags = false
+tag_name = "v{new_version}"
+tag_message = "Bump version: {current_version} → {new_version}"
+allow_dirty = false
+commit = true
+message = "Chore: bump version {current_version} → {new_version}"
+commit_args = ""
+# Cargo.lock records the crate's own version, so bumping only Cargo.toml leaves a
+# stale lockfile and the next `cargo build` dirties the tree. `--offline` keeps the
+# hook from hitting the network just to rewrite one line.
+pre_commit_hooks = ["cargo update --workspace --offline", "git add Cargo.lock"]
+
+# SemVer pre-releases, not PEP 440: Cargo rejects "1.2.3-a.1" style short forms,
+# so the value list is the spelled-out set only.
+[tool.bumpversion.parts.release]
+optional_value = "prod"
+values = [
+    "dev",
+    "alpha",
+    "beta",
+    "rc",
+    "prod"
+]
+
+# Anchored to the [package] table on purpose. `search`/`replace` are applied to
+# EVERY occurrence in the file, so an unanchored `version = "{current_version}"`
+# would also rewrite a [dependencies] entry that happens to share the number.
+[[tool.bumpversion.files]]
+filename = "Cargo.toml"
+regex = true
+search = '(?ms)^\[package\]((?:(?!^\[)[\s\S])*?)^version = "{current_version}"'
+replace = '[package]\1version = "{new_version}"'
+
+# Cargo.lock is deliberately NOT listed as a file here. It records the crate's own
+# version *and* every dependency's, and bump-my-version applies `search` to every
+# occurrence in a file — so an entry for it would rewrite any dependency pinned at
+# the same number as the crate. The `cargo update --workspace` pre-commit hook
+# above is the safe way to refresh it: cargo knows which entry is ours.

--- a/bundles/rust-core/.rhiza/make.d/rust.mk
+++ b/bundles/rust-core/.rhiza/make.d/rust.mk
@@ -1,0 +1,141 @@
+## .rhiza/make.d/rust.mk - the Rust language layer (bundle: rust-core)
+#
+# The Rust sibling of python.mk. `core` provides the make framework and uv/uvx as
+# a tool runner (pre-commit, mkdocs and semgrep run through uvx whatever the
+# project is written in); this file turns that into a Rust project.
+#
+# It keeps the language-layer contract: `install` and `all` mean the same thing
+# they do in python.mk, so book.mk and the CI workflows can call them without
+# knowing the language. Only one language layer is ever synced into a repo.
+#
+# Unlike Python, the test targets live here rather than in a separate `tests`
+# bundle: pytest, coverage and type checking each need configuration files, while
+# their Rust counterparts are cargo subcommands with nothing to configure.
+
+# Declare phony targets (they don't produce files)
+.PHONY: all cargo-tools coverage deps docs-coverage install license rhiza-test security test typecheck
+
+CARGO ?= cargo
+RUSTUP ?= rustup
+
+# Extra flags for the whole gate set — e.g. CARGO_FLAGS="--all-features".
+CARGO_FLAGS ?=
+
+# Coverage floor, mirroring COVERAGE_FAIL_UNDER in the Python layer.
+COVERAGE_FAIL_UNDER ?= 90
+
+# Tools installed on demand by `cargo-tools`. cargo-binstall fetches prebuilt
+# binaries where a project publishes them and falls back to a source build, which
+# turns a multi-minute `cargo install` into seconds on CI.
+CARGO_TOOLS ?= cargo-nextest cargo-llvm-cov cargo-deny cargo-machete
+
+##@ Rust
+install: pre-install ## install the toolchain and fetch dependencies
+	@if ! command -v $(RUSTUP) >/dev/null 2>&1; then \
+	  printf "${RED}[ERROR] rustup not found.${RESET}\n"; \
+	  printf "${YELLOW}       Install it by following https://rustup.rs${RESET}\n"; \
+	  printf "${YELLOW}       (or your platform's package manager: brew install rustup)${RESET}\n"; \
+	  exit 1; \
+	fi
+
+	# rust-toolchain.toml pins the channel and components; `rustup show` is what
+	# materialises them, because rustup installs a pinned toolchain lazily.
+	@if [ -f "rust-toolchain.toml" ]; then \
+	  printf "${BLUE}[INFO] Installing the toolchain pinned in rust-toolchain.toml${RESET}\n"; \
+	  $(RUSTUP) show >/dev/null; \
+	else \
+	  printf "${YELLOW}[WARN] No rust-toolchain.toml found, using the active default toolchain${RESET}\n"; \
+	fi
+
+	@if [ -f "Cargo.toml" ]; then \
+	  printf "${BLUE}[INFO] Fetching dependencies${RESET}\n"; \
+	  $(CARGO) fetch --locked 2>/dev/null || $(CARGO) fetch; \
+	else \
+	  printf "${YELLOW}[WARN] No Cargo.toml found, skipping fetch${RESET}\n"; \
+	fi
+
+	# Install pre-commit hooks (skip when core.hooksPath is set, e.g. by an
+	# external hook manager — pre-commit refuses to install in that case)
+	@if [ -f ".pre-commit-config.yaml" ]; then \
+	  if [ -n "$$(git config --get core.hooksPath 2>/dev/null)" ]; then \
+	    printf "${BLUE}[INFO] Skipping pre-commit hook install: core.hooksPath is set${RESET}\n"; \
+	  else \
+	    printf "${BLUE}[INFO] Installing pre-commit hooks...${RESET}\n"; \
+	    ${UVX_BIN} -p ${PYTHON_VERSION} pre-commit install || { printf "${YELLOW}[WARN] Failed to install pre-commit hooks${RESET}\n"; }; \
+	  fi; \
+	fi
+
+	@$(MAKE) post-install
+
+	@printf "\n${GREEN}[SUCCESS] Installation complete!${RESET}\n\n"
+
+cargo-tools: ## install the cargo subcommands the gates need (idempotent)
+	@if ! command -v cargo-binstall >/dev/null 2>&1; then \
+	  printf "${BLUE}[INFO] Installing cargo-binstall${RESET}\n"; \
+	  $(CARGO) install cargo-binstall --locked || { printf "${RED}[ERROR] Failed to install cargo-binstall${RESET}\n"; exit 1; }; \
+	fi
+	@missing=""; \
+	for tool in $(CARGO_TOOLS); do \
+	  command -v $$tool >/dev/null 2>&1 || missing="$$missing $$tool"; \
+	done; \
+	if [ -n "$$missing" ]; then \
+	  printf "${BLUE}[INFO] Installing:${RESET}$$missing\n"; \
+	  cargo-binstall --no-confirm --locked $$missing || { printf "${RED}[ERROR] Failed to install cargo tools${RESET}\n"; exit 1; }; \
+	else \
+	  printf "${BLUE}[INFO] All cargo tools already installed${RESET}\n"; \
+	fi
+
+all: fmt test docs-coverage security deps license typecheck rhiza-test ## run all CI targets locally
+
+# Double-colon, matching test.mk: book.mk declares `test:: ; @:` as a no-op default
+# so `make book` works without a test bundle, and make rejects a target that has both
+# a `:` and a `::` rule.
+test:: install cargo-tools ## run the test suite with nextest
+	@printf "${BLUE}[INFO] Running tests${RESET}\n"
+	@rm -rf _tests
+	@mkdir -p _tests
+	@$(CARGO) nextest run --all-targets $(CARGO_FLAGS)
+	# nextest does not run doctests — cargo test does, and they are real tests.
+	@printf "${BLUE}[INFO] Running doctests${RESET}\n"
+	@$(CARGO) test --doc $(CARGO_FLAGS)
+
+coverage: install cargo-tools ## measure coverage and emit the reports book.mk consumes
+	@printf "${BLUE}[INFO] Measuring coverage (floor: $(COVERAGE_FAIL_UNDER)%%)${RESET}\n"
+	@mkdir -p _tests/html-coverage
+	# Cobertura XML at exactly the path book.mk's badge step reads, so the docs
+	# site gets a measured coverage badge on Rust projects too.
+	@$(CARGO) llvm-cov nextest \
+		--all-targets $(CARGO_FLAGS) \
+		--fail-under-lines $(COVERAGE_FAIL_UNDER) \
+		--cobertura --output-path _tests/coverage.xml
+	@$(CARGO) llvm-cov report --html --output-dir _tests/html-coverage
+
+typecheck: install ## lint with clippy, warnings as errors (rustc already type-checks)
+	@printf "${BLUE}[INFO] Running clippy${RESET}\n"
+	@$(CARGO) clippy --all-targets $(CARGO_FLAGS) -- -D warnings
+
+docs-coverage: install ## fail on any undocumented public item
+	@printf "${BLUE}[INFO] Building docs with missing_docs denied${RESET}\n"
+	@RUSTDOCFLAGS="-D missing_docs -D rustdoc::broken_intra_doc_links" \
+		$(CARGO) doc --no-deps $(CARGO_FLAGS)
+
+security: install cargo-tools ## scan dependencies for known advisories
+	@printf "${BLUE}[INFO] Running cargo-deny advisories${RESET}\n"
+	@$(CARGO) deny check advisories
+
+deps: install cargo-tools ## report unused dependencies (the deptry analogue)
+	@printf "${BLUE}[INFO] Checking for unused dependencies${RESET}\n"
+	@$(CARGO) machete
+
+license: install cargo-tools ## run license compliance scan (allow-list in deny.toml)
+	@printf "${BLUE}[INFO] Running license compliance scan${RESET}\n"
+	@$(CARGO) deny check licenses
+
+rhiza-test: install ## run rhiza's own tests (if any)
+	# The template's self-tests validate READMEs and YAML, not Python code, so they
+	# stay Python and run through uvx here rather than being ported to Rust.
+	@if [ -d ".rhiza/tests" ]; then \
+		${UV_BIN} run --with pytest --with pytest-timeout --with python-dotenv --with packaging pytest .rhiza/tests; \
+	else \
+		printf "${YELLOW}[WARN] No .rhiza/tests directory found, skipping rhiza-tests${RESET}\n"; \
+	fi

--- a/bundles/rust-core/clippy.toml
+++ b/bundles/rust-core/clippy.toml
@@ -1,0 +1,18 @@
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
+#
+# Thresholds only. Which *lints* run is a crate-level decision — put
+# `[lints.clippy]` in your Cargo.toml for that — because a lint set is about the
+# code being written, not about the infrastructure the template provides.
+# `make typecheck` runs `cargo clippy --all-targets -- -D warnings`, so whatever
+# you enable there is enforced.
+
+# Clippy reads the MSRV to avoid suggesting APIs older toolchains lack. Left
+# commented because the template cannot know yours: uncomment and match
+# `[package].rust-version` if you declare one.
+# msrv = "1.85.0"
+
+# A published crate should not have its signatures churned by a lint suggestion.
+# Set to true in a library whose API is stable; false is the safer default while
+# a crate is pre-1.0.
+avoid-breaking-exported-api = false

--- a/bundles/rust-core/deny.toml
+++ b/bundles/rust-core/deny.toml
@@ -1,0 +1,52 @@
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
+#
+# cargo-deny backs two make targets that are separate scans on purpose:
+#   make security  -> cargo deny check advisories   (RustSec: known CVEs)
+#   make license   -> cargo deny check licenses     (the allow-list below)
+#
+# The Python layer uses pip-audit + bandit and pip-licenses for the same two jobs.
+
+[graph]
+# Check every target, not just the host. A dependency that is sound on Linux and
+# advisory-ridden on Windows should fail the scan on either developer's machine.
+all-features = true
+
+[advisories]
+# Advisories with no fix available yet, each as "RUSTSEC-0000-0000". Every entry
+# is a decision to ship a known issue, so keep it short and dated in review.
+ignore = []
+
+[licenses]
+# Permissive licences only. This mirrors LICENSE_FAIL_ON = "GPL;LGPL;AGPL" in the
+# Python layer, but as an allow-list rather than a deny-list: a crate whose
+# licence is not named here fails the scan, so a new copyleft dependency cannot
+# arrive unnoticed just because nobody thought to deny it.
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "CC0-1.0",
+    "ISC",
+    "MIT",
+    "MIT-0",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+]
+confidence-threshold = 0.9
+
+[bans]
+# Two copies of a crate is normal in a large graph and not worth failing over,
+# but it is worth seeing — duplicates inflate build times and binary size.
+multiple-versions = "warn"
+wildcards = "deny"
+
+[sources]
+# Anything not from crates.io is a supply-chain decision that should be explicit.
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/bundles/rust-core/rust-toolchain.toml
+++ b/bundles/rust-core/rust-toolchain.toml
@@ -1,0 +1,20 @@
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
+#
+# The single source of truth for the toolchain, the way `.python-version` is for
+# Python. rustup reads it automatically, so `cargo` inside this directory always
+# uses the channel below — no activation step, and CI needs no separate pin.
+
+[toolchain]
+# `stable` rather than a pinned "1.xx": rustup resolves it at install time, and a
+# template cannot know which release a consuming project wants. Pin a concrete
+# version here in your own repo if you need reproducible builds — and note that
+# `[package].rust-version` (MSRV) in Cargo.toml is a *different* promise: the
+# oldest toolchain your crate supports, not the one you develop on.
+channel = "stable"
+
+# rustfmt and clippy back `make fmt` and `make typecheck`; llvm-tools-preview is
+# what cargo-llvm-cov instruments with, so `make coverage` fails without it.
+components = ["rustfmt", "clippy", "llvm-tools-preview"]
+
+profile = "minimal"

--- a/bundles/rust-core/rustfmt.toml
+++ b/bundles/rust-core/rustfmt.toml
@@ -1,0 +1,17 @@
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
+#
+# Deliberately small. Most of the interesting rustfmt options (imports_granularity,
+# group_imports, wrap_comments, format_code_in_doc_comments) are nightly-only —
+# rustfmt ignores them on stable and prints a warning, so shipping them in a
+# template would produce noise and formatting that differs between contributors.
+# Only stable options belong here.
+
+# Rust's default is 100; stated explicitly so it matches the line length the
+# markdown and Python linting in this template already use.
+max_width = 100
+
+newline_style = "Unix"
+
+use_field_init_shorthand = true
+use_try_shorthand = true

--- a/docs/reference/BUNDLE_TAXONOMY.md
+++ b/docs/reference/BUNDLE_TAXONOMY.md
@@ -29,6 +29,7 @@ the source of truth for the exact set. See
 |--------|---------|
 | `core` | Required base, and language-neutral: thin Makefile, `.rhiza/` modular make system, help/logo machinery, and uv/uvx as a tool runner. Not a working repo on its own. |
 | `python-core` | The Python language layer: virtualenv and `uv sync` (`install`), `.python-version`, `ruff.toml`, `.bandit`, pre-commit config, `deptry` and licence scans, and the `all` aggregate. Exactly one language layer per repo. |
+| `rust-core` | The Rust language layer: rustup and `cargo fetch` (`install`), `rust-toolchain.toml`, `rustfmt.toml`, `clippy.toml`, `deny.toml`, pre-commit config, and the test/coverage/lint gates. Carries its own test targets — in Rust they are cargo subcommands with nothing to configure. |
 | `tests` | Local testing: pytest, coverage, and type checking. |
 | `benchmarks` | Performance benchmarking with `pytest-benchmark` and reporting (builds on `tests`). |
 | `book` | Documentation site with MkDocs + zensical. |
@@ -82,6 +83,7 @@ context and Rhiza expands it to a sensible bundle set.
 | `local` | `core`, `python-core`, `tests`, `book`, `marimo` | Local-first work with no hosted CI (experiments, private/other-host repos). |
 | `github-project` | the `local` set + `github` and the `github-*` overlays | A standard GitHub-hosted project. |
 | `gitlab-project` | the `local` set + `gitlab` and the `gitlab-*` overlays | A standard GitLab-hosted project. |
+| `rust-local` | `core`, `rust-core`, `book` | A Rust project. Hosted-CI Rust profiles arrive with the Rust workflows — the `github`/`gitlab` bundles currently ship Python CI. |
 
 ## Adoption flow
 

--- a/docs/reference/GLOSSARY.md
+++ b/docs/reference/GLOSSARY.md
@@ -44,6 +44,7 @@ flowchart LR
     subgraph Foundation["Foundation"]
         core["core"]
         python_core["python-core"]
+        rust_core["rust-core"]
     end
 
     subgraph Local["Local-first bundles"]
@@ -81,6 +82,7 @@ flowchart LR
     end
 
     python_core --> core
+    rust_core --> core
     github --> core
     gitlab --> core
     book --> core

--- a/tests/api/test_language_layer.py
+++ b/tests/api/test_language_layer.py
@@ -54,6 +54,67 @@ class TestPythonLayerProvidesTheContract:
         assert "no rule to make target" not in proc.stderr.lower()
 
 
+class TestRustLayerKeepsTheSameContract:
+    """`rust-core` is a peer of `python-core`, not a special case.
+
+    The mother repo is a Python project, so the Rust layer cannot be dogfooded at the
+    root — these assemble it into a temp dir instead. They deliberately do not invoke
+    cargo: what matters here is that the layer *declares* the same contract, which is
+    what lets book.mk and the CI workflows stay language-agnostic.
+    """
+
+    @pytest.fixture(autouse=True)
+    def rust_project(self, root: Path, tmp_path: Path, monkeypatch):
+        """Assemble core + rust-core into a project, standing in for a sync."""
+        project = tmp_path / "rust-project"
+        (project / ".rhiza" / "make.d").mkdir(parents=True)
+        shutil.copy(root / "Makefile", project / "Makefile")
+        shutil.copy(root / ".rhiza" / "rhiza.mk", project / ".rhiza" / "rhiza.mk")
+        for fragment in (root / "bundles" / "core" / ".rhiza" / "make.d").iterdir():
+            shutil.copy(fragment, project / ".rhiza" / "make.d" / fragment.name)
+        shutil.copy(
+            root / "bundles" / "rust-core" / ".rhiza" / "make.d" / "rust.mk",
+            project / ".rhiza" / "make.d" / "rust.mk",
+        )
+        (project / "Cargo.toml").write_text('[package]\nname = "demo"\nversion = "0.1.0"\n')
+        monkeypatch.chdir(project)
+        setup_rhiza_git_repo()
+        self.project = project
+
+    @pytest.mark.parametrize("target", LANGUAGE_LAYER_TARGETS)
+    def test_every_contract_target_resolves(self, logger, target):
+        """The same names python-core provides, so callers need not branch."""
+        proc = run_make(logger, [target], check=False)
+        assert "no rule to make target" not in proc.stderr.lower()
+
+    @pytest.mark.parametrize(
+        ("target", "expected"),
+        [
+            ("typecheck", "clippy"),
+            ("security", "deny check advisories"),
+            ("license", "deny check licenses"),
+            ("deps", "machete"),
+            ("test", "nextest"),
+        ],
+    )
+    def test_gate_maps_to_its_cargo_equivalent(self, logger, target, expected):
+        """Each Python gate has a Rust counterpart under the same target name."""
+        out = strip_ansi(run_make(logger, [target], check=False).stdout)
+        assert expected in out, f"`make {target}` should run {expected}"
+
+    def test_coverage_writes_the_report_book_mk_reads(self, logger):
+        """book.mk badges `_tests/coverage.xml`; llvm-cov must write exactly that path."""
+        out = strip_ansi(run_make(logger, ["coverage"], check=False).stdout)
+        assert "_tests/coverage.xml" in out
+        assert "--cobertura" in out
+
+    def test_install_does_not_reach_for_uv_sync(self, logger):
+        """A Rust `install` is rustup + cargo fetch; uv is only the tool runner."""
+        out = strip_ansi(run_make(logger, ["install"], check=False).stdout)
+        assert "cargo fetch" in out
+        assert "uv sync" not in out
+
+
 class TestCoreAloneHasNoLanguageLayer:
     """Without a layer, core is inert on exactly the targets a layer owns."""
 

--- a/tests/bundles/test_bundle_rhiza_sync.py
+++ b/tests/bundles/test_bundle_rhiza_sync.py
@@ -3,6 +3,12 @@
 Each bundle that ships a .rhiza/ subdirectory is the authoritative source for those
 files. The root .rhiza/ directory is the union of all those bundle-owned files, so
 every bundle file must byte-for-byte match its root counterpart.
+
+With one unavoidable exception: the mother repo can only dogfood **one** language
+layer. It is a Python project, so it runs `python-core`; `rust-core` claims the same
+`.rhiza/.cfg.toml` path and would add a second `install` target, so its files have no
+root counterpart by design. They are covered instead by the synced-project tests in
+`tests/api/test_language_layer.py`, which materialise the layer into a temp dir.
 """
 
 from __future__ import annotations
@@ -12,6 +18,11 @@ from pathlib import Path
 import pytest
 
 _ROOT = Path(__file__).resolve().parents[2]
+
+# Language layers the mother repo does not run on. Exactly one language layer can be
+# dogfooded at a time — rhiza is a Python project — and a sibling layer's files
+# deliberately collide with the active one's.
+_NOT_DOGFOODED = {"rust-core"}
 
 
 def _bundle_rhiza_pairs() -> list[tuple[str, Path, Path]]:
@@ -25,6 +36,8 @@ def _bundle_rhiza_pairs() -> list[tuple[str, Path, Path]]:
 
     for bundle_dir in sorted(bundles_dir.iterdir()):
         if not bundle_dir.is_dir():
+            continue
+        if bundle_dir.name in _NOT_DOGFOODED:
             continue
         bundle_rhiza = bundle_dir / ".rhiza"
         if not bundle_rhiza.is_dir():

--- a/tests/bundles/test_template_bundles.py
+++ b/tests/bundles/test_template_bundles.py
@@ -196,6 +196,7 @@ class TestTemplateBundles:
         requires = {name: (cfg or {}).get("requires", []) for name, cfg in bundles_data["bundles"].items()}
 
         def closure(seeds: list[str]) -> set[str]:
+            """Resolve the transitive bundle closure for the seeds."""
             seen: set[str] = set()
             stack = list(seeds)
             while stack:

--- a/tests/bundles/test_template_bundles.py
+++ b/tests/bundles/test_template_bundles.py
@@ -29,6 +29,19 @@ import pytest
 import yaml
 
 
+def _layers(bundles_data: dict) -> dict[str, str]:
+    """Map bundle name -> its ``layer`` group, for bundles that declare one."""
+    return {
+        name: (config or {})["layer"] for name, config in bundles_data["bundles"].items() if (config or {}).get("layer")
+    }
+
+
+def _all_in_one_layer(owners: list[str], layers: dict[str, str]) -> bool:
+    """Are all *owners* declared members of the same (single) layer group?"""
+    groups = {layers.get(owner) for owner in owners}
+    return len(groups) == 1 and None not in groups
+
+
 def _bundle_dependency_graph(bundles: dict) -> dict[str, set[str]]:
     """Return the bundle dependency graph in TopologicalSorter input format."""
     return {name: set(config.get("requires", [])) for name, config in bundles.items()}
@@ -151,7 +164,15 @@ class TestTemplateBundles:
             pytest.fail("\nBroken symlinks found in bundle dirs:\n" + "\n".join(errors))
 
     def test_no_file_ownership_conflicts(self, bundles_data, bundles_root):
-        """Test that no deployment path is claimed by more than one bundle."""
+        """Test that no deployment path is claimed by more than one bundle.
+
+        Bundles in the same ``layer`` are the one exception. A layer names a set of
+        mutually-exclusive alternatives — the language layers ``python-core`` and
+        ``rust-core`` both have to ship ``.pre-commit-config.yaml``, because that path
+        is fixed by the tool. Overlap *within* one layer is the design; overlap with
+        anything outside it is still a conflict.
+        """
+        layers = _layers(bundles_data)
         dest_owners: dict[str, list[str]] = {}
         for name in bundles_data["bundles"]:
             bundle_dir = bundles_root / name
@@ -160,10 +181,55 @@ class TestTemplateBundles:
             for dep_path in _deployment_paths(bundle_dir):
                 dest_owners.setdefault(dep_path, []).append(name)
 
-        conflicts = {dest: owners for dest, owners in dest_owners.items() if len(owners) > 1}
+        conflicts = {
+            dest: owners
+            for dest, owners in dest_owners.items()
+            if len(owners) > 1 and not _all_in_one_layer(owners, layers)
+        }
         if conflicts:
             lines = [f"  {dest}: {owners}" for dest, owners in sorted(conflicts.items())]
             pytest.fail("\nFile ownership conflicts (same deployment path in multiple bundles):\n" + "\n".join(lines))
+
+    def test_a_profile_never_selects_two_bundles_from_one_layer(self, bundles_data):
+        """Two language layers in one profile would be last-write-wins on shared paths."""
+        layers = _layers(bundles_data)
+        requires = {name: (cfg or {}).get("requires", []) for name, cfg in bundles_data["bundles"].items()}
+
+        def closure(seeds: list[str]) -> set[str]:
+            seen: set[str] = set()
+            stack = list(seeds)
+            while stack:
+                name = stack.pop()
+                if name in seen:
+                    continue
+                seen.add(name)
+                stack.extend(requires.get(name, []))
+            return seen
+
+        for profile, cfg in (bundles_data.get("profiles") or {}).items():
+            chosen: dict[str, list[str]] = {}
+            for bundle in closure(cfg["bundles"]):
+                if bundle in layers:
+                    chosen.setdefault(layers[bundle], []).append(bundle)
+            for layer, members in chosen.items():
+                assert len(members) == 1, (
+                    f"profile '{profile}' selects {sorted(members)} — two bundles from the "
+                    f"'{layer}' layer, which claim the same deployment paths"
+                )
+
+    def test_every_profile_selects_a_language_layer(self, bundles_data):
+        """`core` defines no `install`/`all`, so a profile without a layer is unusable."""
+        layers = _layers(bundles_data)
+        language_bundles = {name for name, layer in layers.items() if layer == "language"}
+        requires = {name: (cfg or {}).get("requires", []) for name, cfg in bundles_data["bundles"].items()}
+
+        for profile, cfg in (bundles_data.get("profiles") or {}).items():
+            selected = set(cfg["bundles"])
+            for bundle in list(selected):
+                selected.update(requires.get(bundle, []))
+            assert selected & language_bundles, (
+                f"profile '{profile}' selects no language layer — `make install` would not exist"
+            )
 
     def test_no_source_file_is_shared_between_bundles(self, bundles_data, bundles_root):
         """Test that a single source file is not included by more than one bundle."""

--- a/tests/utils/test_make_structure.py
+++ b/tests/utils/test_make_structure.py
@@ -165,3 +165,49 @@ def test_parser_sees_known_targets(root):
     expected = {"install", "clean", "doctor", "explain-bundles"}
     missing = expected - all_targets
     assert not missing, f"parser failed to find known single-colon targets: {missing}"
+
+
+def _colon_styles(path: Path) -> dict[str, str]:
+    """Map target name -> ':' or '::' for the rules defined in one fragment."""
+    styles: dict[str, str] = {}
+    in_define = False
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if in_define:
+            in_define = stripped != "endef"
+            continue
+        if stripped.startswith("define "):
+            in_define = True
+            continue
+        match = _TARGET_LINE.match(line)
+        if not match:
+            continue
+        for name in match.group("names").split():
+            if name.startswith(".") or "$(" in name:
+                continue
+            styles[name] = match.group("colon")
+    return styles
+
+
+def test_no_target_mixes_single_and_double_colon_across_bundles(root):
+    """A target must be `:` everywhere or `::` everywhere, across *all* bundle fragments.
+
+    Make refuses a target that has both ("target file `test' has both : and :: entries"),
+    and the failure only appears once two bundles are synced together — so scanning the
+    mother repo's own .rhiza/make.d is not enough. It runs one language layer, while the
+    bundles/ tree holds them all.
+
+    This is a real bug caught late: rust.mk defined `test:` while book.mk declares
+    `test:: ; @:` as its no-op default, and every Rust project would have died on the
+    first `make` invocation.
+    """
+    styles: dict[str, dict[str, list[str]]] = defaultdict(lambda: defaultdict(list))
+    fragments = sorted((root / "bundles").glob("*/.rhiza/make.d/*.mk"))
+    assert fragments, "no bundle make fragments found — layout changed?"
+    for fragment in fragments:
+        owner = fragment.relative_to(root / "bundles").parts[0]
+        for target, colon in _colon_styles(fragment).items():
+            styles[target][colon].append(f"{owner}/{fragment.name}")
+
+    mixed = {target: dict(kinds) for target, kinds in styles.items() if len(kinds) > 1}
+    assert not mixed, f"targets defined with both ':' and '::' across bundles: {mixed}"


### PR DESCRIPTION
Stage 2 of multi-language support. **Stacked on #1449** — review that first; this PR's base is `refactor/core-language-layer`, so its diff shows only the Rust work.

Stage 1 claimed the layer split would admit a second language without touching the rest of the template. This is that claim tested: `rust-core` is a peer of `python-core`, and nothing outside the two layer bundles needed to change to accommodate it.

## Gate parity

Same target names, different engines — which is what lets `book.mk` and the CI workflows stay language-agnostic:

| target | python-core | rust-core |
| --- | --- | --- |
| `install` | `uv venv` + `uv sync` | `rustup show` + `cargo fetch` |
| `test` | pytest | `cargo nextest` + doctests |
| `coverage` | pytest-cov | `cargo llvm-cov` → the same `_tests/coverage.xml` |
| `typecheck` | ty / mypy | `cargo clippy -D warnings` |
| `docs-coverage` | interrogate (%) | `RUSTDOCFLAGS=-D missing_docs` (pass/fail) |
| `security` | bandit + pip-audit | `cargo deny check advisories` |
| `license` | pip-licenses | `cargo deny check licenses` |
| unused deps | `deptry` | `deps` → `cargo machete` |

`coverage` writing Cobertura to exactly `_tests/coverage.xml` is deliberate: that is the path `book.mk` badges, so a Rust project gets a measured coverage badge with no change to the book bundle.

## Decisions worth reviewing

**No `rust-tests` bundle.** Python needs one because pytest, coverage and mypy each have configuration worth bundling. The cargo equivalents have none, so the bundle would own no files. The test targets live in `rust.mk`.

**`layer: language` in the schema.** `.pre-commit-config.yaml` and `.rhiza/.cfg.toml` have paths fixed by the tools that read them, so both layers must ship them. Bundles now declare a `layer`; the ownership tests permit overlap *within* one and still reject it everywhere else. Two new tests fail any profile that selects two layers, or none.

**Only `rust-local`.** `rust-github-project` / `rust-gitlab-project` are almost entirely CI, and the `github`/`gitlab` bundles still ship Python CI — `rhiza_release.yml` runs `uv build` and publishes to PyPI, and `dependabot.yml` declares the `uv` ecosystem. Shipping those to a Rust repo means CI that fails on first run, so they arrive with the Rust workflows in Stage 3. jebel-quant/rhiza-claude#85 has a matching commit so `/rhiza:init --language rust` writes `rust-local` rather than a profile that does not exist.

**`typecheck` is clippy.** rustc already type-checks, so the analogous *gate* is the lint pass that runs after it.

**`target/` went into core's `.gitignore`.** git opens `.gitignore` with `O_NOFOLLOW`, so it cannot be a per-layer file. The entries are inert in a Python repo.

## A real bug this caught

Materialising the profile — rather than trusting the unit tests — surfaced that `rust.mk` defined `test:` while `book.mk` declares `test:: ; @:` as its no-op default. Make aborts on that before running anything: `target file 'test' has both : and :: entries`. **Every Rust project would have died on its first `make` invocation.**

Fixed, and `test_no_target_mixes_single_and_double_colon_across_bundles` now scans every bundle fragment for the mismatch. It has to scan `bundles/`, not the mother repo's own `.rhiza/make.d`, because the mother repo runs one language layer while the bundles tree holds them all. Confirmed it fails on the pre-fix file.

## Verification

- 1281 tests pass; `make fmt` clean; `make sync-self-check` no drift
- Every TOML parses; the pre-commit config passes `pre-commit validate-config`
- bump-my-version bumps `[package].version` while leaving a dependency pinned at the same number untouched — and produces byte-identical behaviour to python-core's config on the equivalent Python case
- The `rust-local` profile was materialised and all of `all`/`test`/`coverage`/`typecheck`/`security`/`license`/`deps` resolve

**What is not verified: cargo itself never ran** — there is no Rust toolchain on this machine, so the recipes are checked by dry-run and structure, not execution. The flags used (`cargo llvm-cov --cobertura --output-path`, `cargo nextest run --all-targets`, `cargo deny check advisories|licenses`, `cargo machete`) are the parts to review most closely, and Stage 3's CI will be the first real exercise of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)