### PR TITLE
test(e2e): run every language layer's gates against a real project

### DIFF
--- a/.github/workflows/rhiza_e2e.yml
+++ b/.github/workflows/rhiza_e2e.yml
@@ -1,0 +1,224 @@
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
+#
+# Workflow: Language-layer end-to-end tests
+#
+# Purpose: Assemble each language layer's profile into a temp directory, scaffold
+#          the smallest project the layer should be green on, and run every gate
+#          for real — install, test, coverage, typecheck, docs-coverage, security,
+#          license, deps, fmt and the `all` aggregate.
+#
+# Why it is a separate workflow rather than jobs in rhiza_ci.yml:
+#   - it needs three toolchains CI does not otherwise install (uv, cargo, go)
+#   - a run costs minutes per layer, against rhiza_ci's <=20 min test budget
+#   - it is the only place the Rust and Go layers execute at all: the suite skips
+#     when a compiler is absent, so a developer's green local run proves nothing
+#     about the two layers they have no toolchain for
+#
+# The suite is opt-in via RHIZA_E2E=1, which `make e2e` sets. E2E_ARGS narrows the
+# run to one layer so each job installs only the toolchain it needs.
+#
+# Trigger: On pull_request, on push to main, and manually.
+
+name: "(RHIZA) E2E"
+
+# Cancel superseded in-progress runs of this workflow for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  python:
+    name: Python layer
+    # CI budget: <=30 min (uv sync, pytest, ty/mypy, and pre-commit provisioning
+    # every hook environment from scratch on the first `fmt`).
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      # Matches bundles/python-core/.python-version, which the scaffold's
+      # requires-python tracks: the check-python-version-consistency pre-commit
+      # hook reconciles the two, so a mismatch here would fail `make fmt`.
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          version: "0.11.16"
+          python-version: "3.12"
+
+      - name: Cache uv artifacts
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-uv-e2e-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-e2e-
+            ${{ runner.os }}-uv-
+
+      # Keyed on the shipped config, not on the repo's own: the hooks that run are
+      # the scaffolded project's, from bundles/python-core/.pre-commit-config.yaml.
+      - name: Cache pre-commit environments
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ runner.os }}-pre-commit-e2e-python-${{ hashFiles('bundles/python-core/.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pre-commit-e2e-python-
+
+      - name: Run the Python layer end to end
+        run: make e2e E2E_ARGS=tests/e2e/test_python_layer_e2e.py
+
+  rust:
+    name: Rust layer
+    # CI budget: <=40 min (the crate is compiled several times over — nextest, an
+    # instrumented coverage build, clippy and rustdoc each build it).
+    timeout-minutes: 40
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      # uv is still needed on a Rust project: the language-neutral half of the
+      # template (pre-commit, mkdocs, semgrep) runs through uvx whatever the
+      # language, and the layer's `fmt` gate is exactly that path.
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          version: "0.11.16"
+
+      # cache: false — rust-cache wants a Cargo.lock, and this repository has none
+      # (the crate under test is scaffolded into a temp directory at run time).
+      # llvm-tools-preview mirrors rust-toolchain.toml's components; `make install`
+      # would materialise them itself through `rustup show`, and asking for them
+      # here just moves the download into a cached step.
+      - name: Install the Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          toolchain: stable
+          components: rustfmt, clippy, llvm-tools-preview
+          cache: false
+
+      # `make cargo-tools` installs these itself, but from source via a
+      # cargo-binstall it first builds from source — minutes of CI for tools the
+      # runner can fetch prebuilt in seconds. cargo-binstall is in the list because
+      # the recipe bootstraps it whenever it is absent, even when nothing is missing.
+      - name: Install the cargo subcommands the gates call
+        uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
+        with:
+          tool: cargo-binstall,cargo-nextest,cargo-llvm-cov,cargo-deny,cargo-machete
+
+      - name: Cache pre-commit environments
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ runner.os }}-pre-commit-e2e-rust-${{ hashFiles('bundles/rust-core/.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pre-commit-e2e-rust-
+
+      - name: Run the Rust layer end to end
+        run: make e2e E2E_ARGS=tests/e2e/test_rust_layer_e2e.py
+
+  go:
+    name: Go layer
+    # CI budget: <=40 min (`go-tools` builds five binaries from source, golangci-lint
+    # being the expensive one, before any gate runs).
+    timeout-minutes: 40
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          version: "0.11.16"
+
+      # cache: false — setup-go's cache keys off a go.sum, and this repository has
+      # none (the module under test is scaffolded into a temp directory at run
+      # time). The build/module cache below is keyed by hand instead.
+      - name: Install Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: "stable"
+          cache: false
+
+      - name: Cache the Go build and module caches
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-e2e-${{ hashFiles('bundles/go-core/.rhiza/make.d/go.mk') }}
+          restore-keys: |
+            ${{ runner.os }}-go-e2e-
+
+      - name: Cache pre-commit environments
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ runner.os }}-pre-commit-e2e-go-${{ hashFiles('bundles/go-core/.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pre-commit-e2e-go-
+
+      - name: Run the Go layer end to end
+        run: make e2e E2E_ARGS=tests/e2e/test_go_layer_e2e.py
+
+  e2e-gate:
+    name: E2E gate
+    # Roll-up gate: one status check aggregating all three layers, so a ruleset can
+    # require this context instead of every per-language name.
+    # CI budget: <=5 min (result aggregation only).
+    timeout-minutes: 5
+    if: always()
+    needs: [python, rust, go]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Verify every language layer succeeded
+        run: |
+          echo "python result: ${{ needs.python.result }}"
+          echo "rust result:   ${{ needs.rust.result }}"
+          echo "go result:     ${{ needs.go.result }}"
+          # Accept "success" or "cancelled" (transient runner cancellation).
+          # Reject "failure" (real failure) and "skipped" (job never ran).
+          for result in "${{ needs.python.result }}" "${{ needs.rust.result }}" "${{ needs.go.result }}"; do
+            if [[ "$result" != "success" && "$result" != "cancelled" ]]; then
+              echo "::error::a language layer did not succeed ($result); failing the E2E gate."
+              exit 1
+            fi
+          done
+          echo "All language layers succeeded."

--- a/.rhiza/make.d/bundles.mk
+++ b/.rhiza/make.d/bundles.mk
@@ -2,7 +2,12 @@
 # Provides make explain-bundles for new contributors unfamiliar with the bundle model.
 # Mother-repo-only fragment: no bundle ships it, so it is never synced downstream.
 
-.PHONY: explain-bundles sync-self sync-self-check
+.PHONY: explain-bundles sync-self sync-self-check e2e
+
+# Which end-to-end modules `make e2e` runs. One per language layer, so CI can give
+# each its own job (and its own toolchain) by narrowing this:
+#   make e2e E2E_ARGS=tests/e2e/test_go_layer_e2e.py
+E2E_ARGS ?= tests/e2e
 
 ##@ Bundles
 explain-bundles: ## print all bundles and profiles with descriptions and dependencies
@@ -13,3 +18,26 @@ sync-self: ## relink root dogfood copies as symlinks into bundles/ (mother repo 
 
 sync-self-check: ## fail if any dogfood symlink is stale/missing without writing (CI drift guard, mother repo only)
 	@uv run utils/link_dogfood.py --check
+
+# The language-layer end-to-end suite: assemble a profile into a temp directory,
+# scaffold the smallest project the layer should be green on, and run every gate
+# for real. Opt-in because it drives real toolchains and takes minutes per layer;
+# a layer whose compiler is absent skips rather than fails, so `make e2e` on a
+# machine with no Go installed still exercises the layers it can.
+#
+# `make test` deliberately does not include it: the matrix would pay for it on
+# every OS and Python version. .github/workflows/rhiza_e2e.yml is where all three
+# actually run.
+#
+# No xdist and no -o timeout override: each module builds one project and runs its
+# gates against it in order, and the suite's own `pytest.mark.timeout` supersedes
+# the 60s pytest.ini default (sized for unit tests, not for a gate that provisions
+# pre-commit from scratch).
+#
+# pytest-timeout is provisioned here the way test.mk provisions its plugins: it is
+# not a declared project dependency, and without it pytest ignores both pytest.ini's
+# `timeout` and the suite's marker — silently, so a hung gate would run until the
+# CI job's own timeout killed it with no indication of which gate hung.
+e2e: install ## run the language-layer end-to-end suite against real toolchains (opt-in, mother repo only)
+	@printf "${BLUE}[INFO] Running end-to-end suite: $(E2E_ARGS)${RESET}\n"
+	@RHIZA_E2E=1 ${UV_BIN} run --with pytest-timeout pytest $(E2E_ARGS) -v

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ make benchmark    # Performance benchmarks
 make hypothesis-test  # Property-based tests only
 make stress       # Load/concurrency tests
 make security     # pip-audit + bandit security scans
+make e2e          # Language-layer end-to-end suite (opt-in, real toolchains; see below)
 make book         # Build documentation
 make marimo       # Start Marimo notebook server
 make clean        # Remove build artifacts and stale branches
@@ -146,6 +147,36 @@ compiler on demand, so there is no rustup step to mirror.
 semgrep through `uvx` regardless of the project's language. What moved is the
 *project* virtualenv and the `uv sync` of its declared dependencies.
 
+**How a layer is tested — two suites, on purpose.** `tests/api/test_language_layer.py`
+asserts the *contract* from `make -n` output: that a layer defines `install` and `all`,
+that core defines neither, and that each gate name expands to the intended command.
+That is fast, runs everywhere, and catches a renamed target or a gate dropped from
+`all` — but it never invokes cargo, go or uv, so a recipe whose flags are wrong passes
+it happily.
+
+`tests/e2e/` closes that gap. For each layer it copies the bundles into a temp
+directory (standing in for a `rhiza-cli` sync), writes the smallest project the layer
+should be green on (`tests/e2e/scaffolds.py`), commits it, and runs every gate for
+real — `install`, `test`, `coverage`, `typecheck`, `docs-coverage`, `security`,
+`license`, `deps`, `fmt` and the `all` aggregate. The failure mode it exists for is
+already on record: go-core's licence gate needs `--ignore $(go list -m)` because
+go-licenses otherwise fails a freshly synced project *for having no LICENSE of its
+own*, which no dry-run assertion could have found.
+
+Two properties keep it from being merely expensive:
+
+- **Opt-in.** Nothing runs without `RHIZA_E2E=1`; `make e2e` sets it. `make test` stays
+  fast and green offline, and the whole matrix does not pay for it on every OS and
+  Python version.
+- **Toolchain-gated.** A layer whose compiler is absent skips with a reason rather than
+  failing, so a developer with no Rust installed is not blocked by the Rust layer. The
+  corollary matters: a green local run proves nothing on its own —
+  `.github/workflows/rhiza_e2e.yml` (one job per layer, each installing only its own
+  toolchain) is the only place all three actually execute.
+
+Narrow the run with `make e2e E2E_ARGS=tests/e2e/test_go_layer_e2e.py`, which is how
+each CI job selects its layer.
+
 ### Modular Makefile System
 
 The root `Makefile` is intentionally thin (~10 lines) and only `include`s `.rhiza/rhiza.mk`. That file auto-loads everything in `.rhiza/make.d/*.mk` alphabetically.
@@ -170,7 +201,7 @@ The root `Makefile` is intentionally thin (~10 lines) and only `include`s `.rhiz
 | `paper.mk` | paper | LaTeX paper compilation |
 | `lfs.mk` | lfs | Git LFS install/track/status |
 | `github.mk` | github | GitHub repo/workflow helpers |
-| `bundles.mk` | *(mother-repo only — no bundle ships it)* | `explain-bundles`, `sync-self`, `sync-self-check` |
+| `bundles.mk` | *(mother-repo only — no bundle ships it)* | `explain-bundles`, `sync-self`, `sync-self-check`, `e2e` |
 
 Hook targets use double-colon syntax (`pre-install::`, `post-install::`) and can be defined multiple times to chain behaviour. Add project-specific hooks directly in the root `Makefile` above the include line. Developer-local shortcuts go in `local.mk` (not committed).
 
@@ -199,7 +230,9 @@ Hook targets use double-colon syntax (`pre-install::`, `post-install::`) and can
 
 ### CI/CD
 
-This repo runs on **GitHub Actions only**: `.github/workflows/` — CI, release, docker, CodeQL, weekly, sync. There is no root `.gitlab-ci.yml` here.
+This repo runs on **GitHub Actions only**: `.github/workflows/` — CI, e2e, release, docker, CodeQL, weekly, sync. There is no root `.gitlab-ci.yml` here.
+
+`rhiza_e2e.yml` is separate from `rhiza_ci.yml` rather than more jobs inside it: it installs three toolchains CI does not otherwise need, costs minutes per layer against CI's ≤20 min test budget, and is the only place the Rust and Go layers execute at all (see **Language layers** above).
 
 GitLab support ships as a **template for downstream consumers**, not as active CI in this repo: the `gitlab` bundle (`bundles/gitlab/`) materializes a `.gitlab-ci.yml` plus `.gitlab/` pipelines into projects that adopt the `gitlab-project` profile, mirroring the GitHub Actions coverage there.
 

--- a/bundles/core/.rhiza/rhiza.mk
+++ b/bundles/core/.rhiza/rhiza.mk
@@ -139,7 +139,7 @@ help: print-logo ## Display this help message
 	+@printf "$(BOLD)Usage:$(RESET)\n"
 	+@printf "  make $(BLUE)<target>$(RESET)\n\n"
 	+@printf "$(BOLD)Targets:$(RESET)\n"
-	+@awk 'BEGIN {FS = ":.*##"; printf ""} /^[a-zA-Z_-]+:.*?##/ { printf "  $(BLUE)%-20s$(RESET) %s\n", $$1, $$2 } /^##@/ { printf "\n$(BOLD)%s$(RESET)\n", substr($$0, 5) }' $(MAKEFILE_LIST)
+	+@awk 'BEGIN {FS = ":.*##"; printf ""} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  $(BLUE)%-20s$(RESET) %s\n", $$1, $$2 } /^##@/ { printf "\n$(BOLD)%s$(RESET)\n", substr($$0, 5) }' $(MAKEFILE_LIST)
 	+@printf "\n"
 
 ci-os-matrix: ## Emit GitHub CI OSes (RHIZA_CI_OS_MATRIX as JSON array, default ["ubuntu-latest"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,10 @@ def pytest_configure(config: pytest.Config) -> None:
         "markers",
         "gitlab_exec: GitLab tests that execute a job in Docker (opt-in via RHIZA_GITLAB_DOCKER=1)",
     )
+    config.addinivalue_line(
+        "markers",
+        "e2e: language-layer tests that run real toolchains (opt-in via RHIZA_E2E=1, or `make e2e`)",
+    )
 
 
 MOCK_MAKE_SCRIPT = """#!/usr/bin/env python3

--- a/tests/e2e/__init__.py
+++ b/tests/e2e/__init__.py
@@ -1,0 +1,1 @@
+"""End-to-end tests that run each language layer's gates against a real project."""

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -1,0 +1,320 @@
+"""Assemble a synced project per language layer and run its gates for real.
+
+`tests/api/test_language_layer.py` asserts the layer *contract* from `make -n`
+output: that `install` and `all` exist, and that each gate name expands to the
+right command. That catches a renamed target or a dropped gate, but it cannot
+catch a gate whose command is wrong — `make -n` never runs cargo, go or uv, so a
+recipe that fails on every real project passes the dry-run test happily. The
+`--ignore` flag in go-core's licence gate is the recorded example: the dry-run
+test for it could only be written *after* someone ran the gate on a real project
+and watched it fail on the project's own module.
+
+This module closes that gap. For each layer it copies the bundles into a temp
+directory (standing in for a `rhiza-cli` sync), writes the smallest project the
+layer should be green on (see `scaffolds.py`), commits it, and runs `make install`.
+The test modules then drive one gate per test against that project, for real.
+
+Two properties keep this honest rather than merely expensive:
+
+* **Opt-in.** Nothing runs unless ``RHIZA_E2E=1``, so `make test` stays fast and
+  green offline. `make e2e` sets it.
+* **Toolchain-gated.** A layer whose compiler is absent skips with a reason
+  instead of failing, so a developer with no Rust installed is not blocked by the
+  Rust layer's tests. That means a green local run proves nothing on its own —
+  `.github/workflows/rhiza_e2e.yml` is where all three actually execute.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess  # nosec B404 - drives git/make against a scratch project
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+from defusedxml import ElementTree
+
+from tests.e2e import scaffolds
+from tests.util import run_make, strip_ansi, sync_bundles
+
+GIT = shutil.which("git") or "/usr/bin/git"
+
+# The suite runs real toolchains, downloads real tools and takes minutes per
+# layer, so it never runs by accident.
+ENABLE_FLAG = "RHIZA_E2E"
+
+# Generous per-test ceiling. The first gate in a module absorbs the fixture cost
+# (bundle copy, `make install`, and — on the first `fmt` — pre-commit provisioning
+# node and every hook environment), and `go-tools` compiles five binaries from
+# source. Applied as a module-level `pytest.mark.timeout` by each test module.
+GATE_TIMEOUT_SECONDS = 1800
+
+
+@dataclass(frozen=True)
+class Layer:
+    """One language layer, and everything needed to stand a real project on it.
+
+    Attributes:
+        name: Short label used in temp-dir names and skip messages.
+        profile: The profile in `.rhiza/template-bundles.yml` this mirrors.
+        bundles: Bundles to sync, in order.
+        tools: Executables that must be on PATH, or the layer's tests skip.
+        files: Project files to write after the sync, keyed by relative path.
+    """
+
+    name: str
+    profile: str
+    bundles: tuple[str, ...]
+    tools: tuple[str, ...]
+    files: dict[str, str] = field(repr=False)
+
+
+# `book` is in every set on purpose: book.mk declares `test:: ; @:` as a no-op
+# default so `make book` works without a test bundle, and a layer's own `test::`
+# rule has to coexist with it. Syncing book is what makes `make test` prove that.
+#
+# marimo is left out of the Python set even though the `local` profile includes it:
+# the bundle ships marimo.mk but no notebooks, and marimo.mk appends
+# $(MARIMO_FOLDER) to DEPTRY_FOLDERS, so `make deptry` would be pointed at a
+# folder no sync creates. A real consumer writes notebooks there; a scaffold has
+# none, and inventing some would test marimo rather than the language layer.
+PYTHON = Layer(
+    name="python",
+    profile="local",
+    bundles=("core", "python-core", "book", "tests"),
+    tools=("git", "uv"),
+    files=scaffolds.PYTHON_FILES,
+)
+
+RUST = Layer(
+    name="rust",
+    profile="rust-local",
+    bundles=("core", "rust-core", "book"),
+    tools=("git", "uv", "cargo", "rustup"),
+    files=scaffolds.RUST_FILES,
+)
+
+GO = Layer(
+    name="go",
+    profile="go-local",
+    bundles=("core", "go-core", "book"),
+    tools=("git", "uv", "go"),
+    files=scaffolds.GO_FILES,
+)
+
+
+@dataclass(frozen=True)
+class Project:
+    """An assembled, installed project standing in for a synced downstream repo.
+
+    Attributes:
+        layer: The layer it was built from.
+        path: The project root.
+        install: The completed `make install` run, so a test can assert on it
+            without paying for a second install.
+    """
+
+    layer: Layer
+    path: Path
+    install: subprocess.CompletedProcess
+
+    @property
+    def install_output(self) -> str:
+        """Return `make install`'s combined output, ANSI-stripped.
+
+        Both streams, for the reason `gate` gives: rustup and the go command report
+        progress on stderr, so which stream a line landed on is not something a test
+        should have to know.
+        """
+        return strip_ansi(self.install.stdout) + strip_ansi(self.install.stderr)
+
+
+def gate_env() -> dict[str, str]:
+    """Return the environment for a nested make run.
+
+    `make e2e` invokes pytest from a recipe, so this process inherits MAKEFLAGS
+    (including the jobserver file descriptors) and MAKELEVEL. Passing those down
+    to a make that is *not* a sub-make of the outer one makes it warn about a
+    missing jobserver and, with `-s` inherited, silences the output a failing gate
+    needs to report. Stripping them makes a gate behave identically whether it was
+    reached through `make e2e` or a bare `pytest` run.
+    """
+    dropped = {"MAKEFLAGS", "MAKELEVEL", "MFLAGS", "MAKE_TERMOUT", "MAKE_TERMERR", "VIRTUAL_ENV"}
+    return {key: value for key, value in os.environ.items() if key not in dropped}
+
+
+def require_e2e_enabled() -> None:
+    """Skip unless the opt-in flag is set."""
+    if os.environ.get(ENABLE_FLAG) != "1":
+        pytest.skip(f"end-to-end suite is opt-in: set {ENABLE_FLAG}=1 (or run `make e2e`)")
+
+
+def require_toolchain(layer: Layer) -> None:
+    """Skip when any executable the layer's gates call is missing.
+
+    Args:
+        layer: The layer about to be exercised.
+    """
+    missing = [tool for tool in layer.tools if shutil.which(tool) is None]
+    if missing:
+        pytest.skip(f"{layer.name} layer needs {', '.join(missing)} on PATH")
+
+
+def _git(project: Path, *args: str) -> None:
+    """Run a git command in the project, raising on failure.
+
+    Args:
+        project: Repository root.
+        args: Arguments after the git executable.
+    """
+    subprocess.run([GIT, *args], cwd=project, check=True, capture_output=True)  # nosec B603
+
+
+def _init_repo(project: Path) -> None:
+    """Make the project a git repo with its scaffold committed.
+
+    pre-commit reads the file list from git and refuses to run outside a
+    repository, so `make fmt` needs both the repo and a commit. The remote is set
+    because rhiza's own tooling reads `origin` to identify the project.
+
+    Args:
+        project: The assembled project root.
+    """
+    _git(project, "init", "--initial-branch=main")
+    _git(project, "config", "user.email", "e2e@example.com")
+    _git(project, "config", "user.name", "Rhiza E2E")
+    _git(project, "remote", "add", "origin", "https://github.com/jebel-quant/demo")
+    _git(project, "add", ".")
+    _git(project, "commit", "--no-verify", "-m", "Initial sync")
+
+
+def _sync(root: Path, layer: Layer, project: Path) -> None:
+    """Copy the layer's bundles into the project, dereferencing symlinks.
+
+    Mirrors what `rhiza-cli` does on a sync: bundle files land at the paths they
+    declare, with dogfood symlinks resolved to real content.
+
+    Args:
+        root: The rhiza repository root.
+        layer: The layer whose bundles to copy.
+        project: Destination project root.
+    """
+    sync_bundles(root, list(layer.bundles), project)
+
+
+def assemble(layer: Layer, root: Path, workdir: Path, logger) -> Project:
+    """Sync, scaffold, commit and install a project for one layer.
+
+    Args:
+        layer: The layer to build.
+        root: The rhiza repository root.
+        workdir: A directory to build in (one per layer).
+        logger: Test logger.
+
+    Returns:
+        The installed project.
+    """
+    require_e2e_enabled()
+    require_toolchain(layer)
+
+    project = workdir / f"{layer.name}-project"
+    project.mkdir(parents=True)
+    _sync(root, layer, project)
+
+    # The one project file derived rather than listed: it names the profile, and
+    # deriving it from the layer keeps that claim tied to the bundles actually synced.
+    files = {**layer.files, ".rhiza/template.yml": scaffolds.template_yml(layer.profile)}
+    for relative, content in files.items():
+        target = project / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+
+    _init_repo(project)
+    logger.info("assembled %s project at %s from bundles %s", layer.name, project, ", ".join(layer.bundles))
+
+    install = run_make(logger, ["install"], check=False, dry_run=False, env=gate_env(), cwd=project)
+    if install.returncode != 0:
+        pytest.fail(_report(layer, "install", install))
+    return Project(layer=layer, path=project, install=install)
+
+
+def _report(layer: Layer, target: str, proc: subprocess.CompletedProcess) -> str:
+    """Return a failure message carrying the whole gate output.
+
+    A gate fails for a reason buried in a compiler or linter's own output, so the
+    assertion has to carry it — the alternative is a bare exit code and a rerun.
+
+    Args:
+        layer: The layer being exercised.
+        target: The make target that ran.
+        proc: The completed process.
+
+    Returns:
+        A multi-line failure message.
+    """
+    return (
+        f"`make {target}` failed on the {layer.name} layer (exit {proc.returncode}).\n"
+        f"--- stdout ---\n{strip_ansi(proc.stdout)}\n"
+        f"--- stderr ---\n{strip_ansi(proc.stderr)}"
+    )
+
+
+def gate(project: Project, target: str, logger) -> str:
+    """Run one gate for real and fail the test with its output if it is red.
+
+    Both streams are returned joined, because which one a gate writes to is not a
+    property the tests should care about: make's own `printf` lines go to stdout,
+    while cargo and go send progress and diagnostics to stderr (nextest reports every
+    test it ran there). Asserting on stdout alone would make a test's outcome depend
+    on a tool's stream choice rather than on whether the gate did its job.
+
+    Args:
+        project: The assembled project.
+        target: The make target to run.
+        logger: Test logger.
+
+    Returns:
+        The gate's combined output, ANSI-stripped, for tests that assert on what ran.
+    """
+    proc = run_make(logger, [target], check=False, dry_run=False, env=gate_env(), cwd=project.path)
+    if proc.returncode != 0:
+        pytest.fail(_report(project.layer, target, proc))
+    return strip_ansi(proc.stdout) + strip_ansi(proc.stderr)
+
+
+def assert_hooks_passed(out: str, hooks: tuple[str, ...]) -> None:
+    """Assert each named pre-commit hook ran and passed in a `make fmt` run.
+
+    An exit code cannot distinguish "every hook passed" from "no hook had anything
+    to look at": pre-commit exits 0 when a hook matches no files and prints
+    ``Skipped`` instead. That is exactly how a config whose ``types``/``files``
+    filters stopped matching would look, and on a language layer whose hooks are all
+    filtered by file type (cargo fmt, gofmt, go vet) it is the likely failure mode.
+
+    Args:
+        out: `make fmt` stdout, ANSI-stripped.
+        hooks: Hook names as pre-commit prints them at the start of each result line.
+    """
+    for hook in hooks:
+        line = next((candidate for candidate in out.splitlines() if candidate.startswith(hook)), None)
+        assert line is not None, f"`make fmt` never ran the {hook!r} hook:\n{out}"
+        assert line.rstrip().endswith("Passed"), f"the {hook!r} hook did not pass: {line.rstrip()}"
+
+
+def line_rate(coverage_xml: Path) -> float:
+    """Return the overall line rate from a Cobertura report.
+
+    All three layers are required to write Cobertura XML to the same path
+    (`_tests/coverage.xml`) because book.mk's badge step reads exactly that, so
+    one reader serves pytest-cov, `cargo llvm-cov --cobertura` and
+    gocover-cobertura alike — which is the point worth asserting.
+
+    Args:
+        coverage_xml: Path to the report.
+
+    Returns:
+        The root element's ``line-rate`` as a float between 0 and 1.
+    """
+    root = ElementTree.parse(coverage_xml).getroot()
+    return float(root.get("line-rate"))

--- a/tests/e2e/scaffolds.py
+++ b/tests/e2e/scaffolds.py
@@ -1,0 +1,287 @@
+"""The project files each language layer's gates are run against.
+
+A bundle sync delivers infrastructure — a Makefile, lint configs, a pre-commit
+config — but no code. So an end-to-end run needs the other half: the smallest
+project that a *correct* layer should pass every gate on. That project is what
+these dictionaries hold, one per layer, keyed by path relative to the project root.
+
+They are deliberately written to be exactly gate-clean and no more:
+
+* documented down to the last public item, because `docs-coverage` is
+  interrogate at 100% / ``-D missing_docs`` / revive's ``exported`` rule
+* fully covered by one test, because the coverage floor is 90%
+* formatter-clean as written (tabs in Go, rustfmt spacing in Rust), because
+  `fmt` runs the formatters through pre-commit and fails on a diff
+* annotated and licensed, because `typecheck` is mypy ``--strict`` and the
+  licence gates read ``[project].license`` / ``[package].license``
+
+That tightness is the point: anything a gate would flag is a deliberate signal,
+so when e2e goes red it is the template that regressed, not the fixture.
+
+Kept as string constants rather than files on disk so the mother repo's own ruff,
+interrogate and mypy runs do not lint a Python package that is meant to be a
+downstream project's, and so each layer's scaffold reads as one unit.
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Shared
+# ---------------------------------------------------------------------------
+
+# Every scaffold carries one: the pointer file `check-rhiza-config` (a pre-commit
+# hook from rhiza-hooks that `fmt` runs) expects in a rhiza-managed repo. No
+# bundle ships it, because it is the consumer's own declaration of what it synced.
+_TEMPLATE_YML = """\
+repository: jebel-quant/rhiza
+ref: v1.2.5
+profiles:
+  - {profile}
+"""
+
+# Prose only, no fenced code blocks: `rhiza-test` runs the shipped
+# test_readme_validation.py, which executes every ```python block in the README
+# and diffs it against the following ```result block. An empty set of blocks
+# passes that trivially, which keeps the README about the scaffold rather than
+# about satisfying a test.
+_README = """\
+# demo
+
+A minimal {language} project assembled by rhiza's end-to-end suite.
+
+It exists to prove that a freshly synced project passes every gate the
+`{layer}` language layer ships, with no hand-holding beyond the code below.
+"""
+
+
+def _readme(language: str, layer: str) -> str:
+    """Return the scaffold README for a layer.
+
+    Args:
+        language: Human-readable language name, e.g. ``"Python"``.
+        layer: The bundle that ships the layer, e.g. ``"python-core"``.
+
+    Returns:
+        Markdown that passes markdownlint with MD013 disabled.
+    """
+    return _README.format(language=language, layer=layer)
+
+
+def template_yml(profile: str) -> str:
+    """Return a `.rhiza/template.yml` naming the profile the scaffold assembles.
+
+    Written by `harness.assemble` from the layer's own ``profile`` field rather than
+    being listed in the dictionaries below, so the profile a scaffold claims and the
+    bundle list it is actually built from cannot drift apart.
+
+    Args:
+        profile: The profile in `.rhiza/template-bundles.yml` this scaffold mirrors.
+
+    Returns:
+        YAML for the repo-owned rhiza pointer file.
+    """
+    return _TEMPLATE_YML.format(profile=profile)
+
+
+# ---------------------------------------------------------------------------
+# Python (bundle: python-core, plus tests for pytest/coverage/typecheck)
+# ---------------------------------------------------------------------------
+
+# requires-python tracks bundles/python-core/.python-version: the
+# check-python-version-consistency pre-commit hook reconciles the two, so a
+# scaffold that disagrees with the shipped interpreter fails `fmt`.
+#
+# hatchling with an explicit wheel target rather than a bare [project] table:
+# without a build system uv treats the project as virtual and never installs it,
+# so `import demo` — and with it the coverage measurement of src/ — would fail.
+_PYTHON_PYPROJECT = """\
+[project]
+name = "demo"
+version = "0.1.0"
+description = "A minimal project proving the python-core layer's gates pass on a fresh sync."
+readme = "README.md"
+requires-python = ">=3.12"
+license = "MIT"
+authors = [
+  { name = "Rhiza End-To-End Suite" }
+]
+classifiers = [
+    "Programming Language :: Python :: 3.12",
+]
+dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/jebel-quant/rhiza"
+Repository = "https://github.com/jebel-quant/rhiza"
+
+[dependency-groups]
+test = [
+    "pytest>=9,<10",
+]
+lint = [
+    "ruff>=0.16,<1.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/demo"]
+"""
+
+_PYTHON_INIT = '"""A minimal package whose public surface is one greeting helper."""\n'
+
+# The doctest is load-bearing: `make rhiza-test` runs the shipped
+# test_docstrings.py, which discovers packages under SOURCE_FOLDER and skips when
+# no module has any doctests. With one here, that self-test actually asserts.
+_PYTHON_GREETING = '''\
+"""Build greetings, the one behaviour this scaffold ships."""
+
+from __future__ import annotations
+
+
+def greet(name: str) -> str:
+    """Return a greeting addressed to ``name``.
+
+    Args:
+        name: Who to greet.
+
+    Returns:
+        The greeting.
+
+    Examples:
+        >>> greet("rhiza")
+        'Hello, rhiza!'
+    """
+    return f"Hello, {name}!"
+'''
+
+_PYTHON_TEST = '''\
+"""Tests for the greeting helper, covering every line of src/."""
+
+from demo.greeting import greet
+
+
+def test_greet_addresses_the_caller_by_name():
+    """greet() interpolates the name it is given."""
+    assert greet("rhiza") == "Hello, rhiza!"
+'''
+
+PYTHON_FILES: dict[str, str] = {
+    "pyproject.toml": _PYTHON_PYPROJECT,
+    "README.md": _readme("Python", "python-core"),
+    "src/demo/__init__.py": _PYTHON_INIT,
+    "src/demo/greeting.py": _PYTHON_GREETING,
+    "tests/test_greeting.py": _PYTHON_TEST,
+}
+
+# ---------------------------------------------------------------------------
+# Rust (bundle: rust-core)
+# ---------------------------------------------------------------------------
+
+# `license` is not decoration: `cargo deny check licenses` walks the whole graph
+# including the root crate, so an unlicensed scaffold fails the licence gate on
+# itself rather than on a dependency.
+_RUST_CARGO_TOML = """\
+[package]
+name = "demo"
+version = "0.1.0"
+edition = "2021"
+description = "A minimal crate proving the rust-core layer's gates pass on a fresh sync."
+license = "MIT"
+
+[dependencies]
+"""
+
+# Formatted as rustfmt would leave it (4-space indent, max_width 100 from
+# rustfmt.toml): `fmt` runs `cargo fmt --all --` through pre-commit, which fails
+# the hook when it rewrites a file.
+#
+# The `# Examples` block is a doctest, which nextest does not run — it is what
+# the layer's separate `cargo test --doc` line exists for, so `make test` only
+# proves both halves when there is a doctest to run.
+_RUST_LIB = """\
+//! A minimal crate whose public surface is one greeting helper.
+
+/// Returns a greeting addressed to `name`.
+///
+/// # Examples
+///
+/// ```
+/// assert_eq!(demo::greet("rhiza"), "Hello, rhiza!");
+/// ```
+pub fn greet(name: &str) -> String {
+    format!("Hello, {name}!")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::greet;
+
+    #[test]
+    fn greets_the_caller_by_name() {
+        assert_eq!(greet("rhiza"), "Hello, rhiza!");
+    }
+}
+"""
+
+RUST_FILES: dict[str, str] = {
+    "Cargo.toml": _RUST_CARGO_TOML,
+    "README.md": _readme("Rust", "rust-core"),
+    "src/lib.rs": _RUST_LIB,
+}
+
+# ---------------------------------------------------------------------------
+# Go (bundle: go-core)
+# ---------------------------------------------------------------------------
+
+# `go 1.23` is the floor the layer's own gates need, not a preference:
+# `go mod tidy -diff` — which `make deps` is — landed in 1.23. A newer toolchain
+# on the machine is fine; go.mod's directive only sets the language version.
+_GO_MOD = """\
+module example.com/demo
+
+go 1.23
+"""
+
+# Tab-indented, single-line imports, doc comments starting with the identifier
+# name: `fmt` runs gofmt through pre-commit and `docs-coverage` runs revive's
+# `exported` rule, so both the layout and the comment wording are gates here.
+#
+# "behavior", not "behaviour": .golangci.yml enables misspell with `locale: US`, so
+# `typecheck` fails a British spelling in a comment. Found by running the gate —
+# the sibling scaffolds spell it the other way and nothing complains, because
+# neither ruff nor clippy checks spelling.
+_GO_GREETING = """\
+// Package greeting builds greetings, the one behavior this scaffold ships.
+package greeting
+
+import "fmt"
+
+// Greet returns a greeting addressed to name.
+func Greet(name string) string {
+\treturn fmt.Sprintf("Hello, %s!", name)
+}
+"""
+
+_GO_GREETING_TEST = """\
+package greeting
+
+import "testing"
+
+func TestGreet(t *testing.T) {
+\tt.Parallel()
+
+\tif got, want := Greet("rhiza"), "Hello, rhiza!"; got != want {
+\t\tt.Fatalf("Greet(%q) = %q, want %q", "rhiza", got, want)
+\t}
+}
+"""
+
+GO_FILES: dict[str, str] = {
+    "go.mod": _GO_MOD,
+    "README.md": _readme("Go", "go-core"),
+    "greeting/greeting.go": _GO_GREETING,
+    "greeting/greeting_test.go": _GO_GREETING_TEST,
+}

--- a/tests/e2e/test_go_layer_e2e.py
+++ b/tests/e2e/test_go_layer_e2e.py
@@ -1,0 +1,188 @@
+"""Every gate the `go-core` layer ships, run for real on a freshly synced module.
+
+Go is where a dry-run test is least sufficient. Two of this layer's gates are
+assembled rather than delegated — coverage converts a Go profile to Cobertura and
+enforces the floor in awk, because `go test` has no `--fail-under`, and the licence
+gate has to feed go-licenses the module's own path so it does not fail the project
+for having no LICENSE of its own. Neither is checkable without running it: the
+`--ignore` flag exists precisely because someone ran the gate on a real project and
+watched it go red.
+
+These run all of it — go test with the race detector, the profile conversion, vet
+plus golangci-lint, revive's exported rule, govulncheck — on the smallest module a
+correct layer should be green on.
+
+Skips unless ``RHIZA_E2E=1`` and go is on PATH. See `harness.py`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.e2e.harness import (
+    GATE_TIMEOUT_SECONDS,
+    GO,
+    Project,
+    assemble,
+    assert_hooks_passed,
+    gate,
+    line_rate,
+)
+
+pytestmark = [pytest.mark.e2e, pytest.mark.timeout(GATE_TIMEOUT_SECONDS)]
+
+# The binaries the gates call. `go-tools` builds them into the project's own bin/
+# rather than the developer's GOPATH, so a gate never depends on what happens to
+# be installed globally.
+GO_TOOLS = ("golangci-lint", "govulncheck", "go-licenses", "gocover-cobertura", "revive")
+
+
+@pytest.fixture(scope="module")
+def project(root, tmp_path_factory, logger) -> Project:
+    """Sync core + go-core + book, scaffold a module, and install it."""
+    return assemble(GO, root, tmp_path_factory.mktemp("e2e-go"), logger)
+
+
+def test_install_is_the_thinnest_of_the_three_layers(project: Project):
+    """`go mod download` and nothing else: no rustup step, no virtualenv.
+
+    go.mod's `go`/`toolchain` directives make the go command fetch a matching
+    compiler itself, which is why this layer has no equivalent of `rustup show`.
+    """
+    assert "Installation complete" in project.install_output
+    assert not (project.path / ".venv").exists(), "the Go layer created a Python virtualenv"
+
+
+def test_go_core_ships_the_version_constant_the_release_flow_writes_to(project: Project):
+    """A Go module's version is its git tag, so the layer ships a file to carry it.
+
+    Without `internal/version/version.go` the release flow has no version location
+    and the release commit and its tag can drift apart. It arrives from the bundle,
+    not the scaffold — deleting it from go-core would fail here.
+    """
+    version_go = project.path / "internal" / "version" / "version.go"
+    assert version_go.is_file(), "go-core no longer ships internal/version/version.go"
+    assert 'const Version = "' in version_go.read_text(encoding="utf-8")
+
+
+def test_go_tools_provides_every_binary_the_gates_call(project: Project, logger):
+    """After `go-tools`, each gate's binary exists in the project's bin/."""
+    gate(project, "go-tools", logger)
+    bin_dir = project.path / "bin"
+    missing = [tool for tool in GO_TOOLS if not (bin_dir / tool).is_file()]
+    assert not missing, f"`make go-tools` left {missing} uninstalled in {bin_dir}"
+
+
+def test_test_gate_runs_the_suite_under_the_race_detector(project: Project, logger):
+    """`go test ./...` with the layer's default flags, and it actually runs a test.
+
+    Also the check that book.mk's no-op `test::` default coexists with the layer's
+    real one: both rules are defined here, so a single-colon rule in either file
+    would break the build rather than quietly run nothing.
+    """
+    out = gate(project, "test", logger)
+    assert "example.com/demo/greeting" in out, f"go test did not run the scaffold's package:\n{out}"
+
+
+def test_coverage_gate_converts_the_profile_and_enforces_the_floor(project: Project, logger):
+    """Go emits a profile; the gate converts it to the Cobertura path book.mk reads.
+
+    Three assembled steps in one gate — the atomic covermode the race build needs,
+    gocover-cobertura's conversion, and the awk floor check that stands in for the
+    `--fail-under` go test does not have.
+    """
+    out = gate(project, "coverage", logger)
+    assert (project.path / "_tests" / "coverage.out").is_file(), "no Go coverage profile was written"
+
+    coverage_xml = project.path / "_tests" / "coverage.xml"
+    assert coverage_xml.is_file(), "`make coverage` did not write _tests/coverage.xml"
+    assert line_rate(coverage_xml) >= 0.9, "the scaffold fell below the coverage floor the gate enforces"
+    assert (project.path / "_tests" / "html-coverage" / "index.html").is_file()
+    assert "floor: 90" in out, f"the coverage floor was never reported, so awk did not see a total:\n{out}"
+
+
+def test_typecheck_gate_runs_vet_and_golangci_lint(project: Project, logger):
+    """The compiler already type-checks, so the gate is vet plus the linter."""
+    out = gate(project, "typecheck", logger)
+    assert "Running go vet" in out
+    assert "Running golangci-lint" in out
+
+
+def test_docs_coverage_gate_requires_doc_comments_on_exported_items(project: Project, logger):
+    """Revive's `exported` rule — pass/fail, the way Rust's `-D missing_docs` is.
+
+    Runs against the bundle's own `internal/version` package as well as the
+    scaffold, so an undocumented export shipped by go-core would fail here.
+    """
+    out = gate(project, "docs-coverage", logger)
+    assert "Checking doc comments on exported items" in out
+
+
+def test_security_gate_scans_for_known_vulnerabilities(project: Project, logger):
+    """`govulncheck` — the pip-audit analogue. Needs the Go vulnerability database."""
+    out = gate(project, "security", logger)
+    assert "Running govulncheck" in out
+
+
+def test_license_gate_ignores_the_projects_own_module(project: Project, logger):
+    """go-licenses walks the project's own packages, not only its dependencies.
+
+    Every freshly synced repo lacks a LICENSE file, so without the `--ignore`
+    argument read from `go list -m` this gate is red on the first run of every Go
+    project. That failure mode only exists when the gate really runs, which is why
+    this test is the one that pins it.
+    """
+    out = gate(project, "license", logger)
+    assert "Running license compliance scan" in out
+
+
+def test_deps_gate_verifies_go_mod_is_tidy(project: Project, logger):
+    """`go mod tidy -diff` is both halves of deptry in one command."""
+    out = gate(project, "deps", logger)
+    assert "Checking that go.mod and go.sum are tidy" in out
+
+
+def test_rhiza_test_gate_skips_cleanly_without_a_tests_bundle(project: Project, logger):
+    """`go-local` ships no `.rhiza/tests`, so the self-test gate must no-op.
+
+    `all` depends on `rhiza-test`, so a gate that failed on a missing directory
+    would make `make all` red on every Go project.
+    """
+    out = gate(project, "rhiza-test", logger)
+    assert "No .rhiza/tests directory found" in out
+
+
+def test_fmt_gate_passes_every_pre_commit_hook(project: Project, logger):
+    """The Go pre-commit config is clean on a fresh sync.
+
+    Covers this layer's own hooks — gofmt, go vet, the go.mod tidiness check — and
+    the neutral half that runs through uvx with no `.python-version` to read.
+
+    Asserted per hook, not just on the exit code: the Go hooks are `types: [go]`, so
+    a config that stopped matching Go files would report every one of them as
+    skipped and still exit 0.
+    """
+    out = gate(project, "fmt", logger)
+    assert_hooks_passed(out, ("gofmt", "go vet", "go.mod and go.sum are tidy", "markdownlint"))
+
+
+def test_all_runs_the_whole_gate_set(project: Project, logger):
+    """`make all` is green, and still chains every gate.
+
+    Asserted on each gate's own output rather than the exit code alone: `all` is a
+    prerequisite list, and a gate dropped from it leaves the aggregate passing while
+    quietly checking less. Last, because it re-runs everything above.
+    """
+    out = gate(project, "all", logger)
+    for gate_name, evidence in (
+        ("fmt", "gofmt"),
+        ("test", "example.com/demo/greeting"),
+        ("docs-coverage", "Checking doc comments on exported items"),
+        ("security", "Running govulncheck"),
+        # The recipe's own line, not the pre-commit hook's near-identical name:
+        # matching the hook name would let `fmt` alone satisfy this.
+        ("deps", "Checking that go.mod and go.sum are tidy"),
+        ("license", "Running license compliance scan"),
+        ("typecheck", "Running go vet"),
+    ):
+        assert evidence in out, f"`make all` no longer runs the {gate_name} gate ({evidence!r})"

--- a/tests/e2e/test_python_layer_e2e.py
+++ b/tests/e2e/test_python_layer_e2e.py
@@ -1,0 +1,154 @@
+"""Every gate the `python-core` layer ships, run for real on a freshly synced project.
+
+The dry-run tests in `tests/api/test_language_layer.py` prove the Python layer
+*names* these gates and expands them to the right commands. These prove the
+commands work: uv creates the venv and resolves a lock, pytest measures coverage
+into the path book.mk badges, interrogate reaches 100%, ty and mypy accept the
+code, and pre-commit's whole hook set passes on a project that was synced five
+seconds ago.
+
+That last one is the interesting case. A downstream project's first act after
+`/rhiza:update` is `make all`, so a hook that cannot pass on a fresh sync is a
+template bug that no amount of dry-run assertion would surface.
+
+Skips unless ``RHIZA_E2E=1`` and uv is on PATH. See `harness.py`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.e2e.harness import (
+    GATE_TIMEOUT_SECONDS,
+    PYTHON,
+    Project,
+    assemble,
+    assert_hooks_passed,
+    gate,
+    line_rate,
+)
+
+pytestmark = [pytest.mark.e2e, pytest.mark.timeout(GATE_TIMEOUT_SECONDS)]
+
+
+@pytest.fixture(scope="module")
+def project(root, tmp_path_factory, logger) -> Project:
+    """Sync core + python-core + book + tests, scaffold a project, and install it."""
+    return assemble(PYTHON, root, tmp_path_factory.mktemp("e2e-python"), logger)
+
+
+def test_install_creates_the_venv_and_resolves_a_lock(project: Project):
+    """`install` is Python's: a uv virtualenv plus a resolved dependency set.
+
+    The lock assertion matters beyond `install` itself — the uv-lock pre-commit
+    hook regenerates uv.lock and fails when it changes, so a project whose first
+    install left no lock behind cannot pass `fmt`.
+    """
+    assert (project.path / ".venv").is_dir(), "install did not create the project virtualenv"
+    assert (project.path / "uv.lock").is_file(), "install did not resolve a lock file"
+    assert "Installation complete" in project.install_output
+
+
+def test_install_wires_up_the_pre_commit_hook(project: Project):
+    """The layer installs git hooks, so a commit runs the same checks CI does."""
+    assert (project.path / ".git" / "hooks" / "pre-commit").is_file(), "install did not install pre-commit's git hook"
+
+
+def test_test_gate_runs_pytest_and_writes_the_reports_book_mk_reads(project: Project, logger):
+    """The scaffold's one test runs, and coverage lands where the docs badge looks.
+
+    Also the check that book.mk's no-op `test::` default has not swallowed the
+    real one: both rules are defined here (book is synced), so an accidental
+    single-colon rule in either file would make this fail rather than run nothing.
+    """
+    out = gate(project, "test", logger)
+    # `[1 item]` rather than "collected 1 item": test.mk runs pytest under xdist,
+    # which replaces the collection line with "N workers [1 item]".
+    assert "[1 item]" in out, f"pytest did not collect the scaffold's test:\n{out}"
+    assert "1 passed" in out, f"pytest did not report a passing test:\n{out}"
+
+    coverage_xml = project.path / "_tests" / "coverage.xml"
+    assert coverage_xml.is_file(), "`make test` did not write _tests/coverage.xml"
+    assert line_rate(coverage_xml) == pytest.approx(1.0), "the scaffold is meant to be fully covered"
+    assert (project.path / "_tests" / "html-coverage").is_dir()
+    assert (project.path / "_tests" / "html-report" / "report.html").is_file()
+
+
+def test_docs_coverage_gate_reaches_100_percent(project: Project, logger):
+    """Interrogate at `--fail-under 100`: every module, class and function documented."""
+    out = gate(project, "docs-coverage", logger)
+    assert "100.0%" in out, f"interrogate did not report full docstring coverage:\n{out}"
+
+
+def test_typecheck_gate_runs_both_checkers(project: Project, logger):
+    """TYPECHECKER defaults to both, so ty and mypy --strict each get a turn."""
+    out = gate(project, "typecheck", logger)
+    assert "Running ty type checking" in out
+    assert "Running mypy strict type checking" in out
+
+
+def test_security_gate_scans_the_source(project: Project, logger):
+    """Bandit runs over SOURCE_FOLDER with the shipped .bandit config."""
+    out = gate(project, "security", logger)
+    assert "Running bandit security scan" in out
+
+
+def test_license_gate_accepts_a_permissive_dependency_set(project: Project, logger):
+    """pip-licenses fails on GPL/LGPL/AGPL; the scaffold declares none."""
+    out = gate(project, "license", logger)
+    assert "Running license compliance scan" in out
+
+
+def test_deptry_gate_finds_no_dependency_problems(project: Project, logger):
+    """Deptry runs on the folders the synced bundles contribute, and is clean."""
+    out = gate(project, "deptry", logger)
+    assert "Running deptry on:" in out
+
+
+def test_rhiza_test_gate_runs_the_shipped_self_tests(project: Project, logger):
+    """The `.rhiza/tests` suite the tests bundle ships passes on a fresh sync.
+
+    This is the gate that judges the *scaffold* against rhiza's own expectations —
+    pyproject shape, README validity, doctests — which is exactly what a downstream
+    project gets judged on.
+    """
+    out = gate(project, "rhiza-test", logger)
+    assert "passed" in out, f"the shipped self-tests collected nothing:\n{out}"
+
+
+def test_fmt_gate_passes_every_pre_commit_hook(project: Project, logger):
+    """A freshly synced project is already clean under its own pre-commit config.
+
+    Includes the hooks that rewrite files (ruff-format, uv-lock, interrogate):
+    pre-commit fails a hook that modifies anything, so this asserts the shipped
+    configs and the scaffold agree byte for byte.
+
+    The per-hook assertions matter as much as the exit code — a config that stopped
+    declaring ruff would still exit 0, and this gate would look green while linting
+    nothing.
+    """
+    out = gate(project, "fmt", logger)
+    assert_hooks_passed(out, ("ruff", "ruff format", "markdownlint", "bandit", "uv-lock", "interrogate"))
+
+
+def test_all_runs_the_whole_gate_set(project: Project, logger):
+    """`make all` — the aggregate a developer and CI both call — is green.
+
+    Asserted on each gate's own output rather than on the exit code alone: `all` is
+    a prerequisite list, and a gate dropped from it leaves the aggregate passing
+    while quietly checking less. Last in the module because it re-runs everything.
+    """
+    out = gate(project, "all", logger)
+    # Each string must be unique to its gate. interrogate runs in both `fmt` (as a
+    # hook) and `docs-coverage` (as the gate), and both pytest runs print "N passed",
+    # so the evidence is a line only one of them emits.
+    for gate_name, evidence in (
+        ("fmt", "ruff format"),
+        ("deptry", "Running deptry on:"),
+        ("test", "[1 item]"),
+        ("docs-coverage", "Checking documentation coverage in:"),
+        ("security", "Running bandit security scan"),
+        ("license", "Running license compliance scan"),
+        ("typecheck", "Running mypy strict type checking"),
+    ):
+        assert evidence in out, f"`make all` no longer runs the {gate_name} gate ({evidence!r})"

--- a/tests/e2e/test_rust_layer_e2e.py
+++ b/tests/e2e/test_rust_layer_e2e.py
@@ -1,0 +1,175 @@
+"""Every gate the `rust-core` layer ships, run for real on a freshly synced crate.
+
+The Rust layer's whole claim is parity: the same target names as `python-core`,
+backed by cargo instead of uv. `tests/api/test_language_layer.py` checks the names
+and the commands they expand to from `make -n`; nothing there ever invokes cargo,
+so a flag cargo rejects, a component rustup never installed, or a report written
+to the wrong path would all pass it.
+
+These run the real thing — nextest, the doctests nextest skips, llvm-cov into the
+Cobertura path book.mk badges, clippy, cargo-deny, cargo-machete — against the
+smallest crate a correct layer should be green on.
+
+Skips unless ``RHIZA_E2E=1`` and cargo/rustup are on PATH. See `harness.py`.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+import pytest
+
+from tests.e2e.harness import (
+    GATE_TIMEOUT_SECONDS,
+    RUST,
+    Project,
+    assemble,
+    assert_hooks_passed,
+    gate,
+    line_rate,
+)
+
+pytestmark = [pytest.mark.e2e, pytest.mark.timeout(GATE_TIMEOUT_SECONDS)]
+
+# The cargo subcommands the gates call. `cargo-tools` installs them on demand;
+# a gate whose subcommand is missing fails with a bare "no such command".
+CARGO_TOOLS = ("cargo-nextest", "cargo-llvm-cov", "cargo-deny", "cargo-machete")
+
+
+@pytest.fixture(scope="module")
+def project(root, tmp_path_factory, logger) -> Project:
+    """Sync core + rust-core + book, scaffold a crate, and install it."""
+    return assemble(RUST, root, tmp_path_factory.mktemp("e2e-rust"), logger)
+
+
+def test_install_materialises_the_toolchain_and_a_lockfile(project: Project):
+    """`install` is rustup + cargo fetch, and fetch is what writes Cargo.lock.
+
+    The lockfile matters beyond the fetch: the cargo-lock-is-current pre-commit
+    hook runs `cargo metadata --locked`, which fails outright when no lock exists.
+    So a layer whose install skipped the fetch would pass `install` and fail `fmt`.
+    """
+    assert (project.path / "Cargo.lock").is_file(), "install did not fetch dependencies (no Cargo.lock)"
+    assert "Installation complete" in project.install_output
+
+
+def test_install_does_not_create_a_python_virtualenv(project: Project):
+    """`uv` stays a tool runner here: no `.venv`, because there is no Python project.
+
+    The dry-run test asserts `uv sync` is absent from the recipe; this asserts the
+    consequence, which is what would actually confuse a Rust developer.
+    """
+    assert not (project.path / ".venv").exists(), "the Rust layer created a Python virtualenv"
+
+
+def test_cargo_tools_provides_every_subcommand_the_gates_call(project: Project, logger):
+    """After `cargo-tools`, each gate's subcommand resolves on PATH."""
+    gate(project, "cargo-tools", logger)
+    missing = [tool for tool in CARGO_TOOLS if shutil.which(tool) is None]
+    assert not missing, f"`make cargo-tools` left {missing} uninstalled"
+
+
+def test_test_gate_runs_both_nextest_and_the_doctests(project: Project, logger):
+    """Nextest runs the unit tests; the separate `cargo test --doc` line runs the rest.
+
+    Asserted separately on purpose: nextest silently ignores doctests, so dropping
+    the second command would leave a green `make test` that never ran the crate's
+    documented examples. The scaffold has one of each so both halves have work.
+    """
+    out = gate(project, "test", logger)
+    assert "greets_the_caller_by_name" in out, f"nextest did not run the unit test:\n{out}"
+    assert "Running doctests" in out
+    assert "test result: ok" in out, f"the doctests did not run:\n{out}"
+
+
+def test_coverage_gate_writes_the_cobertura_report_book_mk_reads(project: Project, logger):
+    """llvm-cov must land at `_tests/coverage.xml`, the same path pytest-cov uses.
+
+    Requires the llvm-tools-preview component that rust-toolchain.toml pins, so
+    this also proves `install`'s `rustup show` actually materialised the components
+    rather than just the channel.
+    """
+    gate(project, "coverage", logger)
+    coverage_xml = project.path / "_tests" / "coverage.xml"
+    assert coverage_xml.is_file(), "`make coverage` did not write _tests/coverage.xml"
+    assert line_rate(coverage_xml) >= 0.9, "the scaffold fell below the coverage floor the gate enforces"
+    assert (project.path / "_tests" / "html-coverage").is_dir()
+
+
+def test_typecheck_gate_runs_clippy_with_warnings_as_errors(project: Project, logger):
+    """`rustc` already type-checks, so the analogous gate is a clean clippy pass."""
+    out = gate(project, "typecheck", logger)
+    assert "Running clippy" in out
+
+
+def test_docs_coverage_gate_builds_docs_with_missing_docs_denied(project: Project, logger):
+    """Rust's answer to interrogate: the doc build fails on any undocumented item."""
+    gate(project, "docs-coverage", logger)
+    assert (project.path / "target" / "doc").is_dir(), "cargo doc produced no documentation"
+
+
+def test_security_gate_checks_the_advisory_database(project: Project, logger):
+    """cargo-deny advisories — the pip-audit analogue. Needs the RustSec index."""
+    out = gate(project, "security", logger)
+    assert "Running cargo-deny advisories" in out
+
+
+def test_license_gate_enforces_the_allow_list(project: Project, logger):
+    """deny.toml is an allow-list, so the crate's own licence must be in it.
+
+    An unlicensed scaffold fails here on itself rather than on a dependency, which
+    is the Rust echo of the `--ignore` flag go-core needs for the same reason.
+    """
+    out = gate(project, "license", logger)
+    assert "Running license compliance scan" in out
+
+
+def test_deps_gate_reports_no_unused_dependencies(project: Project, logger):
+    """cargo-machete is the deptry analogue: declared but unused crates."""
+    out = gate(project, "deps", logger)
+    assert "Checking for unused dependencies" in out
+
+
+def test_rhiza_test_gate_skips_cleanly_without_a_tests_bundle(project: Project, logger):
+    """`rust-local` ships no `.rhiza/tests`, so the self-test gate must no-op.
+
+    `all` depends on `rhiza-test`, so a gate that failed on a missing directory
+    would make `make all` red on every Rust project.
+    """
+    out = gate(project, "rhiza-test", logger)
+    assert "No .rhiza/tests directory found" in out
+
+
+def test_fmt_gate_passes_every_pre_commit_hook(project: Project, logger):
+    """The Rust pre-commit config is clean on a fresh sync.
+
+    Covers the hooks unique to this layer — cargo fmt, clippy, and the Cargo.lock
+    currency check — plus the neutral half that runs through uvx whatever the
+    language, which on a Rust project has no `.python-version` to read.
+
+    Asserted per hook, not just on the exit code: the Rust hooks are `types: [rust]`,
+    so a config that stopped matching Rust files would report every one of them as
+    skipped and still exit 0.
+    """
+    out = gate(project, "fmt", logger)
+    assert_hooks_passed(out, ("cargo fmt", "cargo clippy", "Cargo.lock is up to date", "markdownlint"))
+
+
+def test_all_runs_the_whole_gate_set(project: Project, logger):
+    """`make all` is green, and still chains every gate.
+
+    Asserted on each gate's own output rather than the exit code alone: `all` is a
+    prerequisite list, and a gate dropped from it leaves the aggregate passing while
+    quietly checking less. Last, because it re-runs everything above.
+    """
+    out = gate(project, "all", logger)
+    for gate_name, evidence in (
+        ("fmt", "cargo fmt"),
+        ("test", "greets_the_caller_by_name"),
+        ("docs-coverage", "Building docs with missing_docs denied"),
+        ("security", "Running cargo-deny advisories"),
+        ("deps", "Checking for unused dependencies"),
+        ("license", "Running license compliance scan"),
+        ("typecheck", "Running clippy"),
+    ):
+        assert evidence in out, f"`make all` no longer runs the {gate_name} gate ({evidence!r})"

--- a/tests/util.py
+++ b/tests/util.py
@@ -27,14 +27,21 @@ def run_make(
     check: bool = True,
     dry_run: bool = True,
     env: dict[str, str] | None = None,
+    cwd: Path | None = None,
 ) -> subprocess.CompletedProcess:
-    """Run make with optional arguments and return the completed process."""
+    """Run make with optional arguments and return the completed process.
+
+    ``cwd`` defaults to the process working directory, which is what the tests
+    that chdir into a temp project rely on. The end-to-end suite passes it
+    explicitly instead: its projects are built per module and outlive a single
+    test, so chdir-ing would make the tests order- and worker-dependent.
+    """
     cmd = [_MAKE]
     if args:
         cmd.extend(args)
     cmd.insert(1, "-sn" if dry_run else "-s")
-    logger.info("Running command: %s", " ".join(cmd))
-    result = subprocess.run(cmd, capture_output=True, text=True, env=env)  # nosec B603
+    logger.info("Running command: %s (cwd=%s)", " ".join(cmd), cwd or Path.cwd())
+    result = subprocess.run(cmd, capture_output=True, text=True, env=env, cwd=cwd)  # nosec B603
     if check and result.returncode != 0:
         msg = f"make failed with code {result.returncode}:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
         raise AssertionError(msg)

--- a/tests/utils/test_make_structure.py
+++ b/tests/utils/test_make_structure.py
@@ -14,12 +14,19 @@ import re
 from collections import defaultdict
 from pathlib import Path
 
+from tests.util import run_make
+
 # A target definition line: one or more target names, then `:` or `::`, at the
 # start of a line (recipe lines start with a tab). `(?!=)` keeps `VAR := x`
 # assignments out. Names containing `$(` (computed targets) are skipped later.
 _TARGET_LINE = re.compile(r"^(?P<names>[^\t#:=][^:=]*?)\s*(?P<colon>::?)(?!=)")
 
 _SECTION_HEADER = re.compile(r"^##@\s*(?P<title>.+?)\s*$")
+
+# A target that documents itself with a trailing `##` comment, i.e. one that is meant
+# to appear in `make help`. `%` is excluded so the `print-%` pattern rule is skipped:
+# it has a `##` comment but no fixed name to look for in the output.
+_DOCUMENTED_TARGET = re.compile(r"^(?P<name>[A-Za-z0-9_-]+)\s*::?(?!=)[^#\n]*##")
 
 _PHONY_LINE = re.compile(r"^\.PHONY:\s*(?P<names>.+)$")
 
@@ -165,6 +172,29 @@ def test_parser_sees_known_targets(root):
     expected = {"install", "clean", "doctor", "explain-bundles"}
     missing = expected - all_targets
     assert not missing, f"parser failed to find known single-colon targets: {missing}"
+
+
+def test_every_documented_target_appears_in_help(root, logger):
+    """A target carrying a `##` comment must show up in `make help`.
+
+    The help text is produced by an awk pattern in rhiza.mk, and a target whose name
+    that pattern does not match is *silently* absent — the `##` comment is written,
+    reviewed, and never displayed. `e2e` was exactly that: the pattern accepted only
+    `[a-zA-Z_-]`, so any digit in a target name made it invisible, while every other
+    target regex in this repo (and in the rhiza-hooks Makefile checks) allows digits.
+    """
+    documented: set[str] = set()
+    for source in [root / "Makefile", root / ".rhiza" / "rhiza.mk", *_make_fragments(root)]:
+        for line in source.read_text(encoding="utf-8").splitlines():
+            match = _DOCUMENTED_TARGET.match(line)
+            if match:
+                documented.add(match.group("name"))
+
+    assert "e2e" in documented, "expected to find the digit-bearing target this test was written for"
+
+    out = run_make(logger, ["help"], dry_run=False, cwd=root).stdout
+    missing = sorted(name for name in documented if name not in out)
+    assert not missing, f"targets documented with `##` but absent from `make help`: {missing}"
 
 
 def _colon_styles(path: Path) -> dict[str, str]:


### PR DESCRIPTION
## Summary

The language layers are currently verified only from `make -n` output
(`tests/api/test_language_layer.py`). That catches a renamed target or a gate
dropped from `all`, but it never invokes cargo, go or uv — so a recipe whose
flags are wrong passes it happily. go-core's licence gate is the recorded
example: it needs `--ignore $(go list -m)` because go-licenses otherwise fails a
freshly synced project *for having no LICENSE of its own*, and that could only be
found by running the gate on a real project.

This adds `tests/e2e/`, which does exactly that for all three layers.

## Changes

- **`tests/e2e/harness.py`** — copies a layer's bundles into a temp directory
  (standing in for a `rhiza-cli` sync), writes the scaffold, commits it, runs
  `make install`. Opt-in via `RHIZA_E2E=1`; skips per layer when its compiler is
  absent.
- **`tests/e2e/scaffolds.py`** — the smallest project each layer should be green
  on: documented to the last public item, fully covered by one test,
  formatter-clean as written, licensed. Anything a gate flags is a real signal.
- **`tests/e2e/test_{python,rust,go}_layer_e2e.py`** — 11 / 13 / 13 tests, one
  per gate plus `make all`: `install`, `test`, `coverage`, `typecheck`,
  `docs-coverage`, `security`, `license`, `deps`, `fmt`, `all`. (Python has no
  separate `coverage` target — pytest-cov runs inside `test`, so
  `_tests/coverage.xml` is asserted there.)
- **`make e2e`** (mother-repo-only, `bundles.mk`) — narrowable with
  `E2E_ARGS=tests/e2e/test_go_layer_e2e.py`, which is how each CI job picks its
  layer.
- **`.github/workflows/rhiza_e2e.yml`** — one job per layer, each installing only
  its own toolchain, plus an `e2e-gate` roll-up. Separate from `rhiza_ci.yml`
  because it needs three toolchains CI does not otherwise want and costs minutes
  per layer against CI's ≤20 min test budget.
- **`make help` fix** — the awk pattern in `rhiza.mk` accepted only
  `[a-zA-Z_-]`, so any target with a digit in its name was documented, reviewed
  and *invisible*. `e2e` was the first one to notice. Fixed in the `core` bundle
  with `test_every_documented_target_appears_in_help` to keep it fixed (confirmed
  failing on the old regex).
- **`run_make(cwd=...)`** — the e2e projects outlive a single test, so chdir-ing
  would make the suite order- and worker-dependent.

## Why opt-in and toolchain-gated

`make test` stays fast and green offline, and the OS × Python matrix does not pay
for a multi-minute suite on every leg. A layer whose compiler is missing skips
with a reason rather than failing. The corollary matters: **a green local run
proves nothing on its own** — `rhiza_e2e.yml` is the only place all three
actually execute.

## Testing

- [x] `make test` passes locally — 1374 passed, 38 skipped
- [x] `make fmt` has been run
- [x] New tests added
- [x] `make deptry` passes

End-to-end results:

| Layer | Result | Where |
| --- | --- | --- |
| Python | 11/11 | host |
| Rust | 13/13 | `rust:1-trixie` container via `make e2e` |
| Go | 13/13 | `golang:1-bookworm` container via `make e2e` |

Neither cargo nor go exists on the dev host, hence the containers. **The workflow
itself has not run on GitHub yet** — this PR is its first execution. It passes
actionlint, `check-github-workflows`, and the repo's pinning/concurrency hygiene
tests.

`misspell` (locale US) rejecting the Go scaffold's "behaviour" was found this
way: the fixture was wrong rather than the gate, but only running it says so.

## Notes for review — three things deliberately left alone

1. `rust.mk`'s `cargo-tools` builds `cargo-binstall` from source whenever it is
   absent, *before* checking whether any tool is actually missing — minutes of CI
   for nothing. Worked around by pre-installing binstall via
   `taiki-e/install-action` rather than changing the layer.
2. On a fresh clone with no prior `make install`, `make all` runs `fmt` first; the
   `uv-lock` hook generates `uv.lock` and then fails as "files were modified by
   this hook". Not covered here, because the fixture installs first (the
   documented flow); covering it needs a second project per language.
3. The Python bundle set is the `local` profile **minus marimo**: that bundle
   ships `marimo.mk` but no notebooks, and it appends `$(MARIMO_FOLDER)` to
   `DEPTRY_FOLDERS`, so `make deptry` would be pointed at a folder no sync
   creates. Reason recorded in `harness.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)