### PR TITLE
fix: unify the unused-deps gate name, and stop a fresh Python repo's test gate being vacuous

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,4 +21,4 @@ Closes #<!-- issue number -->
 - [ ] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
 - [ ] `CHANGELOG.md` entry added (or not needed for this change)
 - [ ] Documentation updated if behaviour changed
-- [ ] `make deptry` passes (no unused or missing dependencies)
+- [ ] `make deps` passes (no unused or missing dependencies)

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -249,7 +249,7 @@ jobs:
           token: ${{ secrets.GH_PAT }}
 
       - name: Run deptry
-        run: make deptry
+        run: make deps
 
   pre-commit:
     name: Pre-commit hooks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Downstream projects adopt Rhiza by adding a `.rhiza/template.yml` that lists whi
 make install      # Full setup: installs uv, downloads Python version from .python-version, creates .venv, installs deps
 make test         # Run all tests with coverage (90% minimum required)
 make fmt          # Run all hooks via prek (ruff format/check, markdownlint, bandit, etc.)
-make deptry       # Check for unused/missing dependencies
+make deps         # Check for unused/missing dependencies
 make docs-coverage  # Check docstring coverage with interrogate (100% required)
 make typecheck    # Static type checking with pyright
 make benchmark    # Performance benchmarks
@@ -57,7 +57,7 @@ The core abstraction is the **bundle** — a named group of configuration files.
   `install` and no `all` — see **Language layers** below.
 - `python-core` (the Python **language layer**): `.python-version`, `ruff.toml`,
   `.bandit`, the pre-commit config, `pytest.ini`, and `.rhiza/make.d/python.mk`
-  (`install`, `all`, `deptry`, `license`, plus `test`, `typecheck`, `security` and
+  (`install`, `all`, `deps`, `license`, plus `test`, `typecheck`, `security` and
   `docs-coverage` — see **Language layers**). Ships no bump-my-version config — see
   **Where the version config lives**.
 - `rust-core` (the Rust **language layer**): `rust-toolchain.toml`, `rustfmt.toml`,
@@ -156,7 +156,16 @@ and tags itself so the changelog lands in the bump commit.
 | `docs-coverage` | interrogate (%) | `RUSTDOCFLAGS=-D missing_docs` (pass/fail) | revive `exported` rule (pass/fail) |
 | `security` | bandit + pip-audit | `cargo deny check advisories` | `govulncheck` |
 | `license` | pip-licenses | `cargo deny check licenses` | `go-licenses check` |
-| unused deps | `deptry` | `deps` → `cargo machete` | `deps` → `go mod tidy -diff` |
+| `deps` | `deptry` | `cargo machete` | `go mod tidy -diff` |
+
+Every row is a **shared target name** with a different engine behind it — including
+`deps`, which until #1474 was the one exception: python-core named it `deptry`, after the
+tool, so `make deps` failed on Python and `make deptry` on the other two. The tool-named
+`DEPTRY_FOLDERS`/`DEPTRY_IGNORE` variables stay, because they name deptry's *arguments*
+(marimo.mk appends `--ignore DEP004`) and are the accumulator interface a downstream
+`local.mk` writes to. `make deptry` survives as a deprecated alias that warns.
+`tests/bundles/test_bundle_sync.py::TestEveryLayerDefinesTheSameGateNames` now fails on
+the next divergence rather than documenting it.
 
 All three layers carry `test`/`coverage`/`typecheck` themselves. Python's used to live
 in the separate `tests` bundle, and that was a real inconsistency rather than a
@@ -188,6 +197,26 @@ file whatsoever, so the layer has to bring the first test itself. What it assert
 release invariant next door — that `Version` matches the shape `.bumpversion.toml`
 parses — never the literal shipped `0.0.0`, which bump-my-version rewrites in
 `version.go` and not in the test.
+
+**Two of the three layers ship a starter test, for the same reason.** Python had the
+identical hole (#1476): `make test` searches `TESTS_FOLDER` for `test_*.py`, and finding
+none it warns and **exits 0**, so a freshly synced Python repo passed `make test` — and
+`make all` — measuring nothing. Note that `.rhiza/tests` does not help, since it sits
+outside `TESTS_FOLDER` and runs under the separate `rhiza-test` gate. So `python-core`
+ships `tests/test_rhiza_packaging.py`, asserting that the version installed into the
+environment matches `[project].version` — a real invariant (it catches a stale editable
+install or a build backend pointed at the wrong tree), distinct from
+`test_pyproject.py`'s pyproject-versus-tag check, and one that skips cleanly on a repo
+with no distribution of its own, such as this one.
+
+Both layers' e2e assertions name the **shipped** file rather than the scaffold's own
+test, and that is the load-bearing part: `scaffolds.py` writes a test into every
+scaffold, so an item-count assertion stays green even if the layer ships no starter at
+all. That is precisely how the Go hole survived until #1467. The Python check reads the
+gate's HTML report rather than stdout, because `test` runs pytest under xdist, which
+prints a bare progress line and never names a file — and reading the report lets it
+require *Passed* rather than merely collected, since a silently skipped starter measures
+nothing either.
 
 Its `install` is also the thinnest of the
 three — go.mod's `go`/`toolchain` directives make the go command fetch a matching
@@ -236,7 +265,7 @@ The root `Makefile` is intentionally thin (~10 lines) and only `include`s `.rhiz
 | `.rhiza/make.d/` file | owner bundle | provides |
 | --- | --- | --- |
 | `bootstrap.mk` | core | `install-uv` tool bootstrap, install hooks, `clean` |
-| `python.mk` | python-core | `install`, `all`, `deptry`, `license`, and the pytest-backed gates |
+| `python.mk` | python-core | `install`, `all`, `deps`, `license`, and the pytest-backed gates |
 | `rust.mk` | rust-core | `install`, `all`, and the cargo-backed gates |
 | `go.mk` | go-core | `install`, `all`, and the go-backed gates |
 | `doctor.mk` | core | `make doctor` environment checks |

--- a/bundles/github/.github/pull_request_template.md
+++ b/bundles/github/.github/pull_request_template.md
@@ -21,4 +21,4 @@ Closes #<!-- issue number -->
 - [ ] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
 - [ ] `CHANGELOG.md` entry added (or not needed for this change)
 - [ ] Documentation updated if behaviour changed
-- [ ] `make deptry` passes (no unused or missing dependencies)
+- [ ] `make deps` passes (no unused or missing dependencies)

--- a/bundles/gitlab-tests/.gitlab/workflows/rhiza_ci.yml
+++ b/bundles/gitlab-tests/.gitlab/workflows/rhiza_ci.yml
@@ -68,7 +68,7 @@ ci:deptry:
   needs: []
   image: $UV_IMAGE
   script:
-    - make deptry
+    - make deps
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
     - if: $CI_COMMIT_BRANCH

--- a/bundles/gitlab/.gitlab/README.md
+++ b/bundles/gitlab/.gitlab/README.md
@@ -46,7 +46,7 @@ This directory contains GitLab CI/CD workflow configurations that mirror the fun
 - On merge requests to main/master
 
 **Key Features:**
-- Dependency checking with deptry (`make deptry`)
+- Dependency checking with deptry (`make deps`)
 - Pre-commit hooks for code formatting and linting (`make fmt`)
 - Documentation coverage validation (`make docs-coverage`)
 - Link checking on README.md with lychee

--- a/bundles/gitlab/.gitlab/workflows/rhiza_quality.yml
+++ b/bundles/gitlab/.gitlab/workflows/rhiza_quality.yml
@@ -16,7 +16,7 @@ quality:deptry:
   needs: []
   image: $UV_IMAGE
   script:
-    - make deptry
+    - make deps
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
     - if: $CI_COMMIT_BRANCH

--- a/bundles/python-core/.rhiza/make.d/python.mk
+++ b/bundles/python-core/.rhiza/make.d/python.mk
@@ -19,7 +19,7 @@
 # (benchmark, hypothesis-test, stress, mutation).
 
 # Declare phony targets (they don't produce files)
-.PHONY: all deptry docs-coverage install license security test test-pyproject typecheck
+.PHONY: all deps deptry docs-coverage install license security test test-pyproject typecheck
 
 # The project virtualenv, and the interpreter that fills it. PYTHON_VERSION is
 # declared in rhiza.mk (core needs a Python to run its own tooling on); here
@@ -97,7 +97,7 @@ install: pre-install install-uv ## install
 	@printf "${BLUE}To activate the virtual environment, run:${RESET}\n"
 	@printf "${YELLOW}  source ${VENV}/bin/activate${RESET}\n\n"
 
-all: fmt deptry test docs-coverage security license typecheck rhiza-test ## run all CI targets locally
+all: fmt deps test docs-coverage security license typecheck rhiza-test ## run all CI targets locally
 
 # deptry scans one or more folders for dependency issues. Each feature bundle
 # contributes the folders it owns to DEPTRY_FOLDERS (and any per-folder ignores
@@ -114,13 +114,31 @@ ifneq ($(wildcard $(SOURCE_FOLDER)),)
 DEPTRY_FOLDERS += $(SOURCE_FOLDER)
 endif
 
-deptry: install-uv ## Run deptry over the folders contributed by each bundle
+# Named `deps`, matching rust.mk and go.mk. This was the one gate whose *target name*
+# differed by language (#1474): `deptry` names the tool, which nothing else in the
+# contract does — pytest is `test`, mypy is `typecheck`, bandit is `security`. So
+# `make deps` used to fail on a Python project and `make deptry` on the other two, and
+# nothing language-neutral could invoke the gate without knowing the language first.
+#
+# The variables stay `DEPTRY_*`: they name the tool's *arguments*, honestly so —
+# marimo.mk appends `--ignore DEP004`, a deptry rule code — and they are the accumulator
+# interface a downstream local.mk writes to, so renaming them would break consumers for
+# nothing.
+deps: install-uv ## Run deptry over the folders contributed by each bundle
 	@if [ -n "$(strip $(DEPTRY_FOLDERS))" ]; then \
 		printf "${BLUE}[INFO] Running deptry on:${RESET} $(strip $(DEPTRY_FOLDERS))\n"; \
 		$(UVX_BIN) -p ${PYTHON_VERSION} deptry $(strip $(DEPTRY_FOLDERS) $(DEPTRY_IGNORE)); \
 	else \
 		printf "${YELLOW}[WARN] no deptry folders found, skipping.${RESET}\n"; \
 	fi
+
+# Deprecated alias. A downstream local.mk, a hand-written CI job or a contributor's
+# muscle memory all still call `make deptry`; a hard rename would break them at the
+# point where the gate simply stops existing. Warns rather than failing, and can go in
+# a future release once consumers have moved.
+deptry: ## deprecated alias for `deps`
+	@printf "${YELLOW}[WARN] \`make deptry\` is deprecated and will be removed; use \`make deps\`.${RESET}\n"
+	@$(MAKE) --no-print-directory deps
 
 license: install ## run license compliance scan (fail on GPL, LGPL, AGPL)
 	@printf "${BLUE}[INFO] Running license compliance scan...${RESET}\n"

--- a/bundles/python-core/tests/test_rhiza_packaging.py
+++ b/bundles/python-core/tests/test_rhiza_packaging.py
@@ -1,0 +1,97 @@
+"""The first test a freshly synced Python project has.
+
+This file flows down via a SYNC action from the jebel-quant/rhiza repository
+(https://github.com/jebel-quant/rhiza).
+
+**Why it exists.** Two reasons, and the second is the one that is easy to lose.
+
+It checks a real invariant: that the version the project *declares* in
+``pyproject.toml`` is the version actually installed into the environment. Those drift
+apart more often than anything else on a fresh checkout — an editable install left over
+from a rename, a `uv sync` that never ran, a package directory the build backend is not
+configured to pick up. Each shows up here as a mismatch rather than as a confusing
+ImportError three files later.
+
+And it is the only test a freshly synced project has. ``make test`` searches
+``TESTS_FOLDER`` for ``test_*.py``/``*_test.py``, and finding none it prints a warning
+and **exits 0** — so a new repo passed ``make test``, and therefore ``make all``, while
+measuring nothing (#1476). That was the third instance of one pattern: Go had it until
+``go-core`` shipped ``internal/version/version_test.go`` (#1467), and ``rhiza-test`` had
+it until the ``.rhiza/tests`` suite was actually delivered to every layer (#1469). Rust
+never did, because ``cargo init --lib`` leaves an ``it_works`` test behind.
+
+Writing your own tests alongside this is the point. Deleting it and shipping nothing
+else puts the vacuum back.
+
+**Why not simply fail when no tests exist?** Because that turns ``make all`` red on the
+output of ``/rhiza:init``, before the author has written a line. The warning branch is
+deliberate; what it needed was something to find.
+
+Deliberately self-contained: it uses no fixtures, because this lives in *your* ``tests/``
+directory and must not depend on the ``conftest.py`` that ships with ``.rhiza/tests``.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as installed_version
+from pathlib import Path
+
+import pytest
+
+# tests/ sits at the project root, so the parent of this file's directory is the root.
+#
+# `.absolute()`, never `.resolve()`. In a synced project the difference is nil, but in
+# rhiza's own repository this file is a *symlink* into `bundles/python-core/tests/`, and
+# `.resolve()` follows it — making the "project root" come out as `bundles/python-core`,
+# which has no pyproject.toml. The suite then skips for a plausible-looking wrong reason
+# instead of running. `.rhiza/tests/conftest.py` avoids the same trap the same way.
+_ROOT = Path(__file__).absolute().parent.parent
+
+
+def _project_table() -> dict:
+    """Return the ``[project]`` table from pyproject.toml, skipping when unusable.
+
+    Returns:
+        The parsed ``[project]`` table.
+    """
+    pyproject = _ROOT / "pyproject.toml"
+    if not pyproject.is_file():
+        pytest.skip("no pyproject.toml at the project root")
+    with pyproject.open("rb") as handle:
+        table = tomllib.load(handle).get("project")
+    if not isinstance(table, dict):
+        pytest.skip("pyproject.toml declares no [project] table")
+    return table
+
+
+def test_the_installed_version_matches_pyproject() -> None:
+    """The distribution installed in the environment must match the declared version.
+
+    Skips rather than fails when the project is not installed as a distribution at all —
+    a ``uv`` *virtual* project (no ``[build-system]``, ``source = {{ virtual = "." }}`` in
+    the lockfile) has no metadata to read, and rhiza's own repository is one. That is a
+    real configuration, not a broken one, so it is not this test's business.
+    """
+    project = _project_table()
+
+    name = project.get("name")
+    if not isinstance(name, str) or not name.strip():
+        pytest.skip("[project].name is missing or not a plain string")
+
+    declared = project.get("version")
+    if not isinstance(declared, str):
+        pytest.skip("[project].version is dynamic — there is no static value to compare")
+
+    try:
+        found = installed_version(name)
+    except PackageNotFoundError:
+        pytest.skip(f"{name!r} is not installed as a distribution (a virtual project has no metadata)")
+
+    assert found == declared, (
+        f"pyproject.toml declares version {declared!r} but the installed {name!r} reports "
+        f"{found!r}. The environment is stale or the build backend is picking up a different "
+        f"tree — re-run `make install`, and check [build-system] and the packages it is told "
+        f"to include if that does not fix it."
+    )

--- a/docs/guides/DEMO.md
+++ b/docs/guides/DEMO.md
@@ -47,7 +47,7 @@ make test
 make fmt
 
 # 5. Check dependencies
-make deptry
+make deps
 
 # 6. Check release status (releasing itself is driven by the rhiza-claude /release command)
 make release-status
@@ -93,7 +93,7 @@ sleep 2
 type_cmd "make fmt"
 sleep 2
 
-type_cmd "make deptry"
+type_cmd "make deps"
 sleep 2
 
 echo -e "\n\033[1;34mDemo complete!\033[0m"
@@ -183,7 +183,7 @@ https://user-images.githubusercontent.com/YOUR_ID/VIDEO_ID.mp4
 3. **Install** (10s) - `make install` showing fast uv setup
 4. **Test** (10s) - `make test` with coverage output
 5. **Format** (5s) - `make fmt` for linting
-6. **Quality** (5s) - `make deptry` for dependency check
+6. **Quality** (5s) - `make deps` for dependency check
 7. **Outro** (3s) - Summary message
 
 Total: ~45 seconds

--- a/docs/guides/QUICK_REFERENCE.md
+++ b/docs/guides/QUICK_REFERENCE.md
@@ -25,7 +25,7 @@ A concise reference for common Rhiza operations.
 | Command | Description |
 |---------|-------------|
 | `make fmt` | Format + lint with auto-fix |
-| `make deptry` | Check for unused/missing dependencies |
+| `make deps` | Check for unused/missing dependencies |
 | `make pre-commit` | Run all pre-commit hooks |
 
 ## Template Sync

--- a/docs/operations/CI_ENFORCEMENT.md
+++ b/docs/operations/CI_ENFORCEMENT.md
@@ -15,7 +15,7 @@ These fail the pull request when they fail. They run on every PR via
 | Format, lint, hooks | `make fmt` | ruff, markdownlint, bandit, actionlint, shellcheck, jsonschema, uv-lock. |
 | Type checking | `make typecheck` | `ty` + `mypy --strict` over the project's Python source (set `TYPECHECKER=ty` or `TYPECHECKER=mypy` to run only one). |
 | Tests | `make test`, `make rhiza-test` | Full suites; `rhiza-test` runs Rhiza's own `.rhiza/tests/` suite. |
-| Dependency hygiene | `make deptry` | Unused/missing dependency scan. |
+| Dependency hygiene | `make deps` | Unused/missing dependency scan. |
 | Docstring coverage | `make docs-coverage` | interrogate at 100%. |
 | Security | `make security` | pip-audit + bandit. |
 | CodeQL | `rhiza_codeql.yml` | Code scanning on PR and push. |

--- a/docs/reference/DEPENDENCIES.md
+++ b/docs/reference/DEPENDENCIES.md
@@ -141,7 +141,7 @@ When adding dependencies:
 1. **Research**: Check release notes for recent major versions
 2. **Constrain**: Use `>=X.Y,<(X+1).0` for major version pinning
 3. **Document**: Add inline comment explaining the purpose
-4. **Test**: Verify with `make test` and `make deptry`
+4. **Test**: Verify with `make test` and `make deps`
 5. **Update This Doc**: Add entry to this file explaining the constraint rationale
 
 ### Updating Dependencies

--- a/docs/reference/GLOSSARY.md
+++ b/docs/reference/GLOSSARY.md
@@ -208,7 +208,7 @@ A fast Python linter and formatter from Astral. Replaces flake8, isort, black, a
 A Python build backend used to create distribution packages (wheels and sdists). Invoked via `uv build`.
 
 ### Deptry
-A tool that checks for unused and missing dependencies in Python projects. Integrated in CI via `make deptry`.
+A tool that checks for unused and missing dependencies in Python projects. Integrated in CI via `make deps`.
 
 ### Bandit
 A security linter for Python code. Finds common security issues. Integrated in pre-commit and CI.
@@ -273,5 +273,5 @@ Workflow running security scans (pip-audit, bandit) on the codebase.
 | `make release-status` | Show release workflow status and latest release |
 | `make doctor` | Validate tools and environment — start here when something is wrong |
 | `make validate` | Validate project structure against `.rhiza/template.yml` |
-| `make deptry` | Check for unused/missing dependencies |
+| `make deps` | Check for unused/missing dependencies |
 | `make help` | Show all available targets |

--- a/docs/reference/TOOLS_REFERENCE.md
+++ b/docs/reference/TOOLS_REFERENCE.md
@@ -47,7 +47,7 @@ These are the commands you'll use most frequently:
 
 | Command | Description |
 |---------|-------------|
-| `make deptry` | Check for unused/missing dependencies |
+| `make deps` | Check for unused/missing dependencies |
 | `make pre-commit` | Run all pre-commit hooks |
 | `make typecheck` | Run type checking with ty |
 | `make security` | Run security scans (pip-audit and bandit) |
@@ -354,7 +354,7 @@ uv run bandit -r src/
 
 ```bash
 # Check for unused/missing dependencies
-make deptry
+make deps
 
 # Check for outdated packages
 uv pip list --outdated
@@ -719,7 +719,7 @@ PYTHON_VERSION = 3.12
 - Let uv handle Python version management (don't use pyenv/asdf)
 - Use `uv add` instead of manually editing `pyproject.toml`
 - Commit both `pyproject.toml` and `uv.lock` to git
-- Run `make deptry` regularly to check for unused dependencies
+- Run `make deps` regularly to check for unused dependencies
 
 ### Testing
 

--- a/tests/api/test_language_layer.py
+++ b/tests/api/test_language_layer.py
@@ -45,7 +45,7 @@ class TestPythonLayerProvidesTheContract:
         """`all` names the per-language gate set, so it belongs to the layer."""
         out = strip_ansi(run_make(logger, ["all"]).stdout)
         assert "prek run --all-files" in out  # fmt, from core
-        assert "deptry" in out  # deptry, from the layer
+        assert "deptry" in out  # `deps` runs deptry, from the layer
         assert "pip-licenses" in out  # license, from the layer
 
     @pytest.mark.parametrize("target", LANGUAGE_LAYER_TARGETS)

--- a/tests/api/test_make_variable_overrides.py
+++ b/tests/api/test_make_variable_overrides.py
@@ -133,7 +133,7 @@ class TestSourceFolderVariable:
         src_dir = tmp_path / "mypackage"
         src_dir.mkdir(exist_ok=True)
 
-        proc = run_make(logger, ["deptry", "SOURCE_FOLDER=mypackage"])
+        proc = run_make(logger, ["deps", "SOURCE_FOLDER=mypackage"])
         assert "mypackage" in proc.stdout, "deptry should reference SOURCE_FOLDER; got:\n" + proc.stdout[:400]
 
     def test_deptry_accumulates_marimo_and_source_in_one_call(self, logger, tmp_path) -> None:
@@ -145,7 +145,7 @@ class TestSourceFolderVariable:
         (tmp_path / "mypackage").mkdir(exist_ok=True)
         (tmp_path / "notebooks").mkdir(exist_ok=True)
 
-        proc = run_make(logger, ["deptry", "SOURCE_FOLDER=mypackage", "MARIMO_FOLDER=notebooks"])
+        proc = run_make(logger, ["deps", "SOURCE_FOLDER=mypackage", "MARIMO_FOLDER=notebooks"])
         out = strip_ansi(proc.stdout)
         # marimo.mk is included before quality.mk, so its folder is appended first.
         assert "deptry notebooks mypackage --ignore DEP004" in out, (

--- a/tests/api/test_makefile_targets.py
+++ b/tests/api/test_makefile_targets.py
@@ -42,7 +42,7 @@ class TestMakefile:
         assert "Usage:" in out
         assert "Targets:" in out
         # ensure a few known targets appear in the help index
-        for target in ["install", "fmt", "deptry", "test", "help"]:
+        for target in ["install", "fmt", "deps", "test", "help"]:
             assert target in out
 
     def test_help_target(self, logger):
@@ -115,7 +115,7 @@ class TestMakefile:
         env = os.environ.copy()
         env.pop("PYTHON_VERSION", None)
 
-        proc = run_make(logger, ["deptry"], env=env)
+        proc = run_make(logger, ["deps"], env=env)
 
         out = proc.stdout
         assert_uvx_command_uses_version(out, tmp_path, "deptry src")
@@ -315,6 +315,6 @@ class TestMakefileRootFixture:
             if split_path.exists():
                 content += "\n" + split_path.read_text(encoding="utf-8")
 
-        expected_targets = ["install", "fmt", "test", "deptry", "help"]
+        expected_targets = ["install", "fmt", "test", "deps", "help"]
         for target in expected_targets:
             assert f"{target}:" in content or f".PHONY: {target}" in content

--- a/tests/bundles/test_bundle_combinations.py
+++ b/tests/bundles/test_bundle_combinations.py
@@ -18,11 +18,20 @@ from packaging.requirements import Requirement
 
 from tests.util import sync_bundles
 
+# Keyed by CI *job* name, valued by the make target it runs. Two rows where those
+# deliberately disagree, both for the same reason — the job name is a contract with
+# branch protection, the target name is not:
+#
+#   deptry     → `make deps`  the gate was renamed in #1474 (it was the one target whose
+#                             name differed by language); the job keeps its name because
+#                             "Check dependencies with deptry" is a required status check
+#                             in .github/rulesets/main-branch-protection.json
+#   pre-commit → `make fmt`   the runner became prek, the job name did not change
 PARITY_JOB_COMMANDS = {
     "test": "make test",
     "docs-coverage": "make docs-coverage",
     "typecheck": "make typecheck",
-    "deptry": "make deptry",
+    "deptry": "make deps",
     "pre-commit": "make fmt",
     "security": "make security",
     "license": "make license",

--- a/tests/bundles/test_bundle_sync.py
+++ b/tests/bundles/test_bundle_sync.py
@@ -155,7 +155,7 @@ class TestPythonCoreBundleSync:
         to core's quality.mk in #1471 rather than existing identically in all three layers.
         """
         python_mk = (self.project / ".rhiza" / "make.d" / "python.mk").read_text(encoding="utf-8")
-        for target in ("install:", "all:", "deptry:", "license:"):
+        for target in ("install:", "all:", "deps:", "license:"):
             assert target in python_mk, f"python.mk is missing {target}"
         assert "rhiza-test:" not in python_mk, (
             "python.mk redefines rhiza-test, which core now owns — two recipes for one "
@@ -794,4 +794,45 @@ class TestALayersAllIsSatisfiableOnItsOwn:
             f"`make all` on core + {layer} names {missing}, which no synced fragment defines. "
             f"Either the layer must define them or they belong in core — a gate that only "
             f"resolves once another bundle happens to be selected is not part of the contract."
+        )
+
+
+class TestEveryLayerDefinesTheSameGateNames:
+    """The layers must agree on gate *names*, whatever engine backs each one.
+
+    The whole claim of the language-layer split is "same target names, different
+    recipes" — that is what lets book.mk, the CI workflows and the docs call a gate
+    without knowing the language. `deptry` was the one row that broke it (#1474):
+    python-core named the unused-dependency gate after the tool while rust-core and
+    go-core called it `deps`, so `make deps` failed on Python and `make deptry` on the
+    other two, and no language-neutral caller could invoke it at all.
+
+    CLAUDE.md documented the divergence, which is not the same as it being intended.
+    This test is why the next one fails instead of getting written down.
+    """
+
+    # Deliberately not `install`/`all` — `tests/api/test_language_layer.py` covers those
+    # behaviourally. These are the gates a caller reaches for by name.
+    GATES = ("test", "typecheck", "security", "docs-coverage", "license", "deps")
+
+    @pytest.mark.parametrize("gate", GATES)
+    def test_all_three_layers_define_the_gate(self, tmp_path, root, gate):
+        """Each gate name must be defined by every language layer."""
+        missing = []
+        for layer in ("python-core", "rust-core", "go-core"):
+            project = tmp_path / layer
+            sync_bundles(root, ["core", layer], project)
+            defined = {
+                line.split(":", 1)[0]
+                for fragment in (project / ".rhiza").rglob("*.mk")
+                for line in fragment.read_text(encoding="utf-8").splitlines()
+                if re.match(r"^[a-z][a-z0-9-]*::? ", line)
+            }
+            if gate not in defined:
+                missing.append(layer)
+
+        assert not missing, (
+            f"`{gate}` is not defined by {missing}. A gate the other layers provide under "
+            f"this name makes the contract language-specific: a caller has to know what the "
+            f"project is written in before it can run the gate."
         )

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -82,7 +82,7 @@ class Layer:
 #
 # marimo is left out of the Python set even though the `local` profile includes it:
 # the bundle ships marimo.mk but no notebooks, and marimo.mk appends
-# $(MARIMO_FOLDER) to DEPTRY_FOLDERS, so `make deptry` would be pointed at a
+# $(MARIMO_FOLDER) to DEPTRY_FOLDERS, so `make deps` would be pointed at a
 # folder no sync creates. A real consumer writes notebooks there; a scaffold has
 # none, and inventing some would test marimo rather than the language layer.
 PYTHON = Layer(

--- a/tests/e2e/test_python_layer_e2e.py
+++ b/tests/e2e/test_python_layer_e2e.py
@@ -55,23 +55,62 @@ def test_install_wires_up_the_pre_commit_hook(project: Project):
 
 
 def test_test_gate_runs_pytest_and_writes_the_reports_book_mk_reads(project: Project, logger):
-    """The scaffold's one test runs, and coverage lands where the docs badge looks.
+    """The scaffold's test runs, and coverage lands where the docs badge looks.
 
     Also the check that book.mk's no-op `test::` default has not swallowed the
     real one: both rules are defined here (book is synced), so an accidental
     single-colon rule in either file would make this fail rather than run nothing.
     """
     out = gate(project, "test", logger)
-    # `[1 item]` rather than "collected 1 item": test.mk runs pytest under xdist,
-    # which replaces the collection line with "N workers [1 item]".
-    assert "[1 item]" in out, f"pytest did not collect the scaffold's test:\n{out}"
-    assert "1 passed" in out, f"pytest did not report a passing test:\n{out}"
+    # Two items: the scaffold's own test plus the starter the layer ships (#1476).
+    # `[2 items]` rather than "collected 2 items": test.mk runs pytest under xdist,
+    # which replaces the collection line with "N workers [2 items]".
+    assert "[2 items]" in out, f"pytest did not collect both tests:\n{out}"
+    assert "2 passed" in out, f"pytest did not report both tests passing:\n{out}"
 
     coverage_xml = project.path / "_tests" / "coverage.xml"
     assert coverage_xml.is_file(), "`make test` did not write _tests/coverage.xml"
     assert line_rate(coverage_xml) == pytest.approx(1.0), "the scaffold is meant to be fully covered"
     assert (project.path / "_tests" / "html-coverage").is_dir()
     assert (project.path / "_tests" / "html-report" / "report.html").is_file()
+
+
+def test_the_layer_brings_its_own_test_so_a_fresh_repo_tests_something(project: Project, logger):
+    """The layer's own starter test runs — not just the scaffold's (#1476).
+
+    This is the gate's vacuity check, and it has to name the *shipped* file. `make test`
+    short-circuits on an empty `tests/` with a warning and exit 0, so a fresh Python repo
+    passed `make test` — and `make all` — while measuring nothing. The scaffold writes its
+    own `tests/test_greeting.py`, which means the sibling test above would stay green even
+    if python-core shipped no starter at all.
+
+    That is exactly how the Go instance of this survived until #1467: the scaffold's
+    `greeting_test.go` masked it until the assertion was repointed at the bundle's own
+    `internal/version` package. Asserting on `test_rhiza_packaging.py` is the Python
+    equivalent — drop it from the layer and this fails.
+
+    Read from the HTML report rather than from stdout, because `test` runs pytest under
+    xdist (`-n auto`), which replaces per-file output with a bare progress line: the
+    filename never appears in the console at all. The report is written by the same gate
+    and records each test id with its outcome, so this can require **Passed** rather than
+    merely collected — a starter that silently skipped would satisfy the item count and
+    still measure nothing.
+    """
+    gate(project, "test", logger)
+
+    assert (project.path / "tests" / "test_rhiza_packaging.py").is_file(), (
+        "python-core no longer ships a starter test, so a fresh repo's `tests/` is empty "
+        "and `make test` short-circuits with a warning and exit 0"
+    )
+
+    report = (project.path / "_tests" / "html-report" / "report.html").read_text(encoding="utf-8")
+    assert "test_rhiza_packaging.py::test_the_installed_version_matches_pyproject" in report, (
+        "the starter test was not collected by `make test`"
+    )
+    # The report embeds its data as HTML-escaped JSON, hence the entity-quoted needle.
+    assert "&#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_rhiza_packaging.py" in report, (
+        "the starter test did not pass — a skip here means it measured nothing, which is the vacuum #1476 was about"
+    )
 
 
 def test_docs_coverage_gate_reaches_100_percent(project: Project, logger):
@@ -101,7 +140,7 @@ def test_license_gate_accepts_a_permissive_dependency_set(project: Project, logg
 
 def test_deptry_gate_finds_no_dependency_problems(project: Project, logger):
     """Deptry runs on the folders the synced bundles contribute, and is clean."""
-    out = gate(project, "deptry", logger)
+    out = gate(project, "deps", logger)
     assert "Running deptry on:" in out
 
 
@@ -144,8 +183,8 @@ def test_all_runs_the_whole_gate_set(project: Project, logger):
     # so the evidence is a line only one of them emits.
     for gate_name, evidence in (
         ("fmt", "ruff format"),
-        ("deptry", "Running deptry on:"),
-        ("test", "[1 item]"),
+        ("deps", "Running deptry on:"),
+        ("test", "[2 items]"),  # the scaffold's test plus the layer's starter (#1476)
         ("docs-coverage", "Checking documentation coverage in:"),
         ("security", "Running bandit security scan"),
         ("license", "Running license compliance scan"),

--- a/tests/test_rhiza_packaging.py
+++ b/tests/test_rhiza_packaging.py
@@ -1,0 +1,1 @@
+../bundles/python-core/tests/test_rhiza_packaging.py


### PR DESCRIPTION
Closes #1474 and #1476. They share `CLAUDE.md` and `python.mk`, so one PR rather than a stack.

## `deptry` → `deps` (#1474)

The one gate whose *target name* differed by language — `make deps` failed on Python, `make deptry` on the other two, so nothing language-neutral could invoke it without knowing the language first. `deptry` also leaks a tool name into a contract where nothing else does (pytest is `test`, mypy is `typecheck`).

- **`deptry` survives as a deprecated alias** that warns and delegates. A downstream `local.mk`, a hand-written CI job or muscle memory all still call it; a hard rename breaks them exactly where the gate stops existing.
- **`DEPTRY_FOLDERS`/`DEPTRY_IGNORE` keep their names.** They name the tool's *arguments* (marimo.mk appends `--ignore DEP004`, a deptry rule code) and are the accumulator interface a downstream `local.mk` writes to.
- **Only the invoked command changes in CI.** The GitHub job keeps its id and display name ("Check dependencies with deptry") because that name is a **required status check**; renaming it would leave every PR waiting on a context that never reports. `PARITY_JOB_COMMANDS` now documents the two rows where job name and target name deliberately disagree — this one, and `pre-commit` → `make fmt` after the prek move.

`TestEveryLayerDefinesTheSameGateNames` is the guard the issue asked for: six shared gate names × three layers, so the next divergence fails instead of being written down. Confirmed non-vacuous by running its logic against a `python.mk` with `deps` renamed back — it reports python-core missing.

## A fresh Python repo now tests something (#1476)

`make test` searches `TESTS_FOLDER`, and finding nothing warns and exits **0** — so a fresh repo passed `make test` and `make all` while measuring nothing. Third instance of one pattern, after Go (#1467) and `rhiza-test` (#1469). `.rhiza/tests` doesn't help: it sits outside `TESTS_FOLDER` and runs under a separate gate.

`python-core` now ships `tests/test_rhiza_packaging.py`, asserting the **installed** version matches `[project].version` — a real invariant (catches a stale editable install, or a build backend pointed at the wrong tree), distinct from `test_pyproject.py`'s pyproject-versus-tag check, and skipping cleanly where there's no distribution, as in this repo. A placeholder `assert True` would satisfy the gate while restoring the vacuum in spirit.

Two things caught by running it rather than by review:

- **`.absolute()`, never `.resolve()`.** Here the file is a dogfood *symlink* into `bundles/python-core`, and `.resolve()` follows it — so the project root came out as the bundle dir, which has no `pyproject.toml`, and the test skipped for a plausible-looking wrong reason. `.rhiza/tests/conftest.py` avoids the same trap the same way.
- **The e2e assertion names the shipped file, and reads the HTML report.** `scaffolds.py` writes a test into every scaffold, so an item-count assertion stays green even if the layer ships no starter — exactly how the Go hole survived to #1467. Reading the report (rather than stdout, which under xdist never names a file) also lets it require *Passed* rather than merely collected, since a silently skipped starter measures nothing either.

## Verification

- `make fmt` green
- `make test` — 1425 passed, 2 skipped
- `RHIZA_E2E=1 pytest tests/e2e` — **39 passed**

The Rust `coverage` failure that dogged this whole session turned out **not** to be a template bug: Homebrew's `rust` formula was shadowing rustup's shims, so `cargo` resolved to a sysroot with no `llvm-tools`. With `/opt/homebrew/opt/rustup/bin` first on PATH the suite is fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)