### PR TITLE
fix(rust-core): stop cargo-tools assuming the cargo bin dir is on PATH

### DIFF
--- a/bundles/rust-core/.rhiza/make.d/rust.mk
+++ b/bundles/rust-core/.rhiza/make.d/rust.mk
@@ -29,6 +29,16 @@ COVERAGE_FAIL_UNDER ?= 90
 # turns a multi-minute `cargo install` into seconds on CI.
 CARGO_TOOLS ?= cargo-nextest cargo-llvm-cov cargo-deny cargo-machete
 
+# Where `cargo install` puts a subcommand's binary — and it is *not* necessarily on
+# PATH. `brew install rustup` (which install's error above suggests) leaves the
+# shims in Homebrew's bin and never links ~/.cargo/bin, and `cargo install` only
+# warns about that rather than failing. Cargo resolves `cargo <sub>` by searching
+# this directory as well as PATH, so every gate below is fine either way; what is
+# not fine is `command -v cargo-nextest` or a bare `cargo-binstall`, which see only
+# PATH. So `cargo-tools` probes both, and invokes binstall as a cargo subcommand.
+# Honours the two variables cargo itself reads, in the order cargo reads them.
+CARGO_BIN_DIR ?= $(if $(CARGO_INSTALL_ROOT),$(CARGO_INSTALL_ROOT),$(if $(CARGO_HOME),$(CARGO_HOME),$(HOME)/.cargo))/bin
+
 ##@ Rust
 install: pre-install ## install the toolchain and fetch dependencies
 	@if ! command -v $(RUSTUP) >/dev/null 2>&1; then \
@@ -70,17 +80,17 @@ install: pre-install ## install the toolchain and fetch dependencies
 	@printf "\n${GREEN}[SUCCESS] Installation complete!${RESET}\n\n"
 
 cargo-tools: ## install the cargo subcommands the gates need (idempotent)
-	@if ! command -v cargo-binstall >/dev/null 2>&1; then \
+	@if ! command -v cargo-binstall >/dev/null 2>&1 && [ ! -x "$(CARGO_BIN_DIR)/cargo-binstall" ]; then \
 	  printf "${BLUE}[INFO] Installing cargo-binstall${RESET}\n"; \
 	  $(CARGO) install cargo-binstall --locked || { printf "${RED}[ERROR] Failed to install cargo-binstall${RESET}\n"; exit 1; }; \
 	fi
 	@missing=""; \
 	for tool in $(CARGO_TOOLS); do \
-	  command -v $$tool >/dev/null 2>&1 || missing="$$missing $$tool"; \
+	  command -v $$tool >/dev/null 2>&1 || [ -x "$(CARGO_BIN_DIR)/$$tool" ] || missing="$$missing $$tool"; \
 	done; \
 	if [ -n "$$missing" ]; then \
 	  printf "${BLUE}[INFO] Installing:${RESET}$$missing\n"; \
-	  cargo-binstall --no-confirm --locked $$missing || { printf "${RED}[ERROR] Failed to install cargo tools${RESET}\n"; exit 1; }; \
+	  $(CARGO) binstall --no-confirm --locked $$missing || { printf "${RED}[ERROR] Failed to install cargo tools${RESET}\n"; exit 1; }; \
 	else \
 	  printf "${BLUE}[INFO] All cargo tools already installed${RESET}\n"; \
 	fi

--- a/tests/api/test_language_layer.py
+++ b/tests/api/test_language_layer.py
@@ -128,6 +128,25 @@ class TestRustLayerKeepsTheSameContract:
         for tool in ("cargo-nextest", "cargo-llvm-cov", "cargo-deny", "cargo-machete"):
             assert tool in out, f"`cargo-tools` does not install {tool}, which a gate below calls"
 
+    def test_cargo_tools_never_assumes_the_cargo_bin_dir_is_on_path(self, logger):
+        """`cargo install` writes to $(CARGO_BIN_DIR), which PATH need not contain.
+
+        `brew install rustup` — the install target's own suggestion — puts the shims in
+        Homebrew's bin and leaves ~/.cargo/bin unlinked; `cargo install` warns and
+        carries on. So the recipe may not reach a freshly installed tool by name: it has
+        to go through cargo, which searches its own bin directory too. Both halves are
+        asserted because either one alone still breaks — a `command -v` probe that misses
+        the directory reinstalls the whole tool list on every gate.
+        """
+        out = strip_ansi(run_make(logger, ["cargo-tools"], check=False).stdout)
+        assert "cargo binstall --no-confirm" in out, "binstall must be invoked as a cargo subcommand"
+        assert not re.search(r"(?<![\w./-])cargo-binstall --no-confirm", out), (
+            "a bare `cargo-binstall` resolves only through PATH: 'command not found' wherever "
+            "cargo's bin dir is unlinked"
+        )
+        assert re.search(r'-x "\S*/bin/cargo-binstall"', out), "the binstall probe must also look in the cargo bin dir"
+        assert re.search(r'-x "\S*/bin/\$tool"', out), "the per-tool probe must also look in the cargo bin dir"
+
     def test_all_chains_the_rust_gates(self, logger):
         """The mirror of `test_all_chains_the_python_gates` — a dropped gate shows up here.
 

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -260,7 +260,7 @@ def _report(layer: Layer, target: str, proc: subprocess.CompletedProcess) -> str
     )
 
 
-def gate(project: Project, target: str, logger) -> str:
+def gate(project: Project, target: str, logger, env: dict[str, str] | None = None) -> str:
     """Run one gate for real and fail the test with its output if it is red.
 
     Both streams are returned joined, because which one a gate writes to is not a
@@ -273,11 +273,14 @@ def gate(project: Project, target: str, logger) -> str:
         project: The assembled project.
         target: The make target to run.
         logger: Test logger.
+        env: Environment for the run, defaulting to `gate_env()`. Passed by tests
+            that need a gate to face a different machine than the one running them —
+            a PATH without the cargo bin directory, say.
 
     Returns:
         The gate's combined output, ANSI-stripped, for tests that assert on what ran.
     """
-    proc = run_make(logger, [target], check=False, dry_run=False, env=gate_env(), cwd=project.path)
+    proc = run_make(logger, [target], check=False, dry_run=False, env=env or gate_env(), cwd=project.path)
     if proc.returncode != 0:
         pytest.fail(_report(project.layer, target, proc))
     return strip_ansi(proc.stdout) + strip_ansi(proc.stderr)

--- a/tests/e2e/test_rust_layer_e2e.py
+++ b/tests/e2e/test_rust_layer_e2e.py
@@ -15,7 +15,10 @@ Skips unless ``RHIZA_E2E=1`` and cargo/rustup are on PATH. See `harness.py`.
 
 from __future__ import annotations
 
+import os
 import shutil
+import subprocess  # nosec B404 - resolves cargo subcommands the way the gates do
+from pathlib import Path
 
 import pytest
 
@@ -26,6 +29,7 @@ from tests.e2e.harness import (
     assemble,
     assert_hooks_passed,
     gate,
+    gate_env,
     line_rate,
 )
 
@@ -35,11 +39,65 @@ pytestmark = [pytest.mark.e2e, pytest.mark.timeout(GATE_TIMEOUT_SECONDS)]
 # a gate whose subcommand is missing fails with a bare "no such command".
 CARGO_TOOLS = ("cargo-nextest", "cargo-llvm-cov", "cargo-deny", "cargo-machete")
 
+# Where `cargo install` puts them, mirroring rust.mk's CARGO_BIN_DIR.
+CARGO_BIN_DIR = (
+    Path(os.environ.get("CARGO_INSTALL_ROOT") or os.environ.get("CARGO_HOME") or Path.home() / ".cargo") / "bin"
+)
+
 
 @pytest.fixture(scope="module")
 def project(root, tmp_path_factory, logger) -> Project:
     """Sync core + rust-core + book, scaffold a crate, and install it."""
     return assemble(RUST, root, tmp_path_factory.mktemp("e2e-rust"), logger)
+
+
+def resolves_as_a_cargo_subcommand(tool: str, env: dict[str, str]) -> bool:
+    """Report whether `cargo <sub>` finds `tool`, which is how every gate calls it.
+
+    Not `shutil.which`: cargo resolves a subcommand from `$CARGO_HOME/bin` as well as
+    from PATH, so a tool can be perfectly usable by the gates and invisible to a
+    PATH lookup. Asking cargo is the only check that matches what the gates do.
+
+    Args:
+        tool: The binary name, e.g. `cargo-nextest`.
+        env: Environment for the probe.
+
+    Returns:
+        True when the subcommand runs.
+    """
+    cargo = shutil.which("cargo", path=env.get("PATH")) or "cargo"
+    proc = subprocess.run(  # nosec B603
+        [cargo, tool.removeprefix("cargo-"), "--version"], env=env, capture_output=True, text=True
+    )
+    return proc.returncode == 0
+
+
+def env_without_the_cargo_bin_dir(tmp_path: Path) -> dict[str, str]:
+    """Return a gate environment reproducing a machine whose cargo bin dir is unlinked.
+
+    `brew install rustup` — the layer's own suggestion when rustup is missing — puts
+    the shims in Homebrew's bin and never links ~/.cargo/bin. Dropping that directory
+    from PATH is only half of it: on a rustup-managed runner `cargo` itself lives
+    there, and removing it would test nothing but a missing compiler. So the cargo and
+    rustup binaries are re-exposed through a shim directory, which is exactly the
+    Homebrew layout — cargo reachable, everything it installed not.
+
+    Args:
+        tmp_path: Directory to put the shims in.
+
+    Returns:
+        The environment, ready to hand to `gate`.
+    """
+    env = gate_env()
+    shims = tmp_path / "shims"
+    shims.mkdir(exist_ok=True)
+    for name in ("cargo", "rustup"):
+        resolved = shutil.which(name)
+        if resolved and not (shims / name).exists():
+            (shims / name).symlink_to(resolved)
+    kept = [entry for entry in env.get("PATH", "").split(os.pathsep) if Path(entry) != CARGO_BIN_DIR]
+    env["PATH"] = os.pathsep.join([str(shims), *kept])
+    return env
 
 
 def test_install_materialises_the_toolchain_and_a_lockfile(project: Project):
@@ -63,10 +121,29 @@ def test_install_does_not_create_a_python_virtualenv(project: Project):
 
 
 def test_cargo_tools_provides_every_subcommand_the_gates_call(project: Project, logger):
-    """After `cargo-tools`, each gate's subcommand resolves on PATH."""
+    """After `cargo-tools`, each gate's subcommand resolves through cargo."""
     gate(project, "cargo-tools", logger)
-    missing = [tool for tool in CARGO_TOOLS if shutil.which(tool) is None]
+    env = gate_env()
+    missing = [tool for tool in CARGO_TOOLS if not resolves_as_a_cargo_subcommand(tool, env)]
     assert not missing, f"`make cargo-tools` left {missing} uninstalled"
+
+
+def test_cargo_tools_works_where_the_cargo_bin_dir_is_not_on_path(project: Project, logger, tmp_path: Path):
+    """The gate must not assume `cargo install`'s output directory is on PATH.
+
+    It usually is — rustup's own installer links ~/.cargo/bin — which is why this
+    went unnoticed until a Homebrew-installed rustup hit it: `cargo install
+    cargo-binstall` succeeded with a warning, and the next line, a bare
+    `cargo-binstall`, died with "command not found". Every gate below survives
+    this environment already, because they all invoke cargo rather than the tool.
+
+    Cheap despite being end-to-end: with the fix, the tools already sitting in the
+    cargo bin directory are found there and nothing is reinstalled.
+    """
+    env = env_without_the_cargo_bin_dir(tmp_path)
+    gate(project, "cargo-tools", logger, env=env)
+    missing = [tool for tool in CARGO_TOOLS if not resolves_as_a_cargo_subcommand(tool, env)]
+    assert not missing, f"`make cargo-tools` left {missing} unusable on a bare PATH"
 
 
 def test_test_gate_runs_both_nextest_and_the_doctests(project: Project, logger):


### PR DESCRIPTION
## The failure

On a machine whose cargo bin directory is not on `PATH`, `make test` on a freshly synced crate dies before running a test:

```
[INFO] Installing cargo-binstall
[INFO] Installing: cargo-nextest cargo-llvm-cov cargo-deny cargo-machete
/bin/sh: cargo-binstall: command not found
[ERROR] Failed to install cargo tools
```

`cargo install` writes to `$CARGO_HOME/bin`, and nothing guarantees that is on `PATH`. `brew install rustup` — which the layer's own `install` error suggests — puts the shims in Homebrew's bin and never links `~/.cargo/bin`; cargo warns (`be sure to add ... to your PATH`) and carries on. So `cargo-tools` bootstrapped cargo-binstall successfully and then failed on the next line, invoking it by name.

## What was actually broken

Only `cargo-tools`. Cargo resolves `cargo <sub>` by searching `$CARGO_HOME/bin` **as well as** `PATH`, so `cargo nextest`, `cargo llvm-cov`, `cargo deny` and `cargo machete` — every gate in the layer — work on such a machine already. What sees `PATH` alone is `command -v`, and a bare `cargo-binstall`. Hence two symptoms: the hard failure above, and a quieter one where all four probes reported "missing" on every single run.

## The fix

- New `CARGO_BIN_DIR`, resolved from `CARGO_INSTALL_ROOT` → `CARGO_HOME` → `~/.cargo`, the order cargo itself reads them.
- Both presence probes now accept `command -v <tool>` **or** `-x $(CARGO_BIN_DIR)/<tool>`.
- `cargo-binstall …` → `$(CARGO) binstall …`, so the call goes through cargo's subcommand lookup like every gate does.

## Tests

Two, because neither alone would have caught this.

`tests/api/test_language_layer.py` pins the recipe's shape from `make -n`: binstall invoked as a subcommand, no bare `cargo-binstall` anywhere, and both probes consulting the bin dir.

`tests/e2e/test_rust_layer_e2e.py` builds the environment rather than asserting about it — cargo and rustup re-exposed through a shim directory with `CARGO_BIN_DIR` removed from `PATH`, which is precisely the Homebrew layout (dropping the directory outright would only test a missing compiler, since on a rustup-managed runner `cargo` lives there too). Against the old recipe it reproduces the error above verbatim; when green it costs about a second, because the tools already in the bin directory are found there and nothing is reinstalled.

This is why CI was green throughout: `taiki-e/install-action` and rustup's installer both leave `~/.cargo/bin` on `PATH`, so the condition never arose on a runner.

One pre-existing assertion changed rather than added: the e2e check that each tool is on `PATH` encoded the same wrong assumption, and would fail on an affected machine whose gates all work. It now asks cargo, which is what the gates do.

## Verification

- `tests/api` + `tests/bundles`: 889 passed
- `RHIZA_E2E=1 pytest tests/e2e/test_rust_layer_e2e.py -k cargo_tools`: 2 passed; both new tests confirmed red against the pre-fix `rust.mk`
- `make fmt`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
