### PR TITLE
refactor: run the hooks with prek instead of pre-commit

### DIFF
--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -270,15 +270,15 @@ jobs:
         with:
           token: ${{ secrets.GH_PAT }}
 
-      - name: Cache pre-commit environments
+      - name: Cache prek environments
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
-          path: ~/.cache/pre-commit
-          key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+          path: ~/.cache/prek
+          key: ${{ runner.os }}-prek-${{ hashFiles('.pre-commit-config.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pre-commit-
+            ${{ runner.os }}-prek-
 
-      - name: Run pre-commit
+      - name: Run prek
         run: |
           make fmt
 

--- a/.github/workflows/rhiza_e2e.yml
+++ b/.github/workflows/rhiza_e2e.yml
@@ -74,13 +74,13 @@ jobs:
 
       # Keyed on the shipped config, not on the repo's own: the hooks that run are
       # the scaffolded project's, from bundles/python-core/.pre-commit-config.yaml.
-      - name: Cache pre-commit environments
+      - name: Cache prek environments
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
-          path: ~/.cache/pre-commit
-          key: ${{ runner.os }}-pre-commit-e2e-python-${{ hashFiles('bundles/python-core/.pre-commit-config.yaml') }}
+          path: ~/.cache/prek
+          key: ${{ runner.os }}-prek-e2e-python-${{ hashFiles('bundles/python-core/.pre-commit-config.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pre-commit-e2e-python-
+            ${{ runner.os }}-prek-e2e-python-
 
       - name: Run the Python layer end to end
         run: make e2e E2E_ARGS=tests/e2e/test_python_layer_e2e.py
@@ -130,13 +130,13 @@ jobs:
         with:
           tool: cargo-binstall,cargo-nextest,cargo-llvm-cov,cargo-deny,cargo-machete
 
-      - name: Cache pre-commit environments
+      - name: Cache prek environments
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
-          path: ~/.cache/pre-commit
-          key: ${{ runner.os }}-pre-commit-e2e-rust-${{ hashFiles('bundles/rust-core/.pre-commit-config.yaml') }}
+          path: ~/.cache/prek
+          key: ${{ runner.os }}-prek-e2e-rust-${{ hashFiles('bundles/rust-core/.pre-commit-config.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pre-commit-e2e-rust-
+            ${{ runner.os }}-prek-e2e-rust-
 
       - name: Run the Rust layer end to end
         run: make e2e E2E_ARGS=tests/e2e/test_rust_layer_e2e.py
@@ -181,13 +181,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-e2e-
 
-      - name: Cache pre-commit environments
+      - name: Cache prek environments
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
-          path: ~/.cache/pre-commit
-          key: ${{ runner.os }}-pre-commit-e2e-go-${{ hashFiles('bundles/go-core/.pre-commit-config.yaml') }}
+          path: ~/.cache/prek
+          key: ${{ runner.os }}-prek-e2e-go-${{ hashFiles('bundles/go-core/.pre-commit-config.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pre-commit-e2e-go-
+            ${{ runner.os }}-prek-e2e-go-
 
       - name: Run the Go layer end to end
         run: make e2e E2E_ARGS=tests/e2e/test_go_layer_e2e.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Downstream projects adopt Rhiza by adding a `.rhiza/template.yml` that lists whi
 ```bash
 make install      # Full setup: installs uv, downloads Python version from .python-version, creates .venv, installs deps
 make test         # Run all tests with coverage (90% minimum required)
-make fmt          # Run all pre-commit hooks (ruff format/check, markdownlint, bandit, etc.)
+make fmt          # Run all hooks via prek (ruff format/check, markdownlint, bandit, etc.)
 make deptry       # Check for unused/missing dependencies
 make docs-coverage  # Check docstring coverage with interrogate (100% required)
 make typecheck    # Static type checking with pyright
@@ -193,7 +193,7 @@ Its `install` is also the thinnest of the
 three — go.mod's `go`/`toolchain` directives make the go command fetch a matching
 compiler on demand, so there is no rustup step to mirror.
 
-`uv` sits in core, not in the Python layer, because rhiza runs pre-commit, mkdocs and
+`uv` sits in core, not in the Python layer, because rhiza runs prek, mkdocs and
 semgrep through `uvx` regardless of the project's language. What moved is the
 *project* virtualenv and the `uv sync` of its declared dependencies.
 
@@ -267,7 +267,31 @@ Hook targets use double-colon syntax (`pre-install::`, `post-install::`) and can
 - **Ruff** (`ruff.toml`): see `ruff.toml` for the authoritative and current enabled rule set (rule-prefix reference: https://docs.astral.sh/ruff/rules/)
 - **Docstring coverage**: 100% (interrogate) — all public functions, classes, and modules require docstrings
 - **Test coverage**: 90% minimum
-- **Pre-commit hooks**: `make fmt` runs ruff, markdownlint, bandit, actionlint, interrogate, jsonschema, and uv-lock validation
+- **Hooks**: `make fmt` runs ruff, markdownlint, bandit, actionlint, interrogate, jsonschema, and uv-lock validation
+
+> **The hook runner is [prek](https://github.com/j178/prek), not pre-commit.** It reads the
+> same `.pre-commit-config.yaml` — all four of them are unchanged, and Renovate still
+> manages hook versions from that file — so this is a runner swap, not a config change
+> (ADR 0009 carries the amendment). Two things are worth knowing before editing
+> `quality.mk`:
+>
+> - **`make fmt` passes `--config .pre-commit-config.yaml` deliberately.** prek otherwise
+>   treats *every* nested `.pre-commit-config.yaml` as a separate project and runs each
+>   one's hooks. That is a feature in a monorepo and wrong here: `bundles/python-core`,
+>   `bundles/rust-core` and `bundles/go-core` each ship one as **template content**.
+>   Without the flag, go-core's hooks run `go vet ./...` in a directory that has no
+>   `go.mod` — because a synced project brings its own — and `make fmt` fails on the
+>   mother repo. `.prekignore` is documented for this job but is not honoured by prek
+>   0.4.12.
+> - **`fmt` no longer pins an interpreter.** `uvx pre-commit` needed one to run
+>   pre-commit itself on, so a Rust or Go repo — which ships no `.python-version` — rested
+>   on `rhiza.mk`'s `PYTHON_VERSION` fallback. prek is a binary that provisions each
+>   hook's toolchain itself. `test_fmt_target_no_longer_needs_python_version` pins the
+>   absence, so the coupling cannot creep back.
+>
+> The CI job keeps its id `pre-commit` and its display name "Pre-commit hooks": that name
+> is a required status check in `.github/rulesets/main-branch-protection.json`, so
+> renaming it would leave every PR waiting on a context that never reports.
 
 > **Coverage in this repo (mother-repo specifics).** Rhiza has no `src/` and ships no
 > runtime Python, so `make test` prints `Source folder src not found, running tests without

--- a/bundles/core/.rhiza/make.d/quality.mk
+++ b/bundles/core/.rhiza/make.d/quality.mk
@@ -9,8 +9,28 @@
 .PHONY: fmt todos semgrep rhiza-test
 
 ##@ Quality and Formatting
+# prek rather than pre-commit: a Rust reimplementation that reads the same
+# `.pre-commit-config.yaml` and needs no Python of its own. Two consequences, one
+# gained and one that has to be asked for.
+#
+# Gained: the `-p ${PYTHON_VERSION}` this recipe used to carry is gone. That flag
+# existed because `uvx pre-commit` had to choose an interpreter to run pre-commit
+# *itself* on, and a Rust or Go project ships no `.python-version` — so the whole
+# language-neutral half of the template rested on rhiza.mk's fallback resolving to
+# something real. prek is a binary and provisions each hook's toolchain itself, so the
+# coupling is removed rather than merely satisfied.
+#
+# Asked for: `--config`. By default prek treats every directory below the root that
+# holds a `.pre-commit-config.yaml` as a separate *project* and runs each one's hooks —
+# useful in a monorepo, surprising anywhere else, and wrong in rhiza's own repo, where
+# `bundles/{python,rust,go}-core` each ship one as template content. (go-core's hooks
+# then run `go vet ./...` in a directory with no `go.mod` and fail.) Naming the config
+# explicitly disables that discovery, so `make fmt` means exactly what it meant under
+# pre-commit: this repo's config, once. A consumer who wants the monorepo behaviour
+# drops the flag. `.prekignore` is documented for the same job but is not honoured by
+# prek 0.4.12, so it is not what this relies on.
 fmt: install-uv ## check the pre-commit hooks and the linting
-	@${UVX_BIN} -p ${PYTHON_VERSION} pre-commit run --all-files
+	@${UVX_BIN} prek run --all-files --config .pre-commit-config.yaml
 
 todos: ## search and report all TODO/FIXME/HACK comments in the codebase
 	@printf "${BLUE}[INFO] Searching for TODO, FIXME, and HACK comments...${RESET}\n"

--- a/bundles/gitlab/.gitlab/TESTING.md
+++ b/bundles/gitlab/.gitlab/TESTING.md
@@ -107,7 +107,7 @@ uvx deptry src/
 **Manual test:**
 ```bash
 # Run pre-commit locally
-uv run pre-commit run --all-files
+uvx prek run --all-files
 ```
 
 **Success criteria:**

--- a/bundles/go-core/.rhiza/make.d/go.mk
+++ b/bundles/go-core/.rhiza/make.d/go.mk
@@ -72,7 +72,7 @@ install: pre-install ## install the toolchain and download dependencies
 	    printf "${BLUE}[INFO] Skipping pre-commit hook install: core.hooksPath is set${RESET}\n"; \
 	  else \
 	    printf "${BLUE}[INFO] Installing pre-commit hooks...${RESET}\n"; \
-	    ${UVX_BIN} -p ${PYTHON_VERSION} pre-commit install || { printf "${YELLOW}[WARN] Failed to install pre-commit hooks${RESET}\n"; }; \
+	    ${UVX_BIN} prek install || { printf "${YELLOW}[WARN] Failed to install pre-commit hooks${RESET}\n"; }; \
 	  fi; \
 	fi
 

--- a/bundles/python-core/.rhiza/make.d/python.mk
+++ b/bundles/python-core/.rhiza/make.d/python.mk
@@ -86,7 +86,7 @@ install: pre-install install-uv ## install
 	    printf "${BLUE}[INFO] Skipping pre-commit hook install: core.hooksPath is set${RESET}\n"; \
 	  else \
 	    printf "${BLUE}[INFO] Installing pre-commit hooks...${RESET}\n"; \
-	    ${UVX_BIN} -p ${PYTHON_VERSION} pre-commit install || { printf "${YELLOW}[WARN] Failed to install pre-commit hooks${RESET}\n"; }; \
+	    ${UVX_BIN} prek install || { printf "${YELLOW}[WARN] Failed to install pre-commit hooks${RESET}\n"; }; \
 	  fi; \
 	fi
 

--- a/bundles/rust-core/.rhiza/make.d/rust.mk
+++ b/bundles/rust-core/.rhiza/make.d/rust.mk
@@ -71,7 +71,7 @@ install: pre-install ## install the toolchain and fetch dependencies
 	    printf "${BLUE}[INFO] Skipping pre-commit hook install: core.hooksPath is set${RESET}\n"; \
 	  else \
 	    printf "${BLUE}[INFO] Installing pre-commit hooks...${RESET}\n"; \
-	    ${UVX_BIN} -p ${PYTHON_VERSION} pre-commit install || { printf "${YELLOW}[WARN] Failed to install pre-commit hooks${RESET}\n"; }; \
+	    ${UVX_BIN} prek install || { printf "${YELLOW}[WARN] Failed to install pre-commit hooks${RESET}\n"; }; \
 	  fi; \
 	fi
 

--- a/docs/adr/0009-use-pre-commit-hooks-for-code-quality.md
+++ b/docs/adr/0009-use-pre-commit-hooks-for-code-quality.md
@@ -4,7 +4,10 @@ Date: 2024-04-01
 
 ## Status
 
-Accepted
+Accepted. Amended 2026-08-03: the runner is now
+[prek](https://github.com/j178/prek) rather than pre-commit itself — see
+**Amendment: prek** at the end of this record. Everything the decision rests on is
+unchanged, including `.pre-commit-config.yaml` as the config format.
 
 ## Context
 
@@ -43,7 +46,7 @@ on every commit, enforcing standards at the point of authorship.
    - `uv-lock` — ensures `uv.lock` is up-to-date
    - `rhiza-hooks` — custom Rhiza-specific checks (workflow naming, Makefile targets,
      Python version consistency)
-3. **Installation**: `make install` installs pre-commit hooks via `uv run pre-commit install`.
+3. **Installation**: `make install` installs the hooks via `uvx prek install`.
 4. **CI enforcement**: The `rhiza_pre-commit.yml` GitHub Actions workflow runs all hooks
    in CI to catch any commits that bypassed local hooks.
 5. **Auto-fix in CI**: The CI workflow applies auto-fixes and commits them back,
@@ -59,8 +62,8 @@ on every commit, enforcing standards at the point of authorship.
   local tooling setup.
 - **Reduced review noise**: Reviewers spend time on logic, not style. Automated tools
   handle formatting and trivial issues.
-- **Self-updating**: `pre-commit autoupdate` (run periodically) keeps hook versions
-  current. Renovate can automate this.
+- **Self-updating**: `prek update` (pre-commit's `autoupdate`) keeps hook versions
+  current. Renovate automates it by reading `.pre-commit-config.yaml` directly.
 - **Extensible**: New tools are added by appending to `.pre-commit-config.yaml` with no
   change to the Makefile.
 
@@ -78,5 +81,33 @@ on every commit, enforcing standards at the point of authorship.
   contributor skips `make install`, they will not have hooks. The CI enforcement
   provides a backstop in this case.
 - **Hook version drift**: Hook repositories release new versions independently. Outdated
-  hooks may fail with newer tool versions. Regular `pre-commit autoupdate` runs
+  hooks may fail with newer tool versions. Regular `prek update` runs
   (automated via Renovate) mitigate this.
+
+## Amendment: prek (2026-08-03)
+
+The hook *runner* moved from pre-commit to [prek](https://github.com/j178/prek), a Rust
+reimplementation that reads the same `.pre-commit-config.yaml`. None of the four
+`.pre-commit-config.yaml` files changed, no hook was added or removed, and Renovate keeps
+managing hook versions from the same file — so this amends how the decision is executed,
+not the decision.
+
+What actually changed:
+
+- `make fmt` runs `uvx prek run --all-files --config .pre-commit-config.yaml`, and
+  `make install` runs `uvx prek install`.
+- **The `-p $(PYTHON_VERSION)` coupling is gone.** `uvx pre-commit` had to pick an
+  interpreter to run pre-commit *itself* on, and a Rust or Go project ships no
+  `.python-version` — so the language-neutral half of the template depended on
+  `rhiza.mk`'s fallback resolving to a real version. prek is a binary and provisions each
+  hook's toolchain itself, so the dependency is removed rather than satisfied.
+- CI caches `~/.cache/prek` instead of `~/.cache/pre-commit`; the cache key still hashes
+  `.pre-commit-config.yaml`.
+- `--config` is passed explicitly. prek otherwise treats every nested
+  `.pre-commit-config.yaml` as a separate project — good in a monorepo, wrong in this
+  repo, where `bundles/{python,rust,go}-core` ship one each as template content. Without
+  the flag, go-core's hooks run `go vet ./...` in a directory with no `go.mod` and fail.
+
+The CI job keeps its id (`pre-commit`) and display name ("Pre-commit hooks"), because
+that name is a required status check in `.github/rulesets/main-branch-protection.json`.
+Renaming it would leave every PR waiting on a context that never reports.

--- a/docs/reference/SHELL_SCRIPTS.md
+++ b/docs/reference/SHELL_SCRIPTS.md
@@ -212,7 +212,7 @@ No external dependencies required (no bats-core needed).
 
 **Solutions**:
 1. This is non-critical; bootstrap continues
-2. Install manually later: `uvx pre-commit install`
+2. Install manually later: `uvx prek install`
 3. Ensure `.pre-commit-config.yaml` exists
 
 ## Advanced Usage

--- a/docs/reference/TOOLS_REFERENCE.md
+++ b/docs/reference/TOOLS_REFERENCE.md
@@ -508,13 +508,13 @@ uv run pytest -v -s
 
 ```bash
 # Install pre-commit
-uv run pre-commit install
+uvx prek install
 
 # Run all hooks manually
 make fmt
 
 # Run specific hook
-uv run pre-commit run hook-name --all-files
+uvx prek run hook-name --all-files
 ```
 
 #### "Git LFS files not downloading"

--- a/docs/security/SECURITY_TESTING.md
+++ b/docs/security/SECURITY_TESTING.md
@@ -33,7 +33,7 @@ file is read automatically by both bandit and CodeFactor, making it the single s
 **Running Bandit**:
 ```bash
 # Run via pre-commit
-pre-commit run bandit --all-files
+uvx prek run bandit --all-files
 
 # Or directly with uv (reads .bandit automatically)
 uv tool run bandit -r . --ini .bandit

--- a/tests/api/test_ci_workflow.py
+++ b/tests/api/test_ci_workflow.py
@@ -85,13 +85,18 @@ def test_ci_cache_keys_match_audit_policy(root):
     uv_cache_step = next(step for step in test_steps if step.get("name") == "Cache uv artifacts")
     assert uv_cache_step["with"]["key"] == "${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}"
 
+    # The job id stays `pre-commit` and its display name stays "Pre-commit hooks": that
+    # name is a required status check in .github/rulesets/main-branch-protection.json,
+    # so renaming it would leave every PR waiting on a context that never reports.
+    # What the hook runner is called is a detail of the recipe; what the check is called
+    # is a contract with branch protection.
     pre_commit_steps = workflow["jobs"]["pre-commit"]["steps"]
-    pre_commit_cache_step = next(
-        step for step in pre_commit_steps if step.get("name") == "Cache pre-commit environments"
+    prek_cache_step = next(step for step in pre_commit_steps if step.get("name") == "Cache prek environments")
+    assert prek_cache_step["with"]["path"] == "~/.cache/prek", (
+        "prek caches under ~/.cache/prek, not pre-commit's directory"
     )
-    assert (
-        pre_commit_cache_step["with"]["key"]
-        == "${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}"
+    assert prek_cache_step["with"]["key"] == "${{ runner.os }}-prek-${{ hashFiles('.pre-commit-config.yaml') }}", (
+        "the key still hashes .pre-commit-config.yaml — prek reads the same file"
     )
 
 

--- a/tests/api/test_language_layer.py
+++ b/tests/api/test_language_layer.py
@@ -44,7 +44,7 @@ class TestPythonLayerProvidesTheContract:
     def test_all_chains_the_python_gates(self, logger):
         """`all` names the per-language gate set, so it belongs to the layer."""
         out = strip_ansi(run_make(logger, ["all"]).stdout)
-        assert "pre-commit run --all-files" in out  # fmt, from core
+        assert "prek run --all-files" in out  # fmt, from core
         assert "deptry" in out  # deptry, from the layer
         assert "pip-licenses" in out  # license, from the layer
 
@@ -154,7 +154,7 @@ class TestRustLayerKeepsTheSameContract:
         that is named but whose recipe has been gutted still fails.
         """
         out = strip_ansi(run_make(logger, ["all"], check=False).stdout)
-        assert "pre-commit run --all-files" in out  # fmt, from core
+        assert "prek run --all-files" in out  # fmt, from core
         for gate, command in (
             ("test", "cargo nextest run"),
             ("docs-coverage", "-D missing_docs"),
@@ -181,17 +181,20 @@ class TestRustLayerKeepsTheSameContract:
         out = strip_ansi(run_make(logger, ["rhiza-test"], check=False).stdout)
         assert "pytest .rhiza/tests" in out
 
-    def test_neutral_tooling_works_without_a_python_version_file(self, logger):
-        """`fmt` runs pre-commit through `uvx -p $(PYTHON_VERSION)` whatever the language.
+    def test_neutral_tooling_needs_no_python_at_all(self, logger):
+        """`fmt` must not depend on a Python version on a project that declares none.
 
-        A Rust repo ships no `.python-version`, so the whole language-neutral half of
-        the template rests on the fallback in rhiza.mk resolving to a real version —
-        an empty `-p` would break `fmt` on every Rust project at once.
+        This used to assert the opposite shape — that `fmt` reached pre-commit through
+        `uvx -p $(PYTHON_VERSION)`, so a Rust repo (which ships no `.python-version`)
+        rested on rhiza.mk's fallback resolving to something real. prek is a binary that
+        provisions each hook's toolchain itself, so the dependency is gone rather than
+        satisfied, and the assertion inverts: no `-p` should appear at all.
         """
         out = strip_ansi(run_make(logger, ["fmt"], check=False).stdout)
-        assert not (self.project / ".python-version").exists(), "fixture drifted: this asserts the fallback path"
-        assert re.search(r"-p \d+\.\d+ pre-commit run --all-files", out), (
-            f"`make fmt` did not resolve PYTHON_VERSION to a usable value:\n{out}"
+        assert not (self.project / ".python-version").exists(), "fixture drifted: this asserts the no-Python path"
+        assert "prek run --all-files" in out, f"`make fmt` no longer runs prek:\n{out}"
+        assert not re.search(r"prek\b[^\n]*-p \d", out), (
+            f"`make fmt` still pins an interpreter for prek, which needs none:\n{out}"
         )
 
 
@@ -292,7 +295,7 @@ class TestGoLayerKeepsTheSameContract:
     def test_all_chains_the_go_gates(self, logger):
         """The mirror of the Python and Rust `all` tests — a dropped gate shows up here."""
         out = strip_ansi(run_make(logger, ["all"], check=False).stdout)
-        assert "pre-commit run --all-files" in out  # fmt, from core
+        assert "prek run --all-files" in out  # fmt, from core
         for gate, command in (
             ("test", "go test ./..."),
             ("docs-coverage", "revive"),
@@ -315,12 +318,13 @@ class TestGoLayerKeepsTheSameContract:
         out = strip_ansi(run_make(logger, ["rhiza-test"], check=False).stdout)
         assert "pytest .rhiza/tests" in out
 
-    def test_neutral_tooling_works_without_a_python_version_file(self, logger):
-        """As with Rust: no `.python-version`, so `fmt` rests on the rhiza.mk fallback."""
+    def test_neutral_tooling_needs_no_python_at_all(self, logger):
+        """As with Rust: no `.python-version`, and with prek `fmt` no longer wants one."""
         out = strip_ansi(run_make(logger, ["fmt"], check=False).stdout)
-        assert not (self.project / ".python-version").exists(), "fixture drifted: this asserts the fallback path"
-        assert re.search(r"-p \d+\.\d+ pre-commit run --all-files", out), (
-            f"`make fmt` did not resolve PYTHON_VERSION to a usable value:\n{out}"
+        assert not (self.project / ".python-version").exists(), "fixture drifted: this asserts the no-Python path"
+        assert "prek run --all-files" in out, f"`make fmt` no longer runs prek:\n{out}"
+        assert not re.search(r"prek\b[^\n]*-p \d", out), (
+            f"`make fmt` still pins an interpreter for prek, which needs none:\n{out}"
         )
 
 

--- a/tests/api/test_make_variable_overrides.py
+++ b/tests/api/test_make_variable_overrides.py
@@ -89,13 +89,20 @@ class TestPythonVersionVariable:
         out = strip_ansi(proc.stdout)
         assert "3.13" in out, f"Expected default 3.13; got: {out}"
 
-    def test_python_version_used_in_fmt_target(self, logger, tmp_path) -> None:
-        """The fmt target must pass -p <PYTHON_VERSION> to uvx."""
+    def test_fmt_target_no_longer_needs_python_version(self, logger, tmp_path) -> None:
+        """`fmt` must not pin an interpreter: prek is a binary and needs none.
+
+        The inverse of what this asserted under pre-commit, which `uvx` had to run on
+        some interpreter. Kept rather than deleted because the coupling is worth
+        pinning in its absence — reintroducing `-p` here would quietly make the
+        language-neutral half of the template depend on PYTHON_VERSION again.
+        """
         env = os.environ.copy()
         env.pop("PYTHON_VERSION", None)
 
         proc = run_make(logger, ["fmt"], env=env)
-        assert "uvx -p" in proc.stdout, "fmt target should use uvx -p <version>"
+        assert "prek run --all-files" in proc.stdout, "fmt target should run prek"
+        assert "uvx -p" not in proc.stdout, "fmt should not pin an interpreter for prek"
 
 
 class TestSourceFolderVariable:

--- a/tests/api/test_makefile_targets.py
+++ b/tests/api/test_makefile_targets.py
@@ -97,7 +97,7 @@ class TestMakefile:
 
         proc = run_make(logger, ["fmt"], env=env)
         out = proc.stdout
-        assert_uvx_command_uses_version(out, tmp_path, "pre-commit run --all-files")
+        assert "prek run --all-files" in out, "fmt should run prek over every file"
 
     def test_deptry_target_dry_run(self, logger, tmp_path):
         """Deptry target should invoke deptry via uvx with Python version in dry-run output."""
@@ -221,7 +221,7 @@ class TestMakefile:
         out = proc.stdout
         assert "no rule to make target" not in proc.stderr.lower()
         # Markers proving the prerequisite chain expands each sub-target's recipe.
-        assert "pre-commit run --all-files" in out  # fmt
+        assert "prek run --all-files" in out  # fmt
         assert "uv run --with pytest" in out  # test / rhiza-test
         assert "uv run --with interrogate interrogate" in out  # docs-coverage
         assert "Running bandit security scan in:" in out  # security


### PR DESCRIPTION
Swaps the hook runner from pre-commit to [prek](https://github.com/j178/prek), a Rust
reimplementation that reads the same `.pre-commit-config.yaml`.

**All four config files are untouched**, no hook was added or removed, and Renovate keeps
managing hook versions from the same file. `uvx` stays the delivery mechanism, so there is
no new bootstrap step. This changes the runner, not the hook set.

## Two consequences — one gained, one that has to be asked for

### Gained: `fmt` no longer pins an interpreter

`uvx pre-commit` had to choose one to run pre-commit *itself* on, and a Rust or Go project
ships no `.python-version` — so the language-neutral half of the template rested on
`rhiza.mk`'s `PYTHON_VERSION` fallback resolving to something real. prek is a binary that
provisions each hook's toolchain itself, so the coupling is **removed rather than
satisfied**.

The two tests that asserted the old shape are **inverted, not deleted** — reintroducing
`-p` would quietly make the neutral half depend on `PYTHON_VERSION` again, so
`test_fmt_target_no_longer_needs_python_version` now fails if it comes back.

### Asked for: `--config .pre-commit-config.yaml`

prek treats every directory below the root holding a `.pre-commit-config.yaml` as a
separate **project** and runs each one's hooks. Useful in a monorepo; wrong here, where
`bundles/{python,rust,go}-core` each ship one as *template content*. Found by running it:

```
× bundles/go-core
  go vet...............................................................Failed
    pattern ./...: directory prefix . does not contain main module or its
    selected dependencies
```

`go-core` holds a starter `internal/version/version.go` and deliberately no `go.mod` — a
synced project brings its own — so its hooks cannot pass there. `rust-core` passed only
because its `types: [rust]` hooks matched no files, i.e. accidentally.

Naming the config explicitly disables discovery, so `make fmt` means what it meant before:
this repo's config, once. A consumer who wants the monorepo behaviour drops the flag.

> `.prekignore` is the documented mechanism for excluding directories from discovery and
> would have been tidier, but **prek 0.4.12 does not honour it** — tried at the root as
> `bundles/`, `bundles` and `/bundles/`; all three still discovered the projects. So the
> flag is what this relies on, and `quality.mk`'s comment records why rather than leaving
> the next reader to retry `.prekignore`.

## The CI job name is deliberately unchanged

The job keeps its id (`pre-commit`) and display name ("Pre-commit hooks") because that
name is a **required status check** in `.github/rulesets/main-branch-protection.json`.
Renaming it would leave every PR waiting on a context that never reports — the same hazard
#1474 documents for the `deptry` → `deps` rename. What the runner is called is a detail of
the recipe; what the check is called is a contract with branch protection.

Caches move to `~/.cache/prek`, key still hashing `.pre-commit-config.yaml` since prek
reads it. Four blocks across `rhiza_ci.yml` and `rhiza_e2e.yml`.

## Scope: this moves the template, not just this repo

Worth being explicit — `quality.mk` and the three layer fragments are **bundle files**, so
every downstream project switches on its next `/rhiza:update`. Because the mother repo
dogfoods its own bundles (root files are symlinks into `bundles/`), there is no way to move
only this repo. If you want a slower rollout, that is a reason to hold this PR rather than
something I can change within it.

## Verification

- `make fmt` — green, 22 hooks, through prek
- `make test` — 1417 passed, 1 skipped
- `RHIZA_E2E=1 pytest tests/e2e` — **38 passed**

The e2e run is the one that matters: it runs `fmt` and `install` for real on freshly
synced Python, Rust and Go projects, and asserts **per hook** rather than on the exit code
(`assert_hooks_passed` on cargo fmt, cargo clippy, Cargo.lock currency, markdownlint,
gofmt, go vet). A config prek silently stopped matching would show up there as skipped
hooks, not as a pass.

Also confirmed on the real repo that `default_language_version: node: "24.12.0"` is
honoured — markdownlint is a node hook and passes.

**One pre-existing failure, unrelated:** rust `coverage` fails on my machine with
`failed to find llvm-tools-preview`. Verified identical at `v1.3.1`; Homebrew's rustup
lacks the component. CI installs it.

## Docs

ADR 0009 is **amended, not rewritten** — the decision it records (hook-based enforcement,
this config format) still holds; only its execution changed. Plus `CLAUDE.md` (with the
`--config` and no-interpreter reasoning, since both are non-obvious), `TOOLS_REFERENCE`,
`SHELL_SCRIPTS`, `SECURITY_TESTING` and the GitLab `TESTING.md`.

## Not in scope

`prek install` is still duplicated verbatim across all three language layers — the same
smell #1471 removed for `rhiza-test`. Left alone here so this PR stays a runner swap;
worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
