### PR TITLE
test(rust): cover the rust-core layer and revive the pre-commit guard

### DIFF
--- a/tests/api/test_language_layer.py
+++ b/tests/api/test_language_layer.py
@@ -14,6 +14,7 @@ them, and that the Python layer does — behaviourally, by expanding the recipes
 
 from __future__ import annotations
 
+import re
 import shutil
 from pathlib import Path
 
@@ -21,8 +22,8 @@ import pytest
 
 from tests.util import run_make, setup_rhiza_git_repo, strip_ansi
 
-# The names every language layer owns. Adding a name here is a promise a future
-# `rust-core` must also keep.
+# The names every language layer owns. Adding a name here is a promise every layer
+# must keep — the classes below assert it for `python-core` and `rust-core` alike.
 LANGUAGE_LAYER_TARGETS = ("install", "all")
 
 
@@ -108,11 +109,64 @@ class TestRustLayerKeepsTheSameContract:
         assert "_tests/coverage.xml" in out
         assert "--cobertura" in out
 
+    def test_docs_coverage_denies_undocumented_items(self, logger):
+        """Rust's answer to interrogate: pass/fail on `missing_docs` rather than a percentage."""
+        out = strip_ansi(run_make(logger, ["docs-coverage"], check=False).stdout)
+        assert "-D missing_docs" in out
+        assert "cargo doc" in out
+
     def test_install_does_not_reach_for_uv_sync(self, logger):
         """A Rust `install` is rustup + cargo fetch; uv is only the tool runner."""
         out = strip_ansi(run_make(logger, ["install"], check=False).stdout)
         assert "cargo fetch" in out
         assert "uv sync" not in out
+
+    def test_cargo_tools_bootstraps_every_subcommand_the_gates_call(self, logger):
+        """A gate whose cargo subcommand is not installed fails with a bare 'no such command'."""
+        out = strip_ansi(run_make(logger, ["cargo-tools"], check=False).stdout)
+        assert "cargo-binstall" in out, "prebuilt binaries are what keep this from being a multi-minute build"
+        for tool in ("cargo-nextest", "cargo-llvm-cov", "cargo-deny", "cargo-machete"):
+            assert tool in out, f"`cargo-tools` does not install {tool}, which a gate below calls"
+
+    def test_all_chains_the_rust_gates(self, logger):
+        """The mirror of `test_all_chains_the_python_gates` — a dropped gate shows up here.
+
+        Asserted on the expanded recipes rather than the prerequisite list, so a gate
+        that is named but whose recipe has been gutted still fails.
+        """
+        out = strip_ansi(run_make(logger, ["all"], check=False).stdout)
+        assert "pre-commit run --all-files" in out  # fmt, from core
+        for gate, command in (
+            ("test", "cargo nextest run"),
+            ("docs-coverage", "-D missing_docs"),
+            ("security", "cargo deny check advisories"),
+            ("deps", "cargo machete"),
+            ("license", "cargo deny check licenses"),
+            ("typecheck", "cargo clippy"),
+        ):
+            assert command in out, f"`make all` no longer runs the {gate} gate ({command})"
+
+    def test_all_runs_the_doctests_nextest_skips(self, logger):
+        """Nextest ignores doctests; dropping the `cargo test --doc` line silently stops testing them."""
+        assert "cargo test --doc" in strip_ansi(run_make(logger, ["all"], check=False).stdout)
+
+    def test_rhiza_test_still_runs_the_python_self_tests(self, logger):
+        """The template's own suite validates YAML and READMEs, so it stays Python under uv."""
+        out = strip_ansi(run_make(logger, ["rhiza-test"], check=False).stdout)
+        assert "pytest .rhiza/tests" in out
+
+    def test_neutral_tooling_works_without_a_python_version_file(self, logger):
+        """`fmt` runs pre-commit through `uvx -p $(PYTHON_VERSION)` whatever the language.
+
+        A Rust repo ships no `.python-version`, so the whole language-neutral half of
+        the template rests on the fallback in rhiza.mk resolving to a real version —
+        an empty `-p` would break `fmt` on every Rust project at once.
+        """
+        out = strip_ansi(run_make(logger, ["fmt"], check=False).stdout)
+        assert not (self.project / ".python-version").exists(), "fixture drifted: this asserts the fallback path"
+        assert re.search(r"-p \d+\.\d+ pre-commit run --all-files", out), (
+            f"`make fmt` did not resolve PYTHON_VERSION to a usable value:\n{out}"
+        )
 
 
 class TestCoreAloneHasNoLanguageLayer:

--- a/tests/bundles/test_bundle_content_validity.py
+++ b/tests/bundles/test_bundle_content_validity.py
@@ -1,7 +1,7 @@
 """Content validity tests for bundle files.
 
 Validates the substance of files inside every bundle directory:
-- YAML and JSON files parse without error
+- YAML, JSON and TOML files parse without error
 - GitHub workflow stubs delegate to the canonical reusable workflow in jebel-quant/rhiza
 - Shell completion scripts are non-trivial
 - Makefile fragments expose at least one documented target (## help comment)
@@ -16,6 +16,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -45,6 +46,21 @@ def _load_bundle_names(root: Path) -> list[str]:
     with bundles_file.open() as f:
         data = yaml.safe_load(f)
     return list(data.get("bundles", {}).keys())
+
+
+def _language_layer_bundles(root: Path) -> list[str]:
+    """Return the bundles declaring ``layer: language`` (python-core, rust-core, ...).
+
+    Derived from the YAML rather than hard-coded, so a third language layer is
+    covered by the layer-wide guards below the moment it is declared.
+    """
+    bundles_file = root / ".rhiza" / "template-bundles.yml"
+    with bundles_file.open() as f:
+        data = yaml.safe_load(f)
+    return sorted(name for name, config in data.get("bundles", {}).items() if (config or {}).get("layer") == "language")
+
+
+_LAYER_BUNDLES = _language_layer_bundles(Path(__file__).resolve().parents[2])
 
 
 # ---------------------------------------------------------------------------
@@ -183,6 +199,61 @@ class TestBundleJsonValidity:
                     content = f.read_text(encoding="utf-8").strip()
                     rel = f.relative_to(root / "bundles")
                     assert content, f"JSONC file is empty: [{name}] {rel}"
+
+
+# ---------------------------------------------------------------------------
+# TOML validity
+# ---------------------------------------------------------------------------
+
+
+class TestBundleTomlValidity:
+    """Every TOML file in every bundle directory must parse without error.
+
+    TOML carries as much shipped configuration as YAML does — cliff.toml, ruff.toml,
+    the bump-my-version `.rhiza/.cfg.toml` of each language layer, and the whole
+    rust-core toolchain set (rust-toolchain, rustfmt, clippy, deny). None of it is
+    exercised by the mother repo's own gates when it belongs to a bundle rhiza does
+    not dogfood, so a syntax error there would otherwise reach downstream projects.
+    """
+
+    def test_all_toml_files_are_parseable(self, root: Path, bundle_names: list[str]) -> None:
+        """Walk every bundle and assert every .toml file loads cleanly."""
+        errors: list[str] = []
+        for name in bundle_names:
+            bundle_dir = root / "bundles" / name
+            if not bundle_dir.is_dir():
+                continue
+            for f in _all_files_in_bundle(bundle_dir):
+                if f.suffix != ".toml":
+                    continue
+                try:
+                    with f.open("rb") as fh:
+                        tomllib.load(fh)
+                except tomllib.TOMLDecodeError as exc:
+                    rel = f.relative_to(root / "bundles")
+                    errors.append(f"  [{name}] {rel}: {exc}")
+        if errors:
+            pytest.fail("TOML parse errors in bundle files:\n" + "\n".join(errors))
+
+    def test_no_toml_file_is_empty(self, root: Path, bundle_names: list[str]) -> None:
+        """A TOML file that parses to an empty table is almost certainly a truncated sync."""
+        for name in bundle_names:
+            bundle_dir = root / "bundles" / name
+            if not bundle_dir.is_dir():
+                continue
+            for f in _all_files_in_bundle(bundle_dir):
+                if f.suffix != ".toml":
+                    continue
+                with f.open("rb") as fh:
+                    doc = tomllib.load(fh)
+                rel = f.relative_to(root / "bundles")
+                assert doc, f"TOML file has no content: [{name}] {rel}"
+
+    def test_the_scan_reaches_every_language_layer(self, root: Path) -> None:
+        """Guard against a scan that silently covers nothing: each layer ships TOML."""
+        for layer in _LAYER_BUNDLES:
+            tomls = [f for f in _all_files_in_bundle(root / "bundles" / layer) if f.suffix == ".toml"]
+            assert tomls, f"layer '{layer}' ships no .toml file — has the scan gone stale?"
 
 
 # ---------------------------------------------------------------------------
@@ -558,12 +629,23 @@ class TestRenovateBundleContent:
 
 
 # ---------------------------------------------------------------------------
-# Core pre-commit configuration
+# Language-layer pre-commit configuration
 # ---------------------------------------------------------------------------
 
 
-class TestCorePreCommitConfig:
-    """The core bundle's .pre-commit-config.yaml must pin node for npm-based hooks.
+def _layer_precommit(root: Path, layer: str) -> dict:
+    """Load the .pre-commit-config.yaml shipped by a language-layer bundle."""
+    cfg = root / "bundles" / layer / ".pre-commit-config.yaml"
+    assert cfg.is_file(), (
+        f"layer '{layer}' ships no .pre-commit-config.yaml. Every language layer owns that "
+        "path — pre-commit hard-codes it, which is why the layers are alternatives."
+    )
+    with cfg.open(encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+class TestLayerPreCommitConfig:
+    """Every language layer's .pre-commit-config.yaml must pin node for npm-based hooks.
 
     markdownlint-cli pulls a transitive dependency (ava) whose engines field is
     ``^22.20 || ^24.12 || >=26``.  Odd-numbered current node releases such as v25
@@ -571,22 +653,19 @@ class TestCorePreCommitConfig:
     and the hook fails to install.  Pinning ``default_language_version.node`` makes
     pre-commit provision a compatible node via nodeenv instead of relying on the
     system runtime.  This guard stops the pin from silently disappearing downstream.
+
+    The config used to live in ``core`` and this guard read it from there; the
+    language-layer split moved it into ``python-core`` and gave ``rust-core`` a
+    sibling, so the check now runs once per layer — and asserts the file exists
+    rather than skipping, which is how the earlier version went quietly dead.
     """
 
-    @pytest.fixture
-    def precommit_config(self, root: Path) -> dict:
-        """Load and return the parsed core-bundle .pre-commit-config.yaml."""
-        cfg = root / "bundles" / "core" / ".pre-commit-config.yaml"
-        if not cfg.exists():
-            pytest.skip("core bundle .pre-commit-config.yaml not present")
-        with cfg.open(encoding="utf-8") as fh:
-            return yaml.safe_load(fh)
-
-    def test_default_language_version_pins_node(self, precommit_config: dict) -> None:
+    @pytest.mark.parametrize("layer", _LAYER_BUNDLES)
+    def test_default_language_version_pins_node(self, root: Path, layer: str) -> None:
         """default_language_version.node must be a non-empty pin so npm hooks get a compatible runtime."""
-        versions = precommit_config.get("default_language_version")
+        versions = _layer_precommit(root, layer).get("default_language_version")
         assert isinstance(versions, dict), (
-            "core .pre-commit-config.yaml must declare a 'default_language_version' table "
+            f"{layer} .pre-commit-config.yaml must declare a 'default_language_version' table "
             "pinning node for npm-based hooks (markdownlint-cli)"
         )
         node = versions.get("node")
@@ -594,6 +673,29 @@ class TestCorePreCommitConfig:
         assert node.strip(), (
             "'default_language_version.node' must be a non-empty version string to keep markdownlint-cli "
             "installable on odd-numbered current node releases (EBADENGINE guard)"
+        )
+
+    def test_layers_agree_on_shared_hook_revisions(self, root: Path) -> None:
+        """A repo shared by two layers must be pinned to one rev in both.
+
+        The layers differ by design in *which* hooks they run — ruff/bandit versus
+        rustfmt/clippy. The neutral half (markdownlint, actionlint, schema checks,
+        secret scanning, the rhiza hooks) is the same set of upstream repos, and
+        nothing keeps them in step: Renovate bumps each config file separately, so
+        the two layers drift apart one PR at a time until a Rust project is running
+        a year-old actionlint. This fails the moment they diverge.
+        """
+        revs: dict[str, dict[str, str]] = {}
+        for layer in _LAYER_BUNDLES:
+            for repo in _layer_precommit(root, layer)["repos"]:
+                if repo["repo"] == "local":  # no rev to compare; recipes are language-specific
+                    continue
+                revs.setdefault(repo["repo"], {})[layer] = repo["rev"]
+
+        drifted = {repo: pins for repo, pins in revs.items() if len(pins) > 1 and len(set(pins.values())) > 1}
+        assert not drifted, "language layers pin the same pre-commit repo at different revs:\n" + "\n".join(
+            f"  {repo}: " + ", ".join(f"{layer}={rev}" for layer, rev in sorted(pins.items()))
+            for repo, pins in sorted(drifted.items())
         )
 
 

--- a/tests/bundles/test_bundle_sync.py
+++ b/tests/bundles/test_bundle_sync.py
@@ -10,6 +10,7 @@ shared state between scenarios.
 
 from __future__ import annotations
 
+import re
 import tomllib
 
 import pytest
@@ -143,6 +144,185 @@ class TestPythonCoreBundleSync:
         """The bump-my-version config points at pyproject.toml, so it is Python's."""
         cfg = (self.project / ".rhiza" / ".cfg.toml").read_text(encoding="utf-8")
         assert 'filename = "pyproject.toml"' in cfg
+
+
+class TestRustCoreBundleSync:
+    """Syncing core + rust-core produces a working Rust project layer.
+
+    The mother repo is a Python project, so nothing here is dogfooded at the root —
+    these assertions are the only thing standing between a broken rust-core file and
+    a downstream Rust repo.
+    """
+
+    @pytest.fixture(autouse=True)
+    def synced(self, tmp_path, root):
+        """Sync the core and rust-core bundles into a fresh directory."""
+        sync_bundles(root, ["core", "rust-core"], tmp_path)
+        self.project = tmp_path
+
+    @pytest.mark.parametrize(
+        "name", ["rust-toolchain.toml", "rustfmt.toml", "clippy.toml", "deny.toml", ".pre-commit-config.yaml"]
+    )
+    def test_rust_toolchain_config_is_present(self, name):
+        """The cargo-side counterparts of ruff.toml/.bandit all arrive."""
+        assert (self.project / name).is_file(), f"Missing Rust toolchain file: {name}"
+
+    @pytest.mark.parametrize("name", ["ruff.toml", ".bandit", ".python-version", "pytest.ini"])
+    def test_python_tooling_is_absent(self, name):
+        """A Rust repo gets no Python config — the layers are alternatives, not additions."""
+        assert not (self.project / name).exists(), f"{name} belongs to python-core, not rust-core"
+
+    def test_rust_mk_provides_the_language_contract(self):
+        """rust.mk owns the same target names python.mk does, plus the cargo-backed gates."""
+        rust_mk = (self.project / ".rhiza" / "make.d" / "rust.mk").read_text(encoding="utf-8")
+        for target in ("install:", "all:", "test::", "coverage:", "typecheck:", "docs-coverage:", "rhiza-test:"):
+            assert target in rust_mk, f"rust.mk is missing {target}"
+
+    def test_only_one_language_fragment_is_synced(self):
+        """python.mk and rust.mk both define `install` — receiving both would be a clash."""
+        fragments = sorted(p.name for p in (self.project / ".rhiza" / "make.d").iterdir())
+        assert "rust.mk" in fragments
+        assert "python.mk" not in fragments
+
+    def test_no_symlinks_in_synced_project(self):
+        """Synced files are real files, as a downstream project would receive them."""
+        for path in self.project.rglob("*"):
+            if path.is_file():
+                assert not path.is_symlink(), f"Unexpected symlink in synced project: {path.relative_to(self.project)}"
+
+
+class TestRustBumpversionConfig:
+    """The Rust `.rhiza/.cfg.toml` must rewrite the crate version and nothing else.
+
+    This is the subtlest file rust-core ships. bump-my-version applies ``search`` to
+    *every* occurrence in a file, so the config anchors its pattern to the
+    ``[package]`` table — otherwise a dependency that happens to be pinned at the
+    same version as the crate gets silently rewritten too, and the release lands a
+    broken dependency spec. The comments in the file say so; this test proves it, by
+    running the config's own regex the way bump-my-version does.
+    """
+
+    CURRENT = "1.2.3"
+    NEW = "1.3.0"
+
+    CARGO_TOML = """\
+[package]
+name = "demo"
+version = "1.2.3"
+edition = "2024"
+
+[dependencies]
+serde = "1.2.3"
+
+[dependencies.tracing]
+version = "1.2.3"
+features = ["std"]
+"""
+
+    @pytest.fixture(autouse=True)
+    def config(self, tmp_path, root):
+        """Sync rust-core and load its bump-my-version configuration."""
+        sync_bundles(root, ["core", "rust-core"], tmp_path)
+        with (tmp_path / ".rhiza" / ".cfg.toml").open("rb") as fh:
+            self.cfg = tomllib.load(fh)["tool"]["bumpversion"]
+        self.project = tmp_path
+
+    def _bump(self) -> str:
+        """Apply the configured search/replace to CARGO_TOML exactly as bump-my-version would."""
+        spec = self.cfg["files"][0]
+        assert spec["filename"] == "Cargo.toml"
+        assert spec.get("regex") is True, "the [package] anchor is a regex; without regex=true it is a literal"
+        search = spec["search"].format(current_version=self.CURRENT)
+        replace = spec["replace"].format(new_version=self.NEW)
+        return re.sub(search, replace, self.CARGO_TOML)
+
+    def test_the_crate_version_is_bumped(self):
+        """The [package] version — the one the release is about — must change."""
+        result = self._bump()
+        assert f'[package]\nname = "demo"\nversion = "{self.NEW}"' in result
+
+    def test_a_dependency_pinned_at_the_same_version_is_untouched(self):
+        """The anchor exists for exactly this case; an unanchored search would rewrite it."""
+        result = self._bump()
+        assert 'serde = "1.2.3"' in result, "a shorthand dependency pin was rewritten"
+        assert f'[dependencies.tracing]\nversion = "{self.CURRENT}"' in result, (
+            "the version key of a [dependencies.*] table was rewritten — the [package] anchor is not holding"
+        )
+
+    def test_exactly_one_version_line_changes(self):
+        """Belt and braces: one occurrence of the new version, wherever the anchor matched."""
+        assert self._bump().count(f'"{self.NEW}"') == 1
+
+    def test_cargo_lock_is_refreshed_by_hook_not_by_search_replace(self):
+        """Cargo.lock lists every dependency's version, so it must never be a `files` entry."""
+        filenames = [f["filename"] for f in self.cfg["files"]]
+        assert "Cargo.lock" not in filenames, (
+            "Cargo.lock records dependency versions too; a search/replace entry would rewrite any "
+            "dependency pinned at the crate's version. Refresh it with `cargo update` instead."
+        )
+        hooks = " ".join(self.cfg.get("pre_commit_hooks", []))
+        assert "cargo update" in hooks, "nothing refreshes Cargo.lock, so the bumped tree dirties itself"
+        assert "git add Cargo.lock" in hooks, "the refreshed lockfile is never staged into the bump commit"
+
+    def test_prerelease_parts_are_semver_spellings(self):
+        """Cargo rejects PEP 440 short forms like `1.2.3-a.1`, so the values are spelled out."""
+        values = self.cfg["parts"]["release"]["values"]
+        assert "alpha" in values
+        assert "a" not in values
+
+
+class TestProfileRustLocalSync:
+    """Syncing the 'rust-local' profile yields a Rust project with no hosted CI."""
+
+    RUST_LOCAL_BUNDLES = ["core", "rust-core", "book"]  # transitive closure of the 'rust-local' profile
+
+    @pytest.fixture(autouse=True)
+    def synced(self, tmp_path, root):
+        """Sync all bundles in the rust-local profile transitive closure."""
+        sync_bundles(root, self.RUST_LOCAL_BUNDLES, tmp_path)
+        self.project = tmp_path
+
+    def test_the_language_contract_is_available(self):
+        """`install` and `all` exist, which is what makes the profile usable at all."""
+        rust_mk = (self.project / ".rhiza" / "make.d" / "rust.mk").read_text(encoding="utf-8")
+        assert "install:" in rust_mk
+        assert "all:" in rust_mk
+
+    def test_docs_skeleton_exists(self):
+        """The book bundle is language-neutral, so a Rust project gets docs too."""
+        assert (self.project / "docs" / "index.md").is_file()
+        assert (self.project / "docs" / "mkdocs-base.yml").is_file()
+
+    def test_book_badge_step_and_rust_coverage_agree_on_the_report_path(self):
+        """book.mk badges `_tests/coverage.xml`; the Rust `coverage` target must write it."""
+        book_mk = (self.project / ".rhiza" / "make.d" / "book.mk").read_text(encoding="utf-8")
+        rust_mk = (self.project / ".rhiza" / "make.d" / "rust.mk").read_text(encoding="utf-8")
+        assert "_tests/coverage.xml" in book_mk
+        assert "_tests/coverage.xml" in rust_mk
+
+    def test_no_github_workflows_injected(self):
+        """rust-local is local-first: the Rust CI workflows do not exist yet."""
+        workflows_dir = self.project / ".github" / "workflows"
+        if workflows_dir.exists():
+            workflow_files = list(workflows_dir.glob("*.yml"))
+            assert not workflow_files, (
+                f"rust-local should not inject workflow files, found: {[f.name for f in workflow_files]}"
+            )
+
+    def test_no_gitlab_ci_injected(self):
+        """Nor the GitLab half of hosted CI."""
+        assert not (self.project / ".gitlab-ci.yml").exists()
+
+    def test_exactly_one_pre_commit_config(self):
+        """Two layers would fight over this path; the profile selects exactly one."""
+        configs = list(self.project.rglob(".pre-commit-config.yaml"))
+        assert len(configs) == 1, f"expected one .pre-commit-config.yaml, found {configs}"
+        with configs[0].open(encoding="utf-8") as fh:
+            hook_ids = {hook["id"] for repo in yaml.safe_load(fh)["repos"] for hook in repo["hooks"]}
+        assert "cargo-clippy" in hook_ids, "the synced pre-commit config is not the Rust one"
+        assert not hook_ids & {"ruff", "bandit", "interrogate", "uv-lock"}, (
+            "python-core's hooks leaked into a Rust profile"
+        )
 
 
 class TestCoreAndTestsBundleSync:


### PR DESCRIPTION
The language layer split gave us a second language, but `rust-core` arrived largely unexercised — and took one existing guard down with it. 27 new tests, no source changes.

## The dead guard

`TestCorePreCommitConfig` read `bundles/core/.pre-commit-config.yaml` and `pytest.skip`ed when it was missing. That file moved to `python-core` in eba6803, so the test has been skipping silently ever since — neither layer's node pin (the EBADENGINE guard for markdownlint-cli) was being checked.

It now runs once per bundle declaring `layer: language`, discovered from `template-bundles.yml` so a third layer is covered the moment it is declared, and **asserts the file exists** rather than skipping. Alongside it, `test_layers_agree_on_shared_hook_revisions` fails when the two layers pin a shared upstream repo (markdownlint, actionlint, check-jsonschema, betterleaks, rhiza-hooks) at different revs. They match today; Renovate bumps each config file separately, so drift is a matter of time.

## What else was uncovered

| gap | now |
| --- | --- |
| No `.toml` in any bundle was parse-checked, though YAML and JSON were — and `rust-core` is 5 TOML files out of 7 | `TestBundleTomlValidity` parses every one, rejects empty tables, and asserts each layer ships TOML so the scan cannot go stale |
| `rust-local` had zero references outside `template-bundles.yml` and the README, while `local` / `github-project` / `gitlab-project` each have an assembled-project test | `TestProfileRustLocalSync` — contract present, docs skeleton, `book.mk` and `coverage` agreeing on `_tests/coverage.xml`, no GitHub/GitLab CI, exactly one pre-commit config and it is the Rust one |
| The bumpversion `search` is anchored to `[package]` so a dependency pinned at the crate's version is not rewritten — asserted only in a comment | `TestRustBumpversionConfig` runs the config's own regex over a fixture `Cargo.toml` the way bump-my-version does, and checks `Cargo.lock` is refreshed by hook rather than search/replace |
| `all`, `docs-coverage`, `cargo-tools`, `rhiza-test` had no behavioural test — Python's `all` chain is asserted, Rust's was not | added to `TestRustLayerKeepsTheSameContract`, asserted on expanded recipes so a gutted recipe still fails |
| A Rust repo ships no `.python-version`, so the language-neutral half rests on the `PYTHON_VERSION` fallback in `rhiza.mk` | `test_neutral_tooling_works_without_a_python_version_file` |

Plus `TestRustCoreBundleSync`: the toolchain files arrive, no Python config comes with them, and only one language fragment lands.

## Verification

Six mutations, each caught by the intended test and then reverted: removed the node pin, drifted a rev, broke `clippy.toml`, un-anchored the bumpversion search, dropped `deps` from `all:`, added `Cargo.lock` as a `files` entry.

`make test` — 1316 passed, 1 skipped (the opt-in Docker GitLab job). `make fmt` clean.

## Still open

`rust-core` remains outside the dogfood loop by construction, so these tests verify shape and wiring but not that `cargo nextest` actually passes on a real Rust project. A smoke repo in CI would be the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)