### PR TITLE
feat(go): add the go-core language layer and a go-local profile

### DIFF
--- a/.rhiza/template-bundles.yml
+++ b/.rhiza/template-bundles.yml
@@ -92,6 +92,32 @@ bundles:
       `-D missing_docs`, which is pass/fail rather than a percentage — there is no
       Rust interrogate, so COVERAGE-style thresholds do not apply.
 
+  go-core:
+    description: "Go toolchain layer: go mod, go test, golangci-lint, govulncheck, revive"
+    standalone: true
+    layer: language
+    requires: [core]
+    notes: |
+      The Go sibling of `python-core` and `rust-core`. Ships `.golangci.yml`,
+      `revive.toml`, a Go pre-commit config, a bump-my-version config, a starter
+      `internal/version/version.go`, and `.rhiza/make.d/go.mk`.
+
+      Like Rust it carries its own test targets: `go test` and `go tool cover`
+      need no configuration files, so a `go-tests` bundle would own nothing.
+
+      `install` is only `go mod download` — go.mod's `go`/`toolchain` directives
+      make the go command fetch a matching compiler itself, so there is no rustup
+      step to mirror. `typecheck` is `go vet` plus golangci-lint, since the
+      compiler already type-checks. `docs-coverage` is revive's `exported` rule:
+      pass/fail on missing doc comments, like Rust's `-D missing_docs` and unlike
+      interrogate's percentage.
+
+      The version location is the one real difference between Go and its
+      siblings. A Go module's version is its git tag — pyproject.toml and
+      Cargo.toml have no equivalent in the source tree — so the layer ships a
+      `version.Version` constant for bump-my-version to write to, and the
+      release commit and its tag move together.
+
   github:
     description: "GitHub repository configuration (actions, dependabot, templates, rulesets, core workflows)"
     standalone: true
@@ -401,6 +427,25 @@ profiles:
     bundles:
       - core
       - rust-core
+      - book
+
+  # ============================================================================
+  # GO-LOCAL - Local-first Go development
+  # ============================================================================
+  go-local:
+    description: |
+      Local-first Go setup with no hosted CI/CD workflow files.
+      The Go counterpart of `local`: core infrastructure, the Go toolchain layer
+      (go test, golangci-lint, govulncheck, revive) and documentation.
+
+      As with `rust-local`, there is deliberately no `go-github-project` or
+      `go-gitlab-project` yet: those profiles are made almost entirely of CI
+      workflows, and the `github`/`gitlab` bundles currently ship Python ones —
+      a release job that runs `uv build` and publishes to PyPI, and a Dependabot
+      config declaring the `uv` ecosystem. They arrive with the Go workflows.
+    bundles:
+      - core
+      - go-core
       - book
 
   # ============================================================================

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,9 @@ The core abstraction is the **bundle** — a named group of configuration files.
 - `rust-core` (the Rust **language layer**): `rust-toolchain.toml`, `rustfmt.toml`,
   `clippy.toml`, `deny.toml`, a Rust pre-commit config, and `.rhiza/make.d/rust.mk`.
   Carries its own test targets, unlike Python — see **Language layers**.
+- `go-core` (the Go **language layer**): `.golangci.yml`, `revive.toml`, a Go
+  pre-commit config, a starter `internal/version/version.go`, and
+  `.rhiza/make.d/go.mk`. Carries its own test targets, like Rust.
 - `tests`: pytest, coverage, type checking (Python; requires `python-core`)
 - `benchmarks`: pytest-benchmark infrastructure and reporting
 - `github`: GitHub repository configuration (actions, dependabot, core workflows)
@@ -74,7 +77,7 @@ The core abstraction is the **bundle** — a named group of configuration files.
 
 **Platform overlay bundles** — CI workflow stubs that pair a feature with a platform: `github-tests`, `github-book`, `github-marimo`, `github-docker`, `github-devcontainer`, `github-paper`, `github-quality-review`, `gitlab-tests`, `gitlab-book`, `gitlab-marimo`, `gitlab-quality-review`.
 
-**Meta-bundles** — curated compositions of other bundles: `github-project`, `gitlab-project`, `local` (no hosted CI).
+**Meta-bundles** — curated compositions of other bundles: `github-project`, `gitlab-project`, `local` (no hosted CI), and the single-language local profiles `rust-local` and `go-local`.
 
 ### Dogfooding (root files ↔ bundle sources)
 
@@ -91,7 +94,8 @@ Plus intentional mother-repo overrides that deliberately diverge from their bund
 
 `core` used to be a Python project in disguise: it created a virtualenv, ran `uv sync`
 and named Python gates in `all`. That half now lives in a **language layer** bundle,
-and every profile pairs `core` with exactly one: `python-core` or `rust-core`.
+and every profile pairs `core` with exactly one: `python-core`, `rust-core` or
+`go-core`.
 
 The contract between them is a set of **target names**. `book.mk`, `test.mk`, the CI
 workflows and the release pipeline all call `make install` without knowing what the
@@ -104,30 +108,39 @@ project is written in, so a layer must define:
 | `install-uv`, `fmt`, `todos`, `semgrep`, `doctor`, `clean` | core | language-neutral, whatever the project is |
 
 Two rules follow. **Core must never define `install` or `all`** — `tests/api/test_language_layer.py`
-asserts both halves behaviourally, for both layers. And **layers claim the same
+asserts both halves behaviourally, for every layer. And **layers claim the same
 deployment paths on purpose**: `.pre-commit-config.yaml` and `.rhiza/.cfg.toml` exist
-in both, because those paths are fixed by the tools that read them. A bundle declares
+in all of them, because those paths are fixed by the tools that read them. A bundle declares
 `layer: language` in `template-bundles.yml` to say so; the ownership tests then permit
 overlap *within* a layer and still reject it everywhere else, and a separate test
 fails any profile that selects two layers at once.
 
 **Gate parity between layers.** Same target names, different engines:
 
-| target | python-core | rust-core |
-| --- | --- | --- |
-| `install` | `uv venv` + `uv sync` | `rustup show` + `cargo fetch` |
-| `test` | pytest | `cargo nextest` + doctests |
-| `coverage` | pytest-cov | `cargo llvm-cov` (same `_tests/coverage.xml` path) |
-| `typecheck` | ty / mypy | `cargo clippy -D warnings` (rustc already type-checks) |
-| `docs-coverage` | interrogate (%) | `RUSTDOCFLAGS=-D missing_docs` (pass/fail) |
-| `security` | bandit + pip-audit | `cargo deny check advisories` |
-| `license` | pip-licenses | `cargo deny check licenses` |
-| unused deps | `deptry` | `deps` → `cargo machete` |
+| target | python-core | rust-core | go-core |
+| --- | --- | --- | --- |
+| `install` | `uv venv` + `uv sync` | `rustup show` + `cargo fetch` | `go mod download` |
+| `test` | pytest | `cargo nextest` + doctests | `go test ./...` |
+| `coverage` | pytest-cov | `cargo llvm-cov` (same `_tests/coverage.xml` path) | `go test -coverprofile` + `gocover-cobertura` (same path) |
+| `typecheck` | ty / mypy | `cargo clippy -D warnings` (rustc already type-checks) | `go vet` + golangci-lint (the compiler already type-checks) |
+| `docs-coverage` | interrogate (%) | `RUSTDOCFLAGS=-D missing_docs` (pass/fail) | revive `exported` rule (pass/fail) |
+| `security` | bandit + pip-audit | `cargo deny check advisories` | `govulncheck` |
+| `license` | pip-licenses | `cargo deny check licenses` | `go-licenses check` |
+| unused deps | `deptry` | `deps` → `cargo machete` | `deps` → `go mod tidy -diff` |
 
-The Rust layer also carries `test`/`coverage`/`typecheck`, which on the Python side
+The Rust and Go layers also carry `test`/`coverage`/`typecheck`, which on the Python side
 live in the separate `tests` bundle. That is not an inconsistency: pytest, coverage
-and mypy each need configuration files worth bundling, while their cargo counterparts
-need none, so a `rust-tests` bundle would own no files.
+and mypy each need configuration files worth bundling, while `cargo nextest` and
+`go test` need none, so a `rust-tests` or `go-tests` bundle would own no files.
+
+**Where Go differs from both.** A Go module has no manifest: its version *is* the git
+tag, so unlike `pyproject.toml` and `Cargo.toml` there is no file in the tree for
+bump-my-version to write to. `go-core` therefore ships a starter
+`internal/version/version.go` holding a `Version` constant and anchors the release
+config to it, which keeps the release commit and its tag in step. Delete that file and
+the `/rhiza:release` flow has no version location to write to. Its `install` is also the thinnest of the
+three — go.mod's `go`/`toolchain` directives make the go command fetch a matching
+compiler on demand, so there is no rustup step to mirror.
 
 `uv` sits in core, not in the Python layer, because rhiza runs pre-commit, mkdocs and
 semgrep through `uvx` regardless of the project's language. What moved is the
@@ -144,6 +157,7 @@ The root `Makefile` is intentionally thin (~10 lines) and only `include`s `.rhiz
 | `bootstrap.mk` | core | `install-uv` tool bootstrap, install hooks, `clean` |
 | `python.mk` | python-core | `install`, `all`, `deptry`, `license`, `rhiza-test` |
 | `rust.mk` | rust-core | `install`, `all`, and the cargo-backed gates |
+| `go.mk` | go-core | `install`, `all`, and the go-backed gates |
 | `doctor.mk` | core | `make doctor` environment checks |
 | `quality.mk` | core | `fmt`, `todos`, `semgrep` — the language-neutral gates |
 | `custom-env.mk` | core | example stub: project variables |

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Rhiza provides **profiles** — named presets that select a sensible set of bund
 |---------|-------------|---------|
 | `local` | Local-first development with no hosted CI/CD workflow files | `core`, `python-core`, `book`, `marimo`, `tests` |
 | `rust-local` | Local-first Rust development, no hosted CI/CD (hosted profiles arrive with the Rust workflows) | `core`, `rust-core`, `book` |
+| `go-local` | Local-first Go development, no hosted CI/CD (hosted profiles arrive with the Go workflows) | `core`, `go-core`, `book` |
 | `github-project` | GitHub-hosted project with CI/CD and release automation | `core`, `python-core`, `github`, `book`, `marimo`, `tests`, `github-book`, `github-marimo`, `github-tests` |
 | `gitlab-project` | GitLab-hosted project with GitLab CI/CD pipelines | `core`, `python-core`, `gitlab`, `book`, `marimo`, `tests`, `gitlab-book`, `gitlab-marimo`, `gitlab-tests` |
 
@@ -229,6 +230,7 @@ Any bundle can be selected on its own — its dependencies are resolved and inst
 | `core` | Core Rhiza infrastructure, language-neutral (Makefile, help, uv as tool runner) | — |
 | `python-core` | Python language layer (`install`/`all`, virtualenv, ruff, bandit, deptry) | `core` |
 | `rust-core` | Rust language layer (`install`/`all`, cargo, clippy, nextest, llvm-cov, cargo-deny) | `core` |
+| `go-core` | Go language layer (`install`/`all`, go test, golangci-lint, govulncheck, revive) | `core` |
 | `tests` | Local testing infrastructure with pytest, coverage, and type checking | `book`, `core`, `python-core` |
 | `book` | Comprehensive documentation book (API docs, coverage, notebooks) | `core` |
 | `marimo` | Interactive Marimo notebooks for data exploration and documentation | `book`, `core`, `python-core` |

--- a/bundles/go-core/.golangci.yml
+++ b/bundles/go-core/.golangci.yml
@@ -1,0 +1,32 @@
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
+#
+# golangci-lint drives `make typecheck` (alongside `go vet`), the Go counterpart
+# of ruff on the Python side and clippy on the Rust side. Linting and formatting
+# stay separate the way they do in the other layers: `make fmt` runs pre-commit,
+# whose hook is plain `gofmt` because that ships with the toolchain and needs no
+# install step. The stricter formatters declared below are opt-in — run
+# `golangci-lint fmt` for them; `golangci-lint run` (the typecheck gate) does not
+# rewrite files.
+#
+# Kept close to the standard set on purpose — a template that ships opinionated
+# linting is a template downstream projects start by fighting. Add project rules
+# in your own repo; this is the floor, not the ceiling.
+version: "2"
+
+linters:
+  default: standard
+  enable:
+    # Correctness first: the linters that find bugs rather than style.
+    - bodyclose # an unclosed HTTP response body leaks a connection
+    - errorlint # %v on an error breaks errors.Is/As downstream
+    - unconvert # a redundant conversion usually means a type changed under you
+    - misspell
+  settings:
+    misspell:
+      locale: US
+
+formatters:
+  enable:
+    - gofumpt
+    - goimports

--- a/bundles/go-core/.pre-commit-config.yaml
+++ b/bundles/go-core/.pre-commit-config.yaml
@@ -1,0 +1,99 @@
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
+#
+# The Go counterpart of python-core's and rust-core's configs. Same path on
+# purpose — pre-commit hard-codes `.pre-commit-config.yaml`, so the language
+# layers are alternatives rather than files that could coexist.
+#
+# The neutral hooks (markdownlint, actionlint, schema validation, secret scanning,
+# the rhiza hooks) are identical in all three, down to the pinned revs — a test in
+# the mother repo fails when they drift apart. What differs: ruff/bandit/interrogate
+# and the uv lock check are replaced by gofmt, go vet and a go.mod tidiness check.
+#
+# Pin node so pre-commit provisions a compatible runtime instead of using the
+# system node. Some npm-based hooks (markdownlint-cli) pull transitive deps that
+# reject odd-numbered current node releases (e.g. v25), failing on EBADENGINE.
+default_language_version:
+  node: "24.12.0"
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-toml
+      - id: check-yaml
+        args: ['--unsafe']
+
+  - repo: local
+    hooks:
+      - id: no-rej-files
+        name: Reject .rej files
+        entry: "bash -c 'find . -type f -name \"*.rej\" | grep -q . && { echo \"ERROR: .rej files detected\"; find . -type f -name \"*.rej\"; exit 1; } || exit 0'"
+        language: system
+        pass_filenames: false
+
+      # `language: system` rather than pre-commit's built-in golang support: the
+      # toolchain is already pinned by go.mod's `go`/`toolchain` directives, and
+      # letting pre-commit provision a second one would let the hook and
+      # `make typecheck` disagree.
+      #
+      # gofmt rather than gofumpt because it ships with the toolchain — no hook
+      # that installs a binary behind the developer's back. `golangci-lint fmt`
+      # applies the stricter set for projects that want it.
+      - id: go-fmt
+        name: gofmt
+        entry: gofmt -l -w
+        language: system
+        types: [go]
+
+      - id: go-vet
+        name: go vet
+        entry: go vet ./...
+        language: system
+        types: [go]
+        pass_filenames: false
+
+      # The analogue of python-core's uv-lock hook and rust-core's Cargo.lock
+      # check: `-diff` reports what tidy would change and exits non-zero instead
+      # of rewriting the files mid-commit.
+      - id: go-mod-tidy
+        name: go.mod and go.sum are tidy
+        entry: go mod tidy -diff
+        language: system
+        files: ^(go\.mod|go\.sum)$
+        pass_filenames: false
+
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.49.0
+    hooks:
+      - id: markdownlint
+        args: ["--disable", "MD013"]
+
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.37.4
+    hooks:
+      - id: check-renovate
+        args: [ "--verbose" ]
+
+      - id: check-github-workflows
+        args: ["--verbose"]
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
+
+  - repo: https://github.com/betterleaks/betterleaks
+    rev: v1.7.2
+    hooks:
+      - id: betterleaks
+
+  - repo: https://github.com/Jebel-Quant/rhiza-hooks
+    rev: v0.7.0  # Use the latest release
+    hooks:
+      - id: check-rhiza-workflow-names
+      - id: update-readme-help
+      - id: check-rhiza-config
+      - id: check-makefile-targets
+      # check-python-version-consistency is deliberately absent: there is no
+      # .python-version in a Go repo for it to reconcile.

--- a/bundles/go-core/.rhiza/.cfg.toml
+++ b/bundles/go-core/.rhiza/.cfg.toml
@@ -1,0 +1,45 @@
+[tool.bumpversion]
+parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:-(?P<release>[a-z]+)\\.(?P<pre_n>\\d+))?"
+serialize = ["{major}.{minor}.{patch}-{release}.{pre_n}", "{major}.{minor}.{patch}"]
+search = "{current_version}"
+replace = "{new_version}"
+regex = false
+ignore_missing_version = false
+ignore_missing_files = false
+tag = true
+sign_tags = false
+tag_name = "v{new_version}"
+tag_message = "Bump version: {current_version} → {new_version}"
+allow_dirty = false
+commit = true
+message = "Chore: bump version {current_version} → {new_version}"
+commit_args = ""
+# No pre-commit hooks, unlike the Rust layer: go.sum records the checksums of
+# *dependencies* only, never the module's own version, so nothing needs
+# refreshing after a bump.
+
+# SemVer pre-releases, not PEP 440: Go module tags must be valid SemVer, so the
+# value list is the spelled-out set only ("1.2.3-a.1" is not a legal tag).
+[tool.bumpversion.parts.release]
+optional_value = "prod"
+values = [
+    "dev",
+    "alpha",
+    "beta",
+    "rc",
+    "prod"
+]
+
+# The one place a Go module's version exists in the source tree. Go takes the
+# module version from the git tag, so without this constant there is no file for
+# bump-my-version to write to and `tag`-only bumping would leave the built binary
+# unable to report its own version.
+#
+# The search is a literal `const Version = "..."` line rather than a bare version
+# string: `search` is applied to every occurrence in the file, and anchoring on the
+# declaration keeps a version that appears in a doc comment or an example from
+# being rewritten too.
+[[tool.bumpversion.files]]
+filename = "internal/version/version.go"
+search = 'const Version = "{current_version}"'
+replace = 'const Version = "{new_version}"'

--- a/bundles/go-core/.rhiza/make.d/go.mk
+++ b/bundles/go-core/.rhiza/make.d/go.mk
@@ -1,0 +1,163 @@
+## .rhiza/make.d/go.mk - the Go language layer (bundle: go-core)
+#
+# The third sibling of python.mk and rust.mk. `core` provides the make framework
+# and uv/uvx as a tool runner (pre-commit, mkdocs and semgrep run through uvx
+# whatever the project is written in); this file turns that into a Go project.
+#
+# It keeps the language-layer contract: `install` and `all` mean the same thing
+# they do in the other layers, so book.mk and the CI workflows can call them
+# without knowing the language. Only one language layer is ever synced into a repo.
+#
+# Like rust.mk and unlike python.mk, the test targets live here rather than in a
+# separate `tests` bundle: pytest, coverage and type checking each need
+# configuration files, while `go test` and `go tool cover` need none.
+
+# Declare phony targets (they don't produce files)
+.PHONY: all coverage deps docs-coverage go-tools install license rhiza-test security test typecheck
+
+GO ?= go
+
+# Extra flags for the test-running gates — e.g. GO_FLAGS="-tags integration".
+GO_FLAGS ?=
+
+# `-race` is the Go idiom for a CI test run and `-shuffle=on` catches tests that
+# depend on declaration order. Override to drop them on a slow machine.
+GO_TEST_FLAGS ?= -race -shuffle=on
+
+# Coverage floor, mirroring COVERAGE_FAIL_UNDER in the other layers.
+COVERAGE_FAIL_UNDER ?= 90
+
+# Tool binaries land in the same ./bin core installs uv into, so a gate never
+# depends on what happens to be in the developer's global GOPATH.
+GO_BIN_DIR ?= $(INSTALL_DIR)
+
+# Tools installed on demand by `go-tools`. Pinning happens through these
+# variables rather than inline, so Renovate (or a human) has one line to bump.
+GOLANGCI_LINT_VERSION ?= latest
+GOVULNCHECK_VERSION ?= latest
+GO_LICENSES_VERSION ?= latest
+GOCOVER_COBERTURA_VERSION ?= latest
+REVIVE_VERSION ?= latest
+
+GO_TOOLS ?= \
+	github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) \
+	golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION) \
+	github.com/google/go-licenses@$(GO_LICENSES_VERSION) \
+	github.com/boumenot/gocover-cobertura@$(GOCOVER_COBERTURA_VERSION) \
+	github.com/mgechev/revive@$(REVIVE_VERSION)
+
+##@ Go
+install: pre-install ## install the toolchain and download dependencies
+	@if ! command -v $(GO) >/dev/null 2>&1; then \
+	  printf "${RED}[ERROR] go not found.${RESET}\n"; \
+	  printf "${YELLOW}       Install it by following https://go.dev/doc/install${RESET}\n"; \
+	  printf "${YELLOW}       (or your platform's package manager: brew install go)${RESET}\n"; \
+	  exit 1; \
+	fi
+
+	# go.mod's `go` and `toolchain` directives pin the language and compiler
+	# version, and the go command downloads a matching toolchain on demand — so
+	# there is no rustup step to mirror here.
+	@if [ -f "go.mod" ]; then \
+	  printf "${BLUE}[INFO] Downloading dependencies${RESET}\n"; \
+	  $(GO) mod download; \
+	else \
+	  printf "${YELLOW}[WARN] No go.mod found, skipping download${RESET}\n"; \
+	fi
+
+	# Install pre-commit hooks (skip when core.hooksPath is set, e.g. by an
+	# external hook manager — pre-commit refuses to install in that case)
+	@if [ -f ".pre-commit-config.yaml" ]; then \
+	  if [ -n "$$(git config --get core.hooksPath 2>/dev/null)" ]; then \
+	    printf "${BLUE}[INFO] Skipping pre-commit hook install: core.hooksPath is set${RESET}\n"; \
+	  else \
+	    printf "${BLUE}[INFO] Installing pre-commit hooks...${RESET}\n"; \
+	    ${UVX_BIN} -p ${PYTHON_VERSION} pre-commit install || { printf "${YELLOW}[WARN] Failed to install pre-commit hooks${RESET}\n"; }; \
+	  fi; \
+	fi
+
+	@$(MAKE) post-install
+
+	@printf "\n${GREEN}[SUCCESS] Installation complete!${RESET}\n\n"
+
+go-tools: ## install the Go tools the gates need (idempotent)
+	@mkdir -p $(GO_BIN_DIR)
+	@for tool in $(GO_TOOLS); do \
+	  name=$$(basename $${tool%@*}); \
+	  if [ -x "$(GO_BIN_DIR)/$$name" ]; then \
+	    continue; \
+	  fi; \
+	  printf "${BLUE}[INFO] Installing $$name${RESET}\n"; \
+	  GOBIN="$(GO_BIN_DIR)" $(GO) install "$$tool" || { printf "${RED}[ERROR] Failed to install $$name${RESET}\n"; exit 1; }; \
+	done
+	@printf "${BLUE}[INFO] All Go tools available in $(GO_BIN_DIR)${RESET}\n"
+
+all: fmt test docs-coverage security deps license typecheck rhiza-test ## run all CI targets locally
+
+# Double-colon, matching test.mk and rust.mk: book.mk declares `test:: ; @:` as a
+# no-op default so `make book` works without a test bundle, and make rejects a
+# target that has both a `:` and a `::` rule.
+test:: install ## run the test suite
+	@printf "${BLUE}[INFO] Running tests${RESET}\n"
+	@rm -rf _tests
+	@mkdir -p _tests
+	@$(GO) test ./... $(GO_TEST_FLAGS) $(GO_FLAGS)
+
+coverage: install go-tools ## measure coverage and emit the reports book.mk consumes
+	@printf "${BLUE}[INFO] Measuring coverage (floor: $(COVERAGE_FAIL_UNDER)%%)${RESET}\n"
+	@mkdir -p _tests/html-coverage
+	# -covermode=atomic because the default `set` mode is not race-safe and the
+	# test run above is a race build.
+	@$(GO) test ./... -covermode=atomic -coverprofile=_tests/coverage.out $(GO_FLAGS)
+	# Cobertura XML at exactly the path book.mk's badge step reads, so the docs
+	# site gets a measured coverage badge on Go projects too.
+	@$(GO_BIN_DIR)/gocover-cobertura < _tests/coverage.out > _tests/coverage.xml
+	@$(GO) tool cover -html=_tests/coverage.out -o _tests/html-coverage/index.html
+	# `go test` has no --fail-under; the total line from `go tool cover -func` is
+	# where the number lives, so the floor is enforced here.
+	@$(GO) tool cover -func=_tests/coverage.out | awk -v floor=$(COVERAGE_FAIL_UNDER) ' \
+		/^total:/ { \
+			pct = $$3; sub(/%/, "", pct); \
+			if (pct + 0 < floor + 0) { \
+				printf "[ERROR] Coverage %s%% is below the %s%% floor\n", pct, floor; \
+				exit 1; \
+			} \
+			printf "[INFO] Coverage %s%% (floor: %s%%)\n", pct, floor; \
+		}'
+
+typecheck: install go-tools ## vet and lint (the compiler already type-checks)
+	@printf "${BLUE}[INFO] Running go vet${RESET}\n"
+	@$(GO) vet ./... $(GO_FLAGS)
+	@printf "${BLUE}[INFO] Running golangci-lint${RESET}\n"
+	@$(GO_BIN_DIR)/golangci-lint run
+
+docs-coverage: install go-tools ## fail on any undocumented exported item
+	# revive's `exported` rule is the closest analogue of interrogate: it is
+	# pass/fail on missing doc comments rather than a percentage, exactly as
+	# rust-core's `-D missing_docs` is. revive.toml enables that rule and no other.
+	@printf "${BLUE}[INFO] Checking doc comments on exported items${RESET}\n"
+	@$(GO_BIN_DIR)/revive -config revive.toml -set_exit_status ./...
+
+security: install go-tools ## scan dependencies for known vulnerabilities
+	@printf "${BLUE}[INFO] Running govulncheck${RESET}\n"
+	@$(GO_BIN_DIR)/govulncheck ./...
+
+deps: install ## report dependency drift (the deptry analogue)
+	# `go mod tidy -diff` (Go 1.23+) reports what tidy *would* change and exits
+	# non-zero, which is both the unused-dependency and the missing-dependency
+	# check in one command. No tool to install.
+	@printf "${BLUE}[INFO] Checking that go.mod and go.sum are tidy${RESET}\n"
+	@$(GO) mod tidy -diff
+
+license: install go-tools ## run license compliance scan
+	@printf "${BLUE}[INFO] Running license compliance scan${RESET}\n"
+	@$(GO_BIN_DIR)/go-licenses check ./...
+
+rhiza-test: install ## run rhiza's own tests (if any)
+	# The template's self-tests validate READMEs and YAML, not Go code, so they
+	# stay Python and run through uv here rather than being ported.
+	@if [ -d ".rhiza/tests" ]; then \
+		${UV_BIN} run --with pytest --with pytest-timeout --with python-dotenv --with packaging pytest .rhiza/tests; \
+	else \
+		printf "${YELLOW}[WARN] No .rhiza/tests directory found, skipping rhiza-tests${RESET}\n"; \
+	fi

--- a/bundles/go-core/.rhiza/make.d/go.mk
+++ b/bundles/go-core/.rhiza/make.d/go.mk
@@ -150,8 +150,12 @@ deps: install ## report dependency drift (the deptry analogue)
 	@$(GO) mod tidy -diff
 
 license: install go-tools ## run license compliance scan
+	# `--ignore <module path>`: go-licenses walks the project's own packages as well
+	# as its dependencies, so without this a repo with no LICENSE file fails the gate
+	# on itself rather than on a dependency — which every freshly synced project is.
+	# The module path comes from go.mod, so this holds in any project.
 	@printf "${BLUE}[INFO] Running license compliance scan${RESET}\n"
-	@$(GO_BIN_DIR)/go-licenses check ./...
+	@$(GO_BIN_DIR)/go-licenses check ./... --ignore "$$($(GO) list -m)"
 
 rhiza-test: install ## run rhiza's own tests (if any)
 	# The template's self-tests validate READMEs and YAML, not Go code, so they

--- a/bundles/go-core/internal/version/version.go
+++ b/bundles/go-core/internal/version/version.go
@@ -1,0 +1,17 @@
+// Package version records the version of this module.
+//
+// Go is the odd one out among rhiza's language layers: a Python project keeps its
+// version in pyproject.toml and a Rust crate keeps it in Cargo.toml, but a Go
+// module's version *is* its git tag — nothing in the source tree carries it, and
+// nothing carries it into a built binary either.
+//
+// So this file is that carrier. `.rhiza/.cfg.toml` points bump-my-version at the
+// constant below, which means the release flow rewrites it and creates the
+// matching tag in one commit: the two can never disagree. Print it from a
+// `--version` flag, stamp it into a build, or ignore it — but do not delete it,
+// or the release flow has no version location to write to.
+package version
+
+// Version is the module version. bump-my-version rewrites this literal on
+// release; the tag it creates is "v" + this value.
+const Version = "0.0.0"

--- a/bundles/go-core/revive.toml
+++ b/bundles/go-core/revive.toml
@@ -1,0 +1,25 @@
+# revive configuration — the `docs-coverage` gate, and only that.
+#
+# golangci-lint (see .golangci.yml) is the general linter and runs revive's
+# default rule set as part of `make typecheck`. This file exists for a narrower
+# job: `make docs-coverage` runs revive standalone against it, and revive enables
+# exactly the rules a config declares — so listing only `exported` here makes the
+# gate about doc comments and nothing else.
+#
+# That is the Go analogue of interrogate on the Python side and
+# RUSTDOCFLAGS="-D missing_docs" on the Rust side: pass/fail rather than a
+# percentage, because neither Go nor Rust has a documentation-coverage number.
+
+ignoreGeneratedHeader = true
+severity = "error"
+confidence = 0.8
+errorCode = 1
+warningCode = 1
+
+# Every exported identifier needs a doc comment that starts with its name.
+#   - checkPrivateReceivers: an exported method on an unexported type is still
+#     part of the API surface when the type is returned by an exported function.
+#   - disableStutteringCheck: `version.Version` reads fine; stutter is a naming
+#     opinion, not a documentation gap, and this gate is about the latter.
+[rule.exported]
+arguments = ["checkPrivateReceivers", "disableStutteringCheck"]

--- a/docs/reference/BUNDLE_TAXONOMY.md
+++ b/docs/reference/BUNDLE_TAXONOMY.md
@@ -30,6 +30,7 @@ the source of truth for the exact set. See
 | `core` | Required base, and language-neutral: thin Makefile, `.rhiza/` modular make system, help/logo machinery, and uv/uvx as a tool runner. Not a working repo on its own. |
 | `python-core` | The Python language layer: virtualenv and `uv sync` (`install`), `.python-version`, `ruff.toml`, `.bandit`, pre-commit config, `deptry` and licence scans, and the `all` aggregate. Exactly one language layer per repo. |
 | `rust-core` | The Rust language layer: rustup and `cargo fetch` (`install`), `rust-toolchain.toml`, `rustfmt.toml`, `clippy.toml`, `deny.toml`, pre-commit config, and the test/coverage/lint gates. Carries its own test targets — in Rust they are cargo subcommands with nothing to configure. |
+| `go-core` | The Go language layer: `go mod download` (`install`), `.golangci.yml`, `revive.toml`, pre-commit config, a `version.Version` constant for the release flow, and the test/coverage/lint gates. Carries its own test targets — `go test` and `go tool cover` need no configuration. |
 | `tests` | Local testing: pytest, coverage, and type checking. |
 | `benchmarks` | Performance benchmarking with `pytest-benchmark` and reporting (builds on `tests`). |
 | `book` | Documentation site with MkDocs + zensical. |
@@ -84,6 +85,7 @@ context and Rhiza expands it to a sensible bundle set.
 | `github-project` | the `local` set + `github` and the `github-*` overlays | A standard GitHub-hosted project. |
 | `gitlab-project` | the `local` set + `gitlab` and the `gitlab-*` overlays | A standard GitLab-hosted project. |
 | `rust-local` | `core`, `rust-core`, `book` | A Rust project. Hosted-CI Rust profiles arrive with the Rust workflows — the `github`/`gitlab` bundles currently ship Python CI. |
+| `go-local` | `core`, `go-core`, `book` | A Go project. Hosted-CI Go profiles arrive with the Go workflows, for the same reason. |
 
 ## Adoption flow
 

--- a/docs/reference/GLOSSARY.md
+++ b/docs/reference/GLOSSARY.md
@@ -45,6 +45,7 @@ flowchart LR
         core["core"]
         python_core["python-core"]
         rust_core["rust-core"]
+        go_core["go-core"]
     end
 
     subgraph Local["Local-first bundles"]

--- a/tests/api/test_language_layer.py
+++ b/tests/api/test_language_layer.py
@@ -243,6 +243,20 @@ class TestGoLayerKeepsTheSameContract:
         # its absence, and `make -n` prints recipe comments.
         assert "rustup show" not in out
 
+    def test_license_gate_ignores_the_projects_own_module(self, logger):
+        """go-licenses walks the project's own packages, not just its dependencies.
+
+        Found by running the gate on a real synced project: without
+        `--ignore <module path>` it fails on the project itself for having no LICENSE
+        file, which every freshly synced repo lacks — the profile would ship a gate
+        that is red on the first run. The path must come from `go list -m` rather than
+        be hard-coded, or it only works for one module.
+        """
+        out = strip_ansi(run_make(logger, ["license"], check=False).stdout)
+        assert "go-licenses check ./..." in out
+        assert "--ignore" in out, "the gate fails on a project with no LICENSE without this"
+        assert "go list -m" in out, "the ignored path must be read from go.mod, not hard-coded"
+
     def test_go_tools_bootstraps_every_binary_the_gates_call(self, logger):
         """A gate whose binary is missing fails with a bare 'no such file'."""
         out = strip_ansi(run_make(logger, ["go-tools"], check=False).stdout)

--- a/tests/api/test_language_layer.py
+++ b/tests/api/test_language_layer.py
@@ -169,6 +169,114 @@ class TestRustLayerKeepsTheSameContract:
         )
 
 
+class TestGoLayerKeepsTheSameContract:
+    """`go-core` is the third peer, assembled into a temp dir like the Rust one.
+
+    No cargo, no go: these assert the layer *declares* the contract and maps each
+    gate to its Go equivalent, which is what lets book.mk and the CI workflows stay
+    language-agnostic. There is no Go toolchain in this repo to run them against.
+    """
+
+    @pytest.fixture(autouse=True)
+    def go_project(self, root: Path, tmp_path: Path, monkeypatch):
+        """Assemble core + go-core into a project, standing in for a sync."""
+        project = tmp_path / "go-project"
+        (project / ".rhiza" / "make.d").mkdir(parents=True)
+        shutil.copy(root / "Makefile", project / "Makefile")
+        shutil.copy(root / ".rhiza" / "rhiza.mk", project / ".rhiza" / "rhiza.mk")
+        for fragment in (root / "bundles" / "core" / ".rhiza" / "make.d").iterdir():
+            shutil.copy(fragment, project / ".rhiza" / "make.d" / fragment.name)
+        shutil.copy(
+            root / "bundles" / "go-core" / ".rhiza" / "make.d" / "go.mk",
+            project / ".rhiza" / "make.d" / "go.mk",
+        )
+        (project / "go.mod").write_text("module example.com/demo\n\ngo 1.24\n")
+        monkeypatch.chdir(project)
+        setup_rhiza_git_repo()
+        self.project = project
+
+    @pytest.mark.parametrize("target", LANGUAGE_LAYER_TARGETS)
+    def test_every_contract_target_resolves(self, logger, target):
+        """The same names the other layers provide, so callers need not branch."""
+        proc = run_make(logger, [target], check=False)
+        assert "no rule to make target" not in proc.stderr.lower()
+
+    @pytest.mark.parametrize(
+        ("target", "expected"),
+        [
+            ("typecheck", "go vet"),
+            ("security", "govulncheck"),
+            ("license", "go-licenses check"),
+            ("deps", "go mod tidy -diff"),
+            ("test", "go test ./..."),
+            ("docs-coverage", "revive"),
+        ],
+    )
+    def test_gate_maps_to_its_go_equivalent(self, logger, target, expected):
+        """Each gate has a Go counterpart under the same target name."""
+        out = strip_ansi(run_make(logger, [target], check=False).stdout)
+        assert expected in out, f"`make {target}` should run {expected}"
+
+    def test_coverage_writes_the_report_book_mk_reads(self, logger):
+        """book.mk badges `_tests/coverage.xml`; go emits a profile, so it must be converted."""
+        out = strip_ansi(run_make(logger, ["coverage"], check=False).stdout)
+        assert "-coverprofile=_tests/coverage.out" in out
+        assert "gocover-cobertura" in out
+        assert "_tests/coverage.xml" in out
+
+    def test_coverage_enforces_the_floor_go_test_will_not(self, logger):
+        """`go test` has no --fail-under, so dropping the awk check silently drops the gate."""
+        out = strip_ansi(run_make(logger, ["coverage"], check=False).stdout)
+        assert "go tool cover -func" in out
+        assert "floor" in out
+
+    def test_coverage_is_atomic_because_the_test_run_is_a_race_build(self, logger):
+        """The default `set` covermode is not race-safe; mixing them corrupts counts."""
+        assert "-covermode=atomic" in strip_ansi(run_make(logger, ["coverage"], check=False).stdout)
+
+    def test_install_is_the_thinnest_of_the_three_layers(self, logger):
+        """go.mod's toolchain directive replaces rustup; uv stays a tool runner only."""
+        out = strip_ansi(run_make(logger, ["install"], check=False).stdout)
+        assert "go mod download" in out
+        assert "uv sync" not in out
+        # The command, not the word: go.mk's recipe comments mention rustup to explain
+        # its absence, and `make -n` prints recipe comments.
+        assert "rustup show" not in out
+
+    def test_go_tools_bootstraps_every_binary_the_gates_call(self, logger):
+        """A gate whose binary is missing fails with a bare 'no such file'."""
+        out = strip_ansi(run_make(logger, ["go-tools"], check=False).stdout)
+        for tool in ("golangci-lint", "govulncheck", "go-licenses", "gocover-cobertura", "revive"):
+            assert tool in out, f"`go-tools` does not install {tool}, which a gate below calls"
+
+    def test_all_chains_the_go_gates(self, logger):
+        """The mirror of the Python and Rust `all` tests — a dropped gate shows up here."""
+        out = strip_ansi(run_make(logger, ["all"], check=False).stdout)
+        assert "pre-commit run --all-files" in out  # fmt, from core
+        for gate, command in (
+            ("test", "go test ./..."),
+            ("docs-coverage", "revive"),
+            ("security", "govulncheck"),
+            ("deps", "go mod tidy -diff"),
+            ("license", "go-licenses check"),
+            ("typecheck", "go vet"),
+        ):
+            assert command in out, f"`make all` no longer runs the {gate} gate ({command})"
+
+    def test_rhiza_test_still_runs_the_python_self_tests(self, logger):
+        """The template's own suite validates YAML and READMEs, so it stays Python under uv."""
+        out = strip_ansi(run_make(logger, ["rhiza-test"], check=False).stdout)
+        assert "pytest .rhiza/tests" in out
+
+    def test_neutral_tooling_works_without_a_python_version_file(self, logger):
+        """As with Rust: no `.python-version`, so `fmt` rests on the rhiza.mk fallback."""
+        out = strip_ansi(run_make(logger, ["fmt"], check=False).stdout)
+        assert not (self.project / ".python-version").exists(), "fixture drifted: this asserts the fallback path"
+        assert re.search(r"-p \d+\.\d+ pre-commit run --all-files", out), (
+            f"`make fmt` did not resolve PYTHON_VERSION to a usable value:\n{out}"
+        )
+
+
 class TestCoreAloneHasNoLanguageLayer:
     """Without a layer, core is inert on exactly the targets a layer owns."""
 

--- a/tests/bundles/test_bundle_rhiza_sync.py
+++ b/tests/bundles/test_bundle_rhiza_sync.py
@@ -5,10 +5,11 @@ files. The root .rhiza/ directory is the union of all those bundle-owned files, 
 every bundle file must byte-for-byte match its root counterpart.
 
 With one unavoidable exception: the mother repo can only dogfood **one** language
-layer. It is a Python project, so it runs `python-core`; `rust-core` claims the same
-`.rhiza/.cfg.toml` path and would add a second `install` target, so its files have no
-root counterpart by design. They are covered instead by the synced-project tests in
-`tests/api/test_language_layer.py`, which materialise the layer into a temp dir.
+layer. It is a Python project, so it runs `python-core`; `rust-core` and `go-core`
+claim the same `.rhiza/.cfg.toml` path and would each add a second `install` target,
+so their files have no root counterpart by design. They are covered instead by the
+synced-project tests in `tests/api/test_language_layer.py`, which materialise a layer
+into a temp dir.
 """
 
 from __future__ import annotations
@@ -22,7 +23,7 @@ _ROOT = Path(__file__).resolve().parents[2]
 # Language layers the mother repo does not run on. Exactly one language layer can be
 # dogfooded at a time — rhiza is a Python project — and a sibling layer's files
 # deliberately collide with the active one's.
-_NOT_DOGFOODED = {"rust-core"}
+_NOT_DOGFOODED = {"rust-core", "go-core"}
 
 
 def _bundle_rhiza_pairs() -> list[tuple[str, Path, Path]]:

--- a/tests/bundles/test_bundle_sync.py
+++ b/tests/bundles/test_bundle_sync.py
@@ -325,6 +325,178 @@ class TestProfileRustLocalSync:
         )
 
 
+class TestGoCoreBundleSync:
+    """Syncing core + go-core produces a working Go project layer.
+
+    Like rust-core, nothing here is dogfooded at the root — and unlike rust-core,
+    there is no Go toolchain in this environment at all, so these file-level
+    assertions are the whole safety net.
+    """
+
+    @pytest.fixture(autouse=True)
+    def synced(self, tmp_path, root):
+        """Sync the core and go-core bundles into a fresh directory."""
+        sync_bundles(root, ["core", "go-core"], tmp_path)
+        self.project = tmp_path
+
+    @pytest.mark.parametrize("name", [".golangci.yml", "revive.toml", ".pre-commit-config.yaml"])
+    def test_go_toolchain_config_is_present(self, name):
+        """The Go-side counterparts of ruff.toml/clippy.toml all arrive."""
+        assert (self.project / name).is_file(), f"Missing Go toolchain file: {name}"
+
+    @pytest.mark.parametrize("name", ["ruff.toml", ".bandit", ".python-version", "clippy.toml", "deny.toml"])
+    def test_sibling_layer_config_is_absent(self, name):
+        """A Go repo gets neither the Python nor the Rust toolchain — layers are alternatives."""
+        assert not (self.project / name).exists(), f"{name} belongs to another language layer"
+
+    def test_go_mk_provides_the_language_contract(self):
+        """go.mk owns the same target names its siblings do, plus the go-backed gates."""
+        go_mk = (self.project / ".rhiza" / "make.d" / "go.mk").read_text(encoding="utf-8")
+        for target in ("install:", "all:", "test::", "coverage:", "typecheck:", "docs-coverage:", "rhiza-test:"):
+            assert target in go_mk, f"go.mk is missing {target}"
+
+    def test_only_one_language_fragment_is_synced(self):
+        """python.mk, rust.mk and go.mk all define `install` — receiving two would be a clash."""
+        fragments = sorted(p.name for p in (self.project / ".rhiza" / "make.d").iterdir())
+        assert "go.mk" in fragments
+        assert "python.mk" not in fragments
+        assert "rust.mk" not in fragments
+
+    def test_the_version_constant_ships_with_the_layer(self):
+        """Unlike Cargo.toml, this file does not exist in a Go project unless rhiza puts it there."""
+        version_go = self.project / "internal" / "version" / "version.go"
+        assert version_go.is_file(), (
+            "go-core must ship internal/version/version.go — a Go module has no manifest, so "
+            "without it the release flow has no version location to write to"
+        )
+        source = version_go.read_text(encoding="utf-8")
+        assert source.startswith("// Package version"), "the package doc comment the docs-coverage gate requires"
+        assert 'const Version = "0.0.0"' in source
+
+    def test_no_symlinks_in_synced_project(self):
+        """Synced files are real files, as a downstream project would receive them."""
+        for path in self.project.rglob("*"):
+            if path.is_file():
+                assert not path.is_symlink(), f"Unexpected symlink in synced project: {path.relative_to(self.project)}"
+
+
+class TestGoBumpversionConfig:
+    """The Go `.rhiza/.cfg.toml` must write the one version location a Go module has.
+
+    Go is the odd layer out: pyproject.toml and Cargo.toml carry a version, a Go
+    module does not — its version is the git tag. The layer ships a `Version`
+    constant to serve as that location, so this checks the release config and the
+    shipped file agree, by running the config's own search the way bump-my-version
+    does. A rename on either side breaks the release with `ignore_missing_files
+    = false`, and this is what catches it first.
+    """
+
+    CURRENT = "1.2.3"
+    NEW = "1.3.0"
+
+    @pytest.fixture(autouse=True)
+    def config(self, tmp_path, root):
+        """Sync go-core and load its bump-my-version configuration."""
+        sync_bundles(root, ["core", "go-core"], tmp_path)
+        with (tmp_path / ".rhiza" / ".cfg.toml").open("rb") as fh:
+            self.cfg = tomllib.load(fh)["tool"]["bumpversion"]
+        self.project = tmp_path
+
+    def test_the_configured_file_is_the_file_the_bundle_ships(self):
+        """`ignore_missing_files = false`, so a path typo fails the release, not a test."""
+        assert self.cfg["ignore_missing_files"] is False
+        filenames = [f["filename"] for f in self.cfg["files"]]
+        assert filenames == ["internal/version/version.go"]
+        assert (self.project / filenames[0]).is_file(), "the config points at a file the layer does not ship"
+
+    def test_the_search_matches_the_shipped_constant(self):
+        """The declaration in version.go and the pattern in .cfg.toml must stay in step."""
+        spec = self.cfg["files"][0]
+        source = (self.project / spec["filename"]).read_text(encoding="utf-8")
+        # Version numbers are literal here; substitute the shipped 0.0.0 to match.
+        assert spec["search"].format(current_version="0.0.0") in source, (
+            "the bump-my-version search does not match the constant in version.go — "
+            "the release would fail with 'did not find current version'"
+        )
+
+    def test_a_version_in_prose_is_not_rewritten(self):
+        """Anchoring on `const Version =` is what keeps a doc comment or example safe."""
+        spec = self.cfg["files"][0]
+        search = spec["search"].format(current_version=self.CURRENT)
+        replace = spec["replace"].format(new_version=self.NEW)
+        source = f'// Version was {self.CURRENT} in the last release.\nconst Version = "{self.CURRENT}"\n'
+        result = source.replace(search, replace)
+        assert f"// Version was {self.CURRENT} in the last release." in result
+        assert f'const Version = "{self.NEW}"' in result
+
+    def test_no_lockfile_hook_is_needed(self):
+        """go.sum records dependency checksums only, so there is nothing to refresh."""
+        assert not self.cfg.get("pre_commit_hooks"), (
+            "the Go layer needs no post-bump hook; go.sum never records the module's own version"
+        )
+
+    def test_the_tag_is_the_semver_go_expects(self):
+        """Go resolves module versions from `vX.Y.Z` tags, and rejects PEP 440 short forms."""
+        assert self.cfg["tag_name"] == "v{new_version}"
+        values = self.cfg["parts"]["release"]["values"]
+        assert "alpha" in values
+        assert "a" not in values
+
+
+class TestProfileGoLocalSync:
+    """Syncing the 'go-local' profile yields a Go project with no hosted CI."""
+
+    GO_LOCAL_BUNDLES = ["core", "go-core", "book"]  # transitive closure of the 'go-local' profile
+
+    @pytest.fixture(autouse=True)
+    def synced(self, tmp_path, root):
+        """Sync all bundles in the go-local profile transitive closure."""
+        sync_bundles(root, self.GO_LOCAL_BUNDLES, tmp_path)
+        self.project = tmp_path
+
+    def test_the_language_contract_is_available(self):
+        """`install` and `all` exist, which is what makes the profile usable at all."""
+        go_mk = (self.project / ".rhiza" / "make.d" / "go.mk").read_text(encoding="utf-8")
+        assert "install:" in go_mk
+        assert "all:" in go_mk
+
+    def test_docs_skeleton_exists(self):
+        """The book bundle is language-neutral, so a Go project gets docs too."""
+        assert (self.project / "docs" / "index.md").is_file()
+        assert (self.project / "docs" / "mkdocs-base.yml").is_file()
+
+    def test_book_badge_step_and_go_coverage_agree_on_the_report_path(self):
+        """book.mk badges `_tests/coverage.xml`; the Go `coverage` target must write it."""
+        book_mk = (self.project / ".rhiza" / "make.d" / "book.mk").read_text(encoding="utf-8")
+        go_mk = (self.project / ".rhiza" / "make.d" / "go.mk").read_text(encoding="utf-8")
+        assert "_tests/coverage.xml" in book_mk
+        assert "_tests/coverage.xml" in go_mk
+
+    def test_no_github_workflows_injected(self):
+        """go-local is local-first: the Go CI workflows do not exist yet."""
+        workflows_dir = self.project / ".github" / "workflows"
+        if workflows_dir.exists():
+            workflow_files = list(workflows_dir.glob("*.yml"))
+            assert not workflow_files, (
+                f"go-local should not inject workflow files, found: {[f.name for f in workflow_files]}"
+            )
+
+    def test_no_gitlab_ci_injected(self):
+        """Nor the GitLab half of hosted CI."""
+        assert not (self.project / ".gitlab-ci.yml").exists()
+
+    def test_exactly_one_pre_commit_config(self):
+        """Three layers now claim this path; the profile selects exactly one."""
+        configs = list(self.project.rglob(".pre-commit-config.yaml"))
+        assert len(configs) == 1, f"expected one .pre-commit-config.yaml, found {configs}"
+        with configs[0].open(encoding="utf-8") as fh:
+            hook_ids = {hook["id"] for repo in yaml.safe_load(fh)["repos"] for hook in repo["hooks"]}
+        assert "go-mod-tidy" in hook_ids, "the synced pre-commit config is not the Go one"
+        assert not hook_ids & {"ruff", "bandit", "interrogate", "uv-lock", "cargo-clippy"}, (
+            "a sibling layer's hooks leaked into a Go profile"
+        )
+
+
 class TestCoreAndTestsBundleSync:
     """Syncing core + tests bundles adds pytest infrastructure."""
 


### PR DESCRIPTION
The third language layer, built to the same contract as `python-core` and `rust-core`: `install` and `all` mean what they mean everywhere else, so `book.mk` and the CI workflows stay language-agnostic.

## Gate parity

Same target names, different engines:

| target | rust-core | go-core |
| --- | --- | --- |
| `install` | `rustup show` + `cargo fetch` | `go mod download` |
| `test` | `cargo nextest` + doctests | `go test ./...` |
| `coverage` | `cargo llvm-cov --cobertura` | `go test -coverprofile` + `gocover-cobertura` → same `_tests/coverage.xml` |
| `typecheck` | `cargo clippy -D warnings` | `go vet` + golangci-lint |
| `docs-coverage` | `RUSTDOCFLAGS=-D missing_docs` | revive's `exported` rule — pass/fail, same as Rust |
| `security` | `cargo deny check advisories` | `govulncheck` |
| `license` | `cargo deny check licenses` | `go-licenses check` |
| unused deps | `cargo machete` | `go mod tidy -diff` |

Like `rust-core` it carries its own test targets: `go test` and `go tool cover` need no configuration files, so a `go-tests` bundle would own nothing.

`coverage` has one wrinkle worth noting — `go test` has no `--fail-under`, so the floor is enforced by parsing the `total:` line out of `go tool cover -func`. There is a test for that, because a dropped `awk` block would otherwise look like a passing gate.

## The version location

This is the one place Go genuinely differs from both siblings. A Go module has no manifest — **its version is the git tag** — so unlike `pyproject.toml` and `Cargo.toml` there is no file in the tree for bump-my-version to write to.

The layer ships a starter `internal/version/version.go` holding a `Version` constant and anchors `.rhiza/.cfg.toml` to it, so the release commit and its tag move together. The search is the literal `const Version = "..."` declaration rather than a bare version string, which keeps a version mentioned in a doc comment from being rewritten — tested. `internal/` keeps it out of downstream import paths while staying importable within the module, and the package name is fixed by the directory, so nothing depends on the module path.

No post-bump hook, unlike Rust: `go.sum` records dependency checksums only, never the module's own version, so there is nothing to refresh.

## Tests

The layer-discovery guards from #1451 pick this up for free — node pin, shared-hook-rev drift (the neutral hooks are pinned identically across all three layers), per-layer TOML, plus the existing "no profile selects two layers" and "every profile selects one" checks.

New: `TestGoLayerKeepsTheSameContract` (contract targets, each gate mapped to its Go command, the coverage path/floor/covermode, `go-tools` installing all five binaries, the `all` chain, the `PYTHON_VERSION` fallback a repo with no `.python-version` depends on), `TestGoCoreBundleSync`, `TestGoBumpversionConfig`, `TestProfileGoLocalSync`.

The completeness gates also did their job unprompted: adding the bundle failed ten tests across the README tables, the taxonomy page, the glossary Mermaid map, CLAUDE.md and the dogfood sync until each was updated.

`make test` — 1368 passed, 1 skipped. `make fmt` clean.

## Verified against a real toolchain

The first version of this PR shipped unverified — there was no Go on the machine. Go 1.26.5 is installed now, and every gate has been run against a project synced from the `go-local` profile (a small `greet` package plus a test, `go.mod` at go 1.26):

| gate | result |
| --- | --- |
| `go build` / `go vet` | clean, including the shipped `version.go` |
| `golangci-lint` | `config verify` passes on the v2 schema (v2.12.2); `run` reports 0 issues |
| `docs-coverage` (revive) | passes; **fails** on an added undocumented export — positive control |
| `security` (govulncheck) | no vulnerabilities |
| `deps` (`go mod tidy -diff`) | clean |
| `test` | passes |
| `coverage` | cobertura at `_tests/coverage.xml`, HTML report written, floor honoured — reports 100%, and **fails at 25%** when an uncovered package is added |
| `fmt` (pre-commit) | all hooks pass, including gofmt, go vet and the go.mod tidiness check |
| `all` | the whole chain, green end to end |

**It found one real bug**, now fixed in `fix(go): ignore the project's own module in the license gate`: `go-licenses check ./...` walks the project's own packages as well as its dependencies, so it failed on the project itself for having no LICENSE file. Every freshly synced `go-local` repo is in that state — `local`, `rust-local` and `go-local` all leave `legal` out — so the profile shipped a gate that was red on first run. `--ignore "$(go list -m)"` reads the module path from go.mod, and dependencies are still scanned (verified with `fatih/color` and `golang.org/x/sys` pulled in). There is a regression test for it.

Hosted-CI profiles remain deliberately absent, for the same reason as `rust-local`: the `github`/`gitlab` bundles ship Python CI (`uv build`, PyPI publish, a `uv` Dependabot ecosystem), so a `go-github-project` would deliver CI that fails on first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
