### PR TITLE
refactor(core): own the rhiza-test runner and the neutral README tests

### DIFF
--- a/.rhiza/tests/test_readme.py
+++ b/.rhiza/tests/test_readme.py
@@ -1,0 +1,1 @@
+../../bundles/core/.rhiza/tests/test_readme.py

--- a/bundles/core/.rhiza/make.d/quality.mk
+++ b/bundles/core/.rhiza/make.d/quality.mk
@@ -1,11 +1,12 @@
 ## .rhiza/make.d/quality.mk - Quality and Formatting
-# The language-neutral gates: pre-commit, the TODO sweep, and semgrep. Everything
-# that needs to know how the project declares its dependencies — `deptry`, the
-# licence-compliance scan — and the `all` aggregate that names the per-language
-# gates live in the language layer (python.mk, from the python-core bundle).
+# The language-neutral gates: pre-commit, the TODO sweep, semgrep, and the runner for
+# the template's own test suite. Everything that needs to know how the project declares
+# its dependencies — `deptry`, the licence-compliance scan — and the `all` aggregate that
+# names the per-language gates live in the language layer (python.mk, from the
+# python-core bundle).
 
 # Declare phony targets (they don't produce files)
-.PHONY: fmt todos semgrep
+.PHONY: fmt todos semgrep rhiza-test
 
 ##@ Quality and Formatting
 fmt: install-uv ## check the pre-commit hooks and the linting
@@ -33,4 +34,26 @@ semgrep: install ## run Semgrep static analysis
 		${UVX_BIN} semgrep --config .rhiza/semgrep.yml ${SOURCE_FOLDER}; \
 	else \
 		printf "${YELLOW}[WARN] SOURCE_FOLDER '${SOURCE_FOLDER}' not found, skipping semgrep.${RESET}\n"; \
+	fi
+
+# Owned by core, not by a language layer, because nothing about it is language-specific:
+# `.rhiza/tests` validates the *template* — READMEs, release config, YAML — and runs
+# under pytest whatever the project is written in. `uv` lives in core for the same
+# reason. Each layer contributes its own modules to the suite (test_pyproject.py,
+# test_cargo_toml.py, test_go_module.py) while the runner stays here, so the recipe
+# exists once rather than identically in all three (#1471).
+#
+# `install` is a deliberate exception to core's rule of never naming a layer-owned
+# target. It is a *prerequisite* here, not a definition, and the suite needs it: the
+# shipped test_docstrings.py imports the project's own packages to run their doctests,
+# which requires the dependencies installed. Make resolves it because every fragment is
+# included into one namespace, and every profile selects exactly one language layer —
+# `test_a_profile_never_selects_two_bundles_from_one_layer` and
+# `test_every_profile_selects_a_language_layer` bracket that from both sides. A
+# core-only tree is not a shipped configuration; there, this fails naming `install`.
+rhiza-test: install ## run rhiza's own tests (if any)
+	@if [ -d ".rhiza/tests" ]; then \
+		${UV_BIN} run --with pytest --with pytest-timeout --with python-dotenv --with packaging pytest .rhiza/tests; \
+	else \
+		printf "${YELLOW}[WARN] No .rhiza/tests directory found, skipping rhiza-tests${RESET}\n"; \
 	fi

--- a/bundles/core/.rhiza/tests/test_readme.py
+++ b/bundles/core/.rhiza/tests/test_readme.py
@@ -1,0 +1,140 @@
+"""Tests for the README that hold whatever the project is written in.
+
+This file and its associated tests flow down via a SYNC action from the
+jebel-quant/rhiza repository (https://github.com/jebel-quant/rhiza).
+
+Owned by ``core`` because none of it is language-specific: every synced README documents
+its gates in ``bash`` fences — ``make install``, ``make test``, ``make all`` — and a
+fence with a syntax error is broken the same way in a Rust, Go or Python project. Before
+this split (#1472) all of it lived in the ``tests`` bundle, which requires
+``python-core``, so a Rust or Go repo had no README coverage at all.
+
+The Python-block half stays behind in ``tests`` as ``test_readme_validation.py``: it
+executes ``python`` fences and diffs them against a ``result`` block, which only means
+something where the project *is* Python.
+
+Note the split of labour with the fence flags: ``SKIP_FLAG`` and ``_should_skip`` are
+duplicated across the two modules rather than shared. Bundles are copied
+independently — a Rust project receives this file and not the other — so a shared helper
+would need a third home that both bundles ship, which is a worse trade for four lines.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess  # nosec B404
+from pathlib import Path
+
+import pytest
+
+# Bash code blocks — captures optional flags (e.g. "+RHIZA_SKIP") and the code body.
+BASH_BLOCK = re.compile(r"```bash([^\n]*)\n(.*?)```", re.DOTALL)
+
+# Bash executable used for syntax checking; `bash -n` parses without executing.
+BASH = "bash"
+
+# Flag marking a fence as intentionally excluded. Usage: add it after the language
+# identifier on the opening fence line, e.g. ```bash +RHIZA_SKIP
+SKIP_FLAG = "+RHIZA_SKIP"
+
+# Box-drawing characters mean the fence is a directory tree, not runnable shell.
+_TREE_MARKERS = ("├──", "└──", "│")
+
+
+def _should_skip(flags: str) -> bool:
+    """Return True if the fence flags string contains the +RHIZA_SKIP marker.
+
+    Args:
+        flags: Text following the language identifier on the opening fence line.
+
+    Returns:
+        True when the block is intentionally excluded.
+    """
+    return SKIP_FLAG in flags
+
+
+class TestReadmeExists:
+    """The README has to be there and be readable before anything else applies."""
+
+    def test_readme_file_exists_at_root(self, root: Path) -> None:
+        """README.md should exist at repository root."""
+        readme = root / "README.md"
+        assert readme.exists(), "README.md not found at project root"
+        assert readme.is_file(), "README.md is not a regular file"
+
+    def test_readme_is_readable(self, root: Path) -> None:
+        """README.md should be readable with UTF-8 encoding and non-empty."""
+        content = (root / "README.md").read_text(encoding="utf-8")
+        assert content.strip(), "README.md is empty"
+
+
+class TestReadmeBashFragments:
+    """Bash fences must parse, in any language's project.
+
+    Only ``bash -n`` — the blocks are parsed, never executed. A README's shell examples
+    are usually destructive-adjacent (`make clean`, `git push`) and running them is not
+    what this is for; a fence that cannot even parse is a documentation bug regardless.
+    """
+
+    def test_bash_blocks_basic_syntax(self, root: Path, logger) -> None:
+        """Every non-skipped bash block should parse under `bash -n`."""
+        content = (root / "README.md").read_text(encoding="utf-8")
+        bash_blocks = BASH_BLOCK.findall(content)
+
+        logger.info("Found %d bash code block(s) in README", len(bash_blocks))
+
+        for i, (flags, code) in enumerate(bash_blocks):
+            if _should_skip(flags):
+                logger.info("Skipping bash block %d (%s flag)", i, SKIP_FLAG)
+                continue
+
+            if any(marker in code for marker in _TREE_MARKERS):
+                logger.info("Skipping bash block %d (directory tree representation)", i)
+                continue
+
+            # A block that is only comments has nothing to parse and no way to be wrong.
+            lines = [line.strip() for line in code.split("\n") if line.strip()]
+            if not [line for line in lines if not line.startswith("#")]:
+                logger.info("Skipping bash block %d (only comments)", i)
+                continue
+
+            logger.debug("Checking bash block %d:\n%s", i, code)
+
+            result = subprocess.run(  # nosec B603 B607 - `bash -n` parses without executing
+                [BASH, "-n"],
+                input=code,
+                capture_output=True,
+                text=True,
+            )
+
+            if result.returncode != 0:
+                pytest.fail(f"Bash block {i} has syntax errors:\nCode:\n{code}\nError:\n{result.stderr}")
+
+
+class TestSkipFlag:
+    """Tests for the +RHIZA_SKIP flag that excludes an individual fence."""
+
+    def test_should_skip_returns_true_for_skip_flag(self) -> None:
+        """+RHIZA_SKIP in flags string should cause _should_skip to return True."""
+        assert _should_skip(" +RHIZA_SKIP") is True
+        assert _should_skip("+RHIZA_SKIP") is True
+        assert _should_skip(" +RHIZA_SKIP other-flag") is True
+
+    def test_should_skip_returns_false_without_flag(self) -> None:
+        """Absence of +RHIZA_SKIP should cause _should_skip to return False."""
+        assert _should_skip("") is False
+        assert _should_skip(" ") is False
+        assert _should_skip("other-flag") is False
+
+    def test_bash_block_with_skip_flag_is_excluded(self, tmp_path: Path) -> None:
+        """A ```bash +RHIZA_SKIP block should not be syntax-checked."""
+        readme = tmp_path / "README.md"
+        readme.write_text(
+            "```bash +RHIZA_SKIP\nnot-valid-bash @@@@\n```\n```bash\necho hello\n```\n",
+            encoding="utf-8",
+        )
+        all_blocks = BASH_BLOCK.findall(readme.read_text(encoding="utf-8"))
+        assert len(all_blocks) == 2
+        checked = [code for flags, code in all_blocks if not _should_skip(flags)]
+        assert len(checked) == 1
+        assert "not-valid-bash" not in checked[0]

--- a/bundles/go-core/.rhiza/make.d/go.mk
+++ b/bundles/go-core/.rhiza/make.d/go.mk
@@ -13,7 +13,7 @@
 # configuration files, while `go test` and `go tool cover` need none.
 
 # Declare phony targets (they don't produce files)
-.PHONY: all coverage deps docs-coverage go-tools install license rhiza-test security test typecheck
+.PHONY: all coverage deps docs-coverage go-tools install license security test typecheck
 
 GO ?= go
 
@@ -157,11 +157,3 @@ license: install go-tools ## run license compliance scan
 	@printf "${BLUE}[INFO] Running license compliance scan${RESET}\n"
 	@$(GO_BIN_DIR)/go-licenses check ./... --ignore "$$($(GO) list -m)"
 
-rhiza-test: install ## run rhiza's own tests (if any)
-	# The template's self-tests validate READMEs and YAML, not Go code, so they
-	# stay Python and run through uv here rather than being ported.
-	@if [ -d ".rhiza/tests" ]; then \
-		${UV_BIN} run --with pytest --with pytest-timeout --with python-dotenv --with packaging pytest .rhiza/tests; \
-	else \
-		printf "${YELLOW}[WARN] No .rhiza/tests directory found, skipping rhiza-tests${RESET}\n"; \
-	fi

--- a/bundles/python-core/.rhiza/make.d/python.mk
+++ b/bundles/python-core/.rhiza/make.d/python.mk
@@ -12,7 +12,7 @@
 # knowing the language. Only one language layer is ever synced into a repo.
 
 # Declare phony targets (they don't produce files)
-.PHONY: all deptry install license rhiza-test
+.PHONY: all deptry install license
 
 # The project virtualenv, and the interpreter that fills it. PYTHON_VERSION is
 # declared in rhiza.mk (core needs a Python to run its own tooling on); here
@@ -104,9 +104,3 @@ license: install ## run license compliance scan (fail on GPL, LGPL, AGPL)
 	@printf "${BLUE}[INFO] Running license compliance scan...${RESET}\n"
 	@${UV_BIN} run --with pip-licenses pip-licenses --fail-on="${LICENSE_FAIL_ON}"
 
-rhiza-test: install ## run rhiza's own tests (if any)
-	@if [ -d ".rhiza/tests" ]; then \
-		${UV_BIN} run --with pytest --with pytest-timeout --with python-dotenv --with packaging pytest .rhiza/tests; \
-	else \
-		printf "${YELLOW}[WARN] No .rhiza/tests directory found, skipping rhiza-tests${RESET}\n"; \
-	fi

--- a/bundles/rust-core/.rhiza/make.d/rust.mk
+++ b/bundles/rust-core/.rhiza/make.d/rust.mk
@@ -13,7 +13,7 @@
 # their Rust counterparts are cargo subcommands with nothing to configure.
 
 # Declare phony targets (they don't produce files)
-.PHONY: all cargo-tools coverage deps docs-coverage install license rhiza-test security test typecheck
+.PHONY: all cargo-tools coverage deps docs-coverage install license security test typecheck
 
 CARGO ?= cargo
 RUSTUP ?= rustup
@@ -141,11 +141,3 @@ license: install cargo-tools ## run license compliance scan (allow-list in deny.
 	@printf "${BLUE}[INFO] Running license compliance scan${RESET}\n"
 	@$(CARGO) deny check licenses
 
-rhiza-test: install ## run rhiza's own tests (if any)
-	# The template's self-tests validate READMEs and YAML, not Python code, so they
-	# stay Python and run through uvx here rather than being ported to Rust.
-	@if [ -d ".rhiza/tests" ]; then \
-		${UV_BIN} run --with pytest --with pytest-timeout --with python-dotenv --with packaging pytest .rhiza/tests; \
-	else \
-		printf "${YELLOW}[WARN] No .rhiza/tests directory found, skipping rhiza-tests${RESET}\n"; \
-	fi

--- a/bundles/tests/.rhiza/tests/test_readme_validation.py
+++ b/bundles/tests/.rhiza/tests/test_readme_validation.py
@@ -1,10 +1,19 @@
-"""Tests for README code examples.
+"""Tests for executable Python examples in the README.
 
 This file and its associated tests flow down via a SYNC action from the jebel-quant/rhiza repository
 (https://github.com/jebel-quant/rhiza).
 
 This module extracts Python code and expected result blocks from README.md,
 executes the code, and verifies the output matches the documented result.
+
+The language-neutral half — that the README exists, and that its ``bash`` fences
+parse — moved to ``core``'s ``test_readme.py`` in #1472, so a Rust or Go project gets it
+too. What stays here only means something where the project itself is Python: running a
+``python`` fence and diffing it against the following ``result`` block.
+
+``SKIP_FLAG`` and ``_should_skip`` are duplicated with that module rather than shared.
+Bundles are copied independently, so a shared helper would need a third home both bundles
+ship — a worse trade for four lines.
 """
 
 import re
@@ -17,12 +26,6 @@ import pytest
 CODE_BLOCK = re.compile(r"```python([^\n]*)\n(.*?)```", re.DOTALL)
 
 RESULT = re.compile(r"```result\n(.*?)```", re.DOTALL)
-
-# Regex for Bash code blocks — captures optional flags and the code body.
-BASH_BLOCK = re.compile(r"```bash([^\n]*)\n(.*?)```", re.DOTALL)
-
-# Bash executable used for syntax checking; subprocess.run below is trusted (noqa: S603).
-BASH = "bash"
 
 # Flag that marks a code block as intentionally excluded from readme tests.
 # Usage: add the flag after the language identifier on the opening fence line,
@@ -80,19 +83,6 @@ def test_readme_runs(logger, root):
 class TestReadmeTestEdgeCases:
     """Edge cases for README code block testing."""
 
-    def test_readme_file_exists_at_root(self, root):
-        """README.md should exist at repository root."""
-        readme = root / "README.md"
-        assert readme.exists()
-        assert readme.is_file()
-
-    def test_readme_is_readable(self, root):
-        """README.md should be readable with UTF-8 encoding."""
-        readme = root / "README.md"
-        content = readme.read_text(encoding="utf-8")
-        assert len(content) > 0
-        assert isinstance(content, str)
-
     def test_readme_code_is_syntactically_valid(self, root):
         """Python code blocks in README should be syntactically valid (skipped blocks are excluded)."""
         readme = root / "README.md"
@@ -108,51 +98,8 @@ class TestReadmeTestEdgeCases:
                 pytest.fail(f"Code block {i} has syntax error: {e}")
 
 
-class TestReadmeBashFragments:
-    """Tests for bash code fragments in README."""
-
-    def test_bash_blocks_basic_syntax(self, root, logger):
-        """Bash code blocks should have basic valid syntax (can be parsed by bash -n)."""
-        readme = root / "README.md"
-        content = readme.read_text(encoding="utf-8")
-        bash_blocks = BASH_BLOCK.findall(content)
-
-        logger.info("Found %d bash code block(s) in README", len(bash_blocks))
-
-        for i, (flags, code) in enumerate(bash_blocks):
-            if _should_skip(flags):
-                logger.info("Skipping bash block %d (%s flag)", i, SKIP_FLAG)
-                continue
-
-            # Skip directory tree representations and other non-executable blocks
-            if any(marker in code for marker in ["├──", "└──", "│"]):
-                logger.info("Skipping bash block %d (directory tree representation)", i)
-                continue
-
-            # Skip blocks that are primarily comments or documentation
-            lines = [line.strip() for line in code.split("\n") if line.strip()]
-            non_comment_lines = [line for line in lines if not line.startswith("#")]
-            if not non_comment_lines:
-                logger.info("Skipping bash block %d (only comments)", i)
-                continue
-
-            logger.debug("Checking bash block %d:\n%s", i, code)
-
-            # Use bash -n to check syntax without executing
-            # Trust boundary: we use bash -n which only parses without executing
-            result = subprocess.run(  # nosec
-                [BASH, "-n"],
-                input=code,
-                capture_output=True,
-                text=True,
-            )
-
-            if result.returncode != 0:
-                pytest.fail(f"Bash block {i} has syntax errors:\nCode:\n{code}\nError:\n{result.stderr}")
-
-
 class TestSkipFlag:
-    """Tests for the +RHIZA_SKIP flag that allows individual README code blocks to be excluded."""
+    """Tests for the +RHIZA_SKIP flag as it applies to Python fences."""
 
     def test_should_skip_returns_true_for_skip_flag(self):
         """+RHIZA_SKIP in flags string should cause _should_skip to return True."""
@@ -181,17 +128,3 @@ class TestSkipFlag:
         executed = [code for flags, code in all_blocks if not _should_skip(flags)]
         assert len(executed) == 1
         assert "raise RuntimeError" not in executed[0]
-
-    def test_bash_block_with_skip_flag_is_excluded(self, tmp_path):
-        """A ```bash +RHIZA_SKIP block should not be syntax-checked."""
-        readme = tmp_path / "README.md"
-        readme.write_text(
-            "```bash +RHIZA_SKIP\nnot-valid-bash @@@@\n```\n```bash\necho hello\n```\n",
-            encoding="utf-8",
-        )
-        content = readme.read_text(encoding="utf-8")
-        all_blocks = BASH_BLOCK.findall(content)
-        assert len(all_blocks) == 2
-        checked = [code for flags, code in all_blocks if not _should_skip(flags)]
-        assert len(checked) == 1
-        assert "not-valid-bash" not in checked[0]

--- a/tests/api/test_language_layer.py
+++ b/tests/api/test_language_layer.py
@@ -169,8 +169,15 @@ class TestRustLayerKeepsTheSameContract:
         """Nextest ignores doctests; dropping the `cargo test --doc` line silently stops testing them."""
         assert "cargo test --doc" in strip_ansi(run_make(logger, ["all"], check=False).stdout)
 
-    def test_rhiza_test_still_runs_the_python_self_tests(self, logger):
-        """The template's own suite validates YAML and READMEs, so it stays Python under uv."""
+    def test_rhiza_test_resolves_through_this_layers_install(self, logger):
+        """`rhiza-test` is core's recipe (#1471), but its `install` prerequisite is the layer's.
+
+        The template's own suite validates YAML, READMEs and release config rather than
+        the project's code, so it stays Python under uv and the runner belongs in core.
+        What that costs is one prerequisite crossing from core into the layer, which is
+        worth asserting per layer: a target that exists but cannot build its prerequisite
+        is not a working gate, and `all` depends on this one.
+        """
         out = strip_ansi(run_make(logger, ["rhiza-test"], check=False).stdout)
         assert "pytest .rhiza/tests" in out
 
@@ -296,8 +303,15 @@ class TestGoLayerKeepsTheSameContract:
         ):
             assert command in out, f"`make all` no longer runs the {gate} gate ({command})"
 
-    def test_rhiza_test_still_runs_the_python_self_tests(self, logger):
-        """The template's own suite validates YAML and READMEs, so it stays Python under uv."""
+    def test_rhiza_test_resolves_through_this_layers_install(self, logger):
+        """`rhiza-test` is core's recipe (#1471), but its `install` prerequisite is the layer's.
+
+        The template's own suite validates YAML, READMEs and release config rather than
+        the project's code, so it stays Python under uv and the runner belongs in core.
+        What that costs is one prerequisite crossing from core into the layer, which is
+        worth asserting per layer: a target that exists but cannot build its prerequisite
+        is not a working gate, and `all` depends on this one.
+        """
         out = strip_ansi(run_make(logger, ["rhiza-test"], check=False).stdout)
         assert "pytest .rhiza/tests" in out
 
@@ -341,3 +355,22 @@ class TestCoreAloneHasNoLanguageLayer:
         """The framework half of core stands on its own."""
         out = strip_ansi(run_make(logger, ["help"], dry_run=False).stdout)
         assert "install-uv" in out, "core still provisions the tool runner"
+
+    def test_rhiza_test_is_declared_here_but_needs_a_layer_to_run(self, logger):
+        """Core owns `rhiza-test` (#1471), and its one layer-owned prerequisite shows up as such.
+
+        The recipe is language-neutral, so core is its home — but it depends on `install`,
+        which core must never define. Every shipped profile pairs core with exactly one
+        layer, so the prerequisite always resolves in practice; a core-only tree is the
+        one place it cannot.
+
+        Pinned because the failure has to stay legible. `make rhiza-test` here must
+        complain about the missing *prerequisite*, naming `install`, rather than about
+        `rhiza-test` itself — the latter would suggest the recipe went missing rather
+        than the layer.
+        """
+        proc = run_make(logger, ["rhiza-test"], check=False)
+        assert proc.returncode != 0
+        stderr = proc.stderr.lower()
+        assert "install" in stderr, f"the failure should name the missing prerequisite:\n{proc.stderr}"
+        assert "no rule to make target 'rhiza-test'" not in stderr, f"core stopped declaring rhiza-test:\n{proc.stderr}"

--- a/tests/bundles/test_bundle_sync.py
+++ b/tests/bundles/test_bundle_sync.py
@@ -135,10 +135,18 @@ class TestPythonCoreBundleSync:
         assert "target-version =" not in content
 
     def test_python_mk_provides_the_language_contract(self):
-        """python.mk owns the target names the rest of the template calls."""
+        """python.mk owns the target names the rest of the template calls.
+
+        ``rhiza-test`` is deliberately absent: its recipe is language-neutral, so it moved
+        to core's quality.mk in #1471 rather than existing identically in all three layers.
+        """
         python_mk = (self.project / ".rhiza" / "make.d" / "python.mk").read_text(encoding="utf-8")
-        for target in ("install:", "all:", "deptry:", "license:", "rhiza-test:"):
+        for target in ("install:", "all:", "deptry:", "license:"):
             assert target in python_mk, f"python.mk is missing {target}"
+        assert "rhiza-test:" not in python_mk, (
+            "python.mk redefines rhiza-test, which core now owns — two recipes for one "
+            "target name is exactly what #1471 removed"
+        )
 
     @pytest.mark.parametrize("name", [".bumpversion.toml", ".bumpversion.cfg", "setup.cfg", ".rhiza/.cfg.toml"])
     def test_no_bumpversion_config_is_shipped(self, name):
@@ -189,10 +197,18 @@ class TestRustCoreBundleSync:
         assert not (self.project / name).exists(), f"{name} belongs to python-core, not rust-core"
 
     def test_rust_mk_provides_the_language_contract(self):
-        """rust.mk owns the same target names python.mk does, plus the cargo-backed gates."""
+        """rust.mk owns the same target names python.mk does, plus the cargo-backed gates.
+
+        ``rhiza-test`` is deliberately absent: its recipe is language-neutral, so it moved
+        to core's quality.mk in #1471 rather than existing identically in all three layers.
+        """
         rust_mk = (self.project / ".rhiza" / "make.d" / "rust.mk").read_text(encoding="utf-8")
-        for target in ("install:", "all:", "test::", "coverage:", "typecheck:", "docs-coverage:", "rhiza-test:"):
+        for target in ("install:", "all:", "test::", "coverage:", "typecheck:", "docs-coverage:"):
             assert target in rust_mk, f"rust.mk is missing {target}"
+        assert "rhiza-test:" not in rust_mk, (
+            "rust.mk redefines rhiza-test, which core now owns — two recipes for one "
+            "target name is exactly what #1471 removed"
+        )
 
     def test_only_one_language_fragment_is_synced(self):
         """python.mk and rust.mk both define `install` — receiving both would be a clash."""
@@ -422,10 +438,18 @@ class TestGoCoreBundleSync:
         assert not (self.project / name).exists(), f"{name} belongs to another language layer"
 
     def test_go_mk_provides_the_language_contract(self):
-        """go.mk owns the same target names its siblings do, plus the go-backed gates."""
+        """go.mk owns the same target names its siblings do, plus the go-backed gates.
+
+        ``rhiza-test`` is deliberately absent: its recipe is language-neutral, so it moved
+        to core's quality.mk in #1471 rather than existing identically in all three layers.
+        """
         go_mk = (self.project / ".rhiza" / "make.d" / "go.mk").read_text(encoding="utf-8")
-        for target in ("install:", "all:", "test::", "coverage:", "typecheck:", "docs-coverage:", "rhiza-test:"):
+        for target in ("install:", "all:", "test::", "coverage:", "typecheck:", "docs-coverage:"):
             assert target in go_mk, f"go.mk is missing {target}"
+        assert "rhiza-test:" not in go_mk, (
+            "go.mk redefines rhiza-test, which core now owns — two recipes for one "
+            "target name is exactly what #1471 removed"
+        )
 
     def test_only_one_language_fragment_is_synced(self):
         """python.mk, rust.mk and go.mk all define `install` — receiving two would be a clash."""

--- a/tests/e2e/scaffolds.py
+++ b/tests/e2e/scaffolds.py
@@ -39,11 +39,18 @@ profiles:
   - {profile}
 """
 
-# Prose only, no fenced code blocks: `rhiza-test` runs the shipped
-# test_readme_validation.py, which executes every ```python block in the README
-# and diffs it against the following ```result block. An empty set of blocks
-# passes that trivially, which keeps the README about the scaffold rather than
-# about satisfying a test.
+# No ```python fence, and one ```bash fence, for two different reasons.
+#
+# No Python: `rhiza-test` runs the shipped test_readme_validation.py, which executes
+# every ```python block and diffs it against the following ```result block. An empty
+# set of blocks passes that trivially, which keeps the README about the scaffold
+# rather than about satisfying a test — and on a Rust or Go scaffold there is no
+# Python to demonstrate anyway.
+#
+# One bash fence, because core's test_readme.py syntax-checks them with `bash -n` for
+# every layer (#1472), and a README with no fence at all would pass that trivially too
+# — the exact vacuum #1469 was about. The block is never executed, so naming real
+# targets here costs nothing and keeps the check honest.
 _README = """\
 # demo
 
@@ -51,6 +58,11 @@ A minimal {language} project assembled by rhiza's end-to-end suite.
 
 It exists to prove that a freshly synced project passes every gate the
 `{layer}` language layer ships, with no hand-holding beyond the code below.
+
+```bash
+make install
+make all
+```
 """
 
 

--- a/tests/e2e/test_go_layer_e2e.py
+++ b/tests/e2e/test_go_layer_e2e.py
@@ -173,6 +173,8 @@ def test_rhiza_test_gate_actually_runs_the_shipped_suite(project: Project, logge
     out = gate(project, "rhiza-test", logger)
     assert "No .rhiza/tests directory found" not in out, "the self-test suite was not delivered to a Go project"
     assert "test_go_module.py" in out, f"the Go layer's own self-tests did not run:\n{out}"
+    # core's neutral half must arrive too, not just the layer's own module (#1472):
+    assert "test_readme.py" in out, f"core's language-neutral README tests did not run:\n{out}"
     assert re.search(r"\d+ passed", out), f"rhiza-test collected nothing:\n{out}"
     # Nothing in the Go suite has a legitimate reason to skip on this scaffold, and the
     # ones that would — every test reconciling the Version constant with the newest tag —

--- a/tests/e2e/test_rust_layer_e2e.py
+++ b/tests/e2e/test_rust_layer_e2e.py
@@ -222,6 +222,8 @@ def test_rhiza_test_gate_actually_runs_the_shipped_suite(project: Project, logge
     out = gate(project, "rhiza-test", logger)
     assert "No .rhiza/tests directory found" not in out, "the self-test suite was not delivered to a Rust project"
     assert "test_cargo_toml.py" in out, f"the Rust layer's own self-tests did not run:\n{out}"
+    # core's neutral half must arrive too, not just the layer's own module (#1472):
+    assert "test_readme.py" in out, f"core's language-neutral README tests did not run:\n{out}"
     assert re.search(r"\d+ passed", out), f"rhiza-test collected nothing:\n{out}"
     # Nothing in the Rust suite has a legitimate reason to skip on this scaffold, and the
     # ones that would — every test reconciling [package].version with the newest tag — are


### PR DESCRIPTION
Closes #1471 and #1472 — the two follow-ups filed out of #1469.

> Follows #1470, which merged while this was being written — so this targets `main`
> directly and needs no stacking. #1472 depended on #1470 for `core` owning
> `.rhiza/tests/` and its `conftest.py`; that is in place now.
>
> Kept out of #1470 because #1471 touches the layer contract, which was the reason for
> deferring it in the first place.

Two independent commits, disjoint files, reviewable separately.

---

## `refactor(core)`: move the `rhiza-test` runner out of the layers — #1471

The recipe was byte-identical in `python.mk`, `rust.mk` and `go.mk`, differing only in a
comment. Nothing about it is language-specific: `.rhiza/tests` validates the *template*
and runs under pytest whatever the project is, which is why `uv` lives in `core` rather
than the Python layer. After #1470 `core` also owns the suite's harness, so the runner
was the last part still living three times over. It now sits in `core`'s `quality.mk`
beside the other neutral gates; each layer keeps `rhiza-test` in its own `all`.

**The wart, stated plainly.** `rhiza-test` depends on `install`, which `core` must never
*define*. Naming it as a prerequisite is a different thing from defining it, and the
suite genuinely needs it — the shipped `test_docstrings.py` imports the project's own
packages to run their doctests. Make resolves it because every fragment is included into
one namespace and every profile selects exactly one layer, which
`test_a_profile_never_selects_two_bundles_from_one_layer` and
`test_every_profile_selects_a_language_layer` bracket from both sides.

If a reviewer would rather keep the three copies, that is a legitimate call and the issue
says so — the useful outcome then is a comment in each marking the duplication deliberate.

Three test changes, none cosmetic:

- The two per-layer assertions that used to prove *ownership* now prove the **crossing
  resolves** — that `make rhiza-test` in a Rust or Go project can build its `install`
  prerequisite. `all` depends on this target, so a name that exists but cannot build is
  not a working gate.
- A new assertion in `TestCoreAloneHasNoLanguageLayer` pins the one configuration where
  it cannot resolve: a core-only tree must fail naming **`install`**, not `rhiza-test`.
  The latter would read as the recipe having gone missing rather than the layer.
- The three bundle-sync contract tests now assert `rhiza-test:` is **absent** from each
  layer, so a copy-paste back into one fails rather than silently reintroducing a second
  recipe for a single target name.

## `feat(core)`: give Rust and Go projects README coverage — #1472

`test_readme_validation.py` did two unrelated jobs. Executing a `` ```python `` fence and
diffing it against a `` ```result `` block only means something where the project is
Python. Checking that the README exists and that its `` ```bash `` fences parse means the
same thing everywhere — every synced README documents its gates in bash. Because the
whole module lived in `tests` (which requires `python-core`), a Rust or Go repo got
neither half.

Split along that line — option 2 of the three the issue laid out:

| Bundle | Module | Holds |
| --- | --- | --- |
| `core` | `test_readme.py` *(new)* | README presence, `bash -n` on every non-skipped fence, skip-flag tests for bash |
| `tests` | `test_readme_validation.py` | the Python executor and the `compile()` syntax check |

`SKIP_FLAG` and `_should_skip` are duplicated rather than shared: bundles are copied
independently, so a shared helper needs a third home *both* bundles ship — a worse trade
for four lines. Same reasoning as `_has_bumpversion_section` across the two layers in
#1470.

### The part that would have made this pointless

The e2e scaffold README was **prose only**, with a comment explaining why: an empty set
of `` ```python `` blocks passes the executor trivially, keeping the README about the
scaffold. That reasoning holds for Python fences and silently defeated the new bash
check — nought fences parse nought ways, and the gate would have gone green having done
nothing. Precisely the vacuum #1469 was about, one module over.

The issue predicted this as a "worth checking first" item, and it was real. The scaffold
now carries one bash fence naming real targets; it is only ever parsed, never executed,
so that costs nothing. Both layer e2e suites also now assert **core's** neutral module
arrives, not just the layer's own — delivery is the half #1469 showed can silently not
happen.

---

## Verification

- `make fmt` — all hooks pass
- `make test` — 1410 passed, 1 skipped (the opt-in GitLab Docker job)
- `RHIZA_E2E=1 pytest tests/e2e` — **38 passed**, all three layers
- The Rust and Go `rhiza-test` gates run their layer module *and* `test_readme.py`, with
  zero skips

**One pre-existing failure, unrelated:** rust `coverage` fails on my machine with
`failed to find llvm-tools-preview`. Verified identical at `v1.3.1` in a throwaway
worktree; Homebrew's rustup lacks the component, same environment class as #1468. CI
installs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
