### PR TITLE
fix(go-core): ship a test so a fresh Go repo's test gate is not vacuous

### DIFF
--- a/.rhiza/template-bundles.yml
+++ b/.rhiza/template-bundles.yml
@@ -117,10 +117,18 @@ bundles:
       The Go sibling of `python-core` and `rust-core`. Ships `.golangci.yml`,
       `revive.toml`, a Go pre-commit config, a root `.bumpversion.toml` (see
       `rust-core` for why it is not in `.rhiza/`), a starter
-      `internal/version/version.go`, and `.rhiza/make.d/go.mk`.
+      `internal/version/version.go` with its `version_test.go`, and
+      `.rhiza/make.d/go.mk`.
 
       Like Rust it carries its own test targets: `go test` and `go tool cover`
-      need no configuration files, so a `go-tests` bundle would own nothing.
+      need no configuration files, so a `go-tests` bundle would own nothing but
+      the gates.
+
+      The shipped test is what keeps those gates honest. `go test ./...` prints
+      "[no test files]" for a package without one and exits 0, so a fresh Go repo
+      passed `make test` while running nothing. Rust is spared because
+      `cargo init --lib` leaves an `it_works` test behind; `go mod init` writes no
+      Go file at all, so the layer brings the first test itself.
 
       `install` is only `go mod download` — go.mod's `go`/`toolchain` directives
       make the go command fetch a matching compiler itself, so there is no rustup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,8 +64,9 @@ The core abstraction is the **bundle** — a named group of configuration files.
   `.rhiza/make.d/rust.mk`. Carries its own test targets, unlike Python — see
   **Language layers**.
 - `go-core` (the Go **language layer**): `.golangci.yml`, `revive.toml`, a Go
-  pre-commit config, `.bumpversion.toml`, a starter `internal/version/version.go`,
-  and `.rhiza/make.d/go.mk`. Carries its own test targets, like Rust.
+  pre-commit config, `.bumpversion.toml`, a starter `internal/version/version.go`
+  with its `version_test.go`, and `.rhiza/make.d/go.mk`. Carries its own test
+  targets, like Rust.
 - `tests`: pytest, coverage, type checking (Python; requires `python-core`)
 - `benchmarks`: pytest-benchmark infrastructure and reporting
 - `github`: GitHub repository configuration (actions, dependabot, core workflows)
@@ -158,14 +159,27 @@ and tags itself so the changelog lands in the bump commit.
 The Rust and Go layers also carry `test`/`coverage`/`typecheck`, which on the Python side
 live in the separate `tests` bundle. That is not an inconsistency: pytest, coverage
 and mypy each need configuration files worth bundling, while `cargo nextest` and
-`go test` need none, so a `rust-tests` or `go-tests` bundle would own no files.
+`go test` need no configuration at all — so a `rust-tests` or `go-tests` bundle would
+own nothing but the gates themselves.
 
 **Where Go differs from both.** A Go module has no manifest: its version *is* the git
 tag, so unlike `pyproject.toml` and `Cargo.toml` there is no file in the tree for
 bump-my-version to write to. `go-core` therefore ships a starter
 `internal/version/version.go` holding a `Version` constant and anchors the release
 config to it, which keeps the release commit and its tag in step. Delete that file and
-the `/rhiza:release` flow has no version location to write to. Its `install` is also the thinnest of the
+the `/rhiza:release` flow has no version location to write to.
+
+It ships that file's `version_test.go` too, and that one is about the test gate rather
+than the release. `go test ./...` prints `[no test files]` for a package without one and
+exits 0, so a freshly synced Go repo passed `make test` — and therefore `make all` —
+while running nothing at all. Rust never had the hole: `cargo init --lib` leaves an
+`it_works` test behind and the skeleton step preserves it. `go mod init` writes no Go
+file whatsoever, so the layer has to bring the first test itself. What it asserts is the
+release invariant next door — that `Version` matches the shape `.bumpversion.toml`
+parses — never the literal shipped `0.0.0`, which bump-my-version rewrites in
+`version.go` and not in the test.
+
+Its `install` is also the thinnest of the
 three — go.mod's `go`/`toolchain` directives make the go command fetch a matching
 compiler on demand, so there is no rustup step to mirror.
 

--- a/bundles/go-core/internal/version/version_test.go
+++ b/bundles/go-core/internal/version/version_test.go
@@ -1,0 +1,38 @@
+package version
+
+import (
+	"regexp"
+	"testing"
+)
+
+// WHY THIS FILE EXISTS. Two reasons, and the second is the one that is easy to lose.
+//
+// It checks a real invariant. `.bumpversion.toml` parses the constant next door with
+// this same shape and sets `ignore_missing_version = false`, so a hand-edited
+// `const Version = "1.2"` does not fail a gate — it fails the *release*, at the one
+// moment nobody wants to debug a regex. Cheaper to catch here.
+//
+// And it is the only test a freshly synced Go project has. `go test ./...` reports
+// "[no test files]" for a package without one and still exits 0, so a new go-local
+// repo used to pass `make test` — and therefore `make all` — while running nothing
+// at all. Rust never had that problem: `cargo init --lib` leaves an `it_works` test
+// behind. `go mod init` creates no Go file whatsoever, so the layer has to bring one.
+//
+// Replacing it is fine once the project has tests of its own. Deleting it and
+// shipping nothing else puts the vacuum back.
+
+// semver is the version shape `.bumpversion.toml` can parse: MAJOR.MINOR.PATCH with
+// an optional SemVer pre-release. Kept in step with the `parse` key there, not with
+// SemVer at large — the release config is what this guards.
+var semver = regexp.MustCompile(`^\d+\.\d+\.\d+(?:-[a-z]+\.\d+)?$`)
+
+func TestVersionIsShapedTheWayTheReleaseFlowExpects(t *testing.T) {
+	t.Parallel()
+
+	// Deliberately not compared against a literal: bump-my-version rewrites
+	// version.go and nothing else, so asserting the shipped "0.0.0" would turn this
+	// red on the project's first release.
+	if !semver.MatchString(Version) {
+		t.Fatalf("Version = %q, want MAJOR.MINOR.PATCH with an optional -pre.N suffix", Version)
+	}
+}

--- a/docs/reference/BUNDLE_TAXONOMY.md
+++ b/docs/reference/BUNDLE_TAXONOMY.md
@@ -30,7 +30,7 @@ the source of truth for the exact set. See
 | `core` | Required base, and language-neutral: thin Makefile, `.rhiza/` modular make system, help/logo machinery, and uv/uvx as a tool runner. Not a working repo on its own. |
 | `python-core` | The Python language layer: virtualenv and `uv sync` (`install`), `.python-version`, `ruff.toml`, `.bandit`, pre-commit config, `deptry` and licence scans, and the `all` aggregate. Exactly one language layer per repo. |
 | `rust-core` | The Rust language layer: rustup and `cargo fetch` (`install`), `rust-toolchain.toml`, `rustfmt.toml`, `clippy.toml`, `deny.toml`, pre-commit config, and the test/coverage/lint gates. Carries its own test targets — in Rust they are cargo subcommands with nothing to configure. |
-| `go-core` | The Go language layer: `go mod download` (`install`), `.golangci.yml`, `revive.toml`, pre-commit config, a `version.Version` constant for the release flow, and the test/coverage/lint gates. Carries its own test targets — `go test` and `go tool cover` need no configuration. |
+| `go-core` | The Go language layer: `go mod download` (`install`), `.golangci.yml`, `revive.toml`, pre-commit config, a `version.Version` constant for the release flow (with the one test file that keeps `make test` from passing vacuously), and the test/coverage/lint gates. Carries its own test targets — `go test` and `go tool cover` need no configuration. |
 | `tests` | Local testing: pytest, coverage, and type checking. |
 | `benchmarks` | Performance benchmarking with `pytest-benchmark` and reporting (builds on `tests`). |
 | `book` | Documentation site with MkDocs + zensical. |

--- a/tests/bundles/test_bundle_sync.py
+++ b/tests/bundles/test_bundle_sync.py
@@ -445,6 +445,31 @@ class TestGoCoreBundleSync:
         assert source.startswith("// Package version"), "the package doc comment the docs-coverage gate requires"
         assert 'const Version = "0.0.0"' in source
 
+    def test_the_layer_ships_a_test_so_the_test_gate_is_not_vacuous(self):
+        """`go test ./...` exits 0 on a package with no test file, printing "[no test files]".
+
+        So a freshly synced Go project passed `make test` — and `make all` — while
+        running nothing at all. Rust never had this hole: `cargo init --lib` leaves an
+        `it_works` test behind, while `go mod init` writes no Go file whatsoever, so
+        the layer has to bring the first test itself.
+        """
+        version_test = self.project / "internal" / "version" / "version_test.go"
+        assert version_test.is_file(), (
+            "go-core must ship internal/version/version_test.go — without a single test "
+            "file a fresh Go repo's `make test` is green without testing anything"
+        )
+        source = version_test.read_text(encoding="utf-8")
+        assert "func Test" in source, "the file ships no test function, so it does not close the vacuum"
+
+        # Comments are stripped before the literal check: the file explains in prose why
+        # it does not compare against "0.0.0", and matching that would fail the test for
+        # documenting the very trap it avoids.
+        code = "\n".join(line for line in source.splitlines() if not line.lstrip().startswith("//"))
+        assert '"0.0.0"' not in code, (
+            "the test must not compare against the literal shipped version: bump-my-version "
+            "rewrites version.go and not this file, so a literal turns red on the first release"
+        )
+
     def test_no_symlinks_in_synced_project(self):
         """Synced files are real files, as a downstream project would receive them."""
         for path in self.project.rglob("*"):

--- a/tests/e2e/test_go_layer_e2e.py
+++ b/tests/e2e/test_go_layer_e2e.py
@@ -84,6 +84,21 @@ def test_test_gate_runs_the_suite_under_the_race_detector(project: Project, logg
     assert "example.com/demo/greeting" in out, f"go test did not run the scaffold's package:\n{out}"
 
 
+def test_the_layer_brings_its_own_test_so_a_fresh_repo_tests_something(project: Project, logger):
+    """The bundle's `internal/version` package runs a test, not "[no test files]".
+
+    This is the gate's vacuity check, and it has to run for real: `go test ./...`
+    exits 0 on a package with no test file, so the scaffold's own `greeting_test.go`
+    would mask a go-core that shipped none. Asserting on the bundle's package
+    instead is what fails if `version_test.go` is dropped from the layer.
+    """
+    out = gate(project, "test", logger)
+    assert "example.com/demo/internal/version" in out, (
+        f"go-core's own package reported no test run — a fresh Go repo's `make test` "
+        f"passes without testing anything:\n{out}"
+    )
+
+
 def test_coverage_gate_converts_the_profile_and_enforces_the_floor(project: Project, logger):
     """Go emits a profile; the gate converts it to the Cobertura path book.mk reads.
 


### PR DESCRIPTION
The Go scaffold ships no test file. `go test ./...` prints `[no test files]` for a package without one and exits 0, so a freshly synced `go-local` repo passed `make test` — and therefore `make all` — while testing nothing at all.

Rust never had this hole: `cargo init --lib` leaves an `it_works` test behind, and the skeleton step preserves it while adding the `//!` crate doc. `go mod init` writes no Go file whatsoever, so the layer has to bring the first test itself. Whether it should is a template decision, not a plugin one, which is why the fix lands here rather than in `init_skeleton.py`.

## What it asserts

`bundles/go-core/internal/version/version_test.go` checks the invariant next door rather than being a placeholder. `.bumpversion.toml` parses the `Version` constant as `MAJOR.MINOR.PATCH` with an optional SemVer pre-release and sets `ignore_missing_version = false`, so a hand-edited `const Version = "1.2"` does not fail a gate — it fails the *release*, at the one moment nobody wants to debug a regex.

It deliberately does **not** compare against the shipped `0.0.0`: only `internal/version/version.go` is in `[[tool.bumpversion.files]]`, so bump-my-version rewrites the constant and not the test, and a literal would turn red on the project’s first release. A sync test pins that, stripping comments first so the file may explain the trap it avoids.

## Notes

- **Coverage is unaffected.** The package is const-only, i.e. zero coverable statements, so the 90% floor and its e2e assertion do not move.
- **The e2e assertion keys on the bundle’s own package** (`example.com/demo/internal/version`), not the scaffold’s `greeting`. The scaffold ships its own test, so asserting on that would let a go-core with no test file pass.
- **A real synced repo still prints one `[no test files]`** — for the root `doc.go` package the plugin’s `_finish_go` writes. The layer’s own package is no longer vacuous; that root package is a separate, plugin-side decision.

## Verification

- `make test` — 1394 passed
- `make fmt` — all hooks green
- `make e2e E2E_ARGS=tests/e2e/test_go_layer_e2e.py` — **14/14 passed** against real toolchains

That last one matters: the mother repo has no Go toolchain, so gofmt, `go vet`, golangci-lint and revive reach this file only under `RHIZA_E2E=1`. Default CI cannot catch a syntax, formatting or (given `misspell` `locale: US`) spelling error in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)