### PR TITLE
chore: bump rhiza-hooks to v1.0.0 and enable check-license-metadata

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,7 +99,7 @@ repos:
         files: ^src/
 
   - repo: https://github.com/Jebel-Quant/rhiza-hooks
-    rev: v0.7.1  # Use the latest release
+    rev: v1.0.0  # Use the latest release
     hooks:
       # Migrated from rhiza
       - id: check-rhiza-workflow-names
@@ -108,9 +108,14 @@ repos:
       - id: check-rhiza-config
       - id: check-makefile-targets
       - id: check-python-version-consistency
+      # Rejects a PEP 639 `license` expression declared alongside a `License ::` trove
+      # classifier — setuptools/hatch treat that pairing as an error, so it is worth
+      # catching at commit time rather than at build time.
+      - id: check-license-metadata
       # check-bumpversion-config asserts that bump-my-version can actually discover
-      # this repo's version config (issue #1453). Enable it once rhiza-hooks ships a
-      # release containing it — v0.7.1 does not. Until then .rhiza/tests/test_pyproject.py
-      # enforces the same invariant, one gate later.
+      # this repo's version config (issue #1453). The pinned v1.0.0 ships it, so the pin
+      # no longer blocks it — enabling it is now just a decision to move the gate
+      # earlier. Until then .rhiza/tests/test_pyproject.py enforces the same invariant,
+      # one gate later.
       # - id: check-bumpversion-config
       # - id: check-template-bundles

--- a/bundles/go-core/.pre-commit-config.yaml
+++ b/bundles/go-core/.pre-commit-config.yaml
@@ -89,7 +89,7 @@ repos:
       - id: betterleaks
 
   - repo: https://github.com/Jebel-Quant/rhiza-hooks
-    rev: v0.7.1  # Use the latest release
+    rev: v1.0.0  # Use the latest release
     hooks:
       - id: check-rhiza-workflow-names
       - id: update-readme-help

--- a/bundles/python-core/.pre-commit-config.yaml
+++ b/bundles/python-core/.pre-commit-config.yaml
@@ -88,7 +88,7 @@ repos:
         files: ^src/
 
   - repo: https://github.com/Jebel-Quant/rhiza-hooks
-    rev: v0.7.1  # Use the latest release
+    rev: v1.0.0  # Use the latest release
     hooks:
       # Migrated from rhiza
       - id: check-rhiza-workflow-names
@@ -97,9 +97,14 @@ repos:
       - id: check-rhiza-config
       - id: check-makefile-targets
       - id: check-python-version-consistency
+      # Rejects a PEP 639 `license` expression declared alongside a `License ::` trove
+      # classifier — setuptools/hatch treat that pairing as an error, so it is worth
+      # catching at commit time rather than at build time.
+      - id: check-license-metadata
       # check-bumpversion-config asserts that bump-my-version can actually discover
-      # this repo's version config (issue #1453). Enable it once rhiza-hooks ships a
-      # release containing it — v0.7.1 does not. Until then .rhiza/tests/test_pyproject.py
-      # enforces the same invariant, one gate later.
+      # this repo's version config (issue #1453). The pinned v1.0.0 ships it, so the pin
+      # no longer blocks it — enabling it is now just a decision to move the gate
+      # earlier. Until then .rhiza/tests/test_pyproject.py enforces the same invariant,
+      # one gate later.
       # - id: check-bumpversion-config
       # - id: check-template-bundles

--- a/bundles/rust-core/.pre-commit-config.yaml
+++ b/bundles/rust-core/.pre-commit-config.yaml
@@ -83,7 +83,7 @@ repos:
       - id: betterleaks
 
   - repo: https://github.com/Jebel-Quant/rhiza-hooks
-    rev: v0.7.1  # Use the latest release
+    rev: v1.0.0  # Use the latest release
     hooks:
       - id: check-rhiza-workflow-names
       - id: update-readme-help


### PR DESCRIPTION
Moves the `rhiza-hooks` pin from `v0.7.1` to `v1.0.0` in the root config and all three core bundles, following the [v1.0.0 release](https://github.com/Jebel-Quant/rhiza-hooks/releases/tag/v1.0.0).

## Changes

| File | Change |
|---|---|
| `.pre-commit-config.yaml` | rev → `v1.0.0`; enable `check-license-metadata`; correct a stale comment |
| `bundles/python-core/.pre-commit-config.yaml` | same three changes |
| `bundles/rust-core/.pre-commit-config.yaml` | rev bump only |
| `bundles/go-core/.pre-commit-config.yaml` | rev bump only |

### `check-license-metadata`

Rejects a PEP 639 `license` expression declared alongside a `License ::` trove classifier — a pairing setuptools/hatch treat as an error — so this catches at commit time what would otherwise surface at build time.

It is enabled only in the two Python configs, where its `files: ^pyproject\.toml$` pattern can match. The rust-core and go-core bundles take the rev bump alone, matching how they already omit `check-python-version-consistency` for the analogous reason.

### Stale comment

The `check-bumpversion-config` comment read *"Enable it once rhiza-hooks ships a release containing it — v0.7.1 does not."* This bump falsifies that premise, so the comment now says the pinned `v1.0.0` ships it. **That hook stays commented out** — enabling it is a separate decision, since it would move the gate earlier for every downstream repo.

## Verification

Run against this repo at the new pin, which resolved `v1.0.0` to `51c0f17`:

- `check-license-metadata` — **passes** (via `pre-commit run`, not just the console script)
- `check-rhiza-workflow-names`, `check-makefile-targets`, `check-python-version-consistency` — **pass**
- `update-readme-help`, `check-rhiza-config` — "no files to check" (no root `Makefile` match; no `.rhiza/template.yml`, this repo being the template)

No hook modified a file.

## Not included

`v1.0.0` ships 12 hooks; these remain unadopted and are each a new gate for every downstream repo: `check-bumpversion-config`, `check-template-bundles`, `check-managed-files`, `check-workflow-make-targets`, and `check-rust-version-consistency` / `check-go-version-consistency` for their respective bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)