### PR TITLE
fix(deps): bump rhiza-hooks to v1.1.0 and enable the Rust/Go consistency hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,7 +99,7 @@ repos:
         files: ^src/
 
   - repo: https://github.com/Jebel-Quant/rhiza-hooks
-    rev: v0.7.1  # Use the latest release
+    rev: v1.1.0  # Use the latest release
     hooks:
       # Migrated from rhiza
       - id: check-rhiza-workflow-names

--- a/bundles/go-core/.pre-commit-config.yaml
+++ b/bundles/go-core/.pre-commit-config.yaml
@@ -89,11 +89,17 @@ repos:
       - id: betterleaks
 
   - repo: https://github.com/Jebel-Quant/rhiza-hooks
-    rev: v0.7.1  # Use the latest release
+    rev: v1.1.0  # Use the latest release
     hooks:
       - id: check-rhiza-workflow-names
       - id: update-readme-help
       - id: check-rhiza-config
       - id: check-makefile-targets
+      # Fails when `.go-version` is below go.mod's `go` directive. This layer ships no
+      # `.go-version` — go.mod's directives are the source of truth here — so the hook is
+      # dormant until a consumer adds one, which many do for `actions/setup-go`. Enabled
+      # anyway: it costs nothing while absent and guards the mismatch the moment the file
+      # appears, which is exactly when nobody is looking for it.
+      - id: check-go-version-consistency
       # check-python-version-consistency is deliberately absent: there is no
       # .python-version in a Go repo for it to reconcile.

--- a/bundles/python-core/.pre-commit-config.yaml
+++ b/bundles/python-core/.pre-commit-config.yaml
@@ -88,7 +88,7 @@ repos:
         files: ^src/
 
   - repo: https://github.com/Jebel-Quant/rhiza-hooks
-    rev: v0.7.1  # Use the latest release
+    rev: v1.1.0  # Use the latest release
     hooks:
       # Migrated from rhiza
       - id: check-rhiza-workflow-names

--- a/bundles/rust-core/.pre-commit-config.yaml
+++ b/bundles/rust-core/.pre-commit-config.yaml
@@ -83,11 +83,18 @@ repos:
       - id: betterleaks
 
   - repo: https://github.com/Jebel-Quant/rhiza-hooks
-    rev: v0.7.1  # Use the latest release
+    rev: v1.1.0  # Use the latest release
     hooks:
       - id: check-rhiza-workflow-names
       - id: update-readme-help
       - id: check-rhiza-config
       - id: check-makefile-targets
+      # Fails when rust-toolchain.toml's channel is *below* Cargo.toml's
+      # `[package].rust-version`, which is genuinely unbuildable. It does not demand the
+      # two be equal — they are different promises, as rust-toolchain.toml's own comment
+      # says — so this does not contradict the layer's stance on MSRV. Dormant on the
+      # shipped `channel = "stable"`, which has no concrete version to compare; it starts
+      # working the moment a consumer pins one.
+      - id: check-rust-version-consistency
       # check-python-version-consistency is deliberately absent: there is no
       # .python-version in a Rust repo for it to reconcile.


### PR DESCRIPTION
Closes #1480.

## The diagnosis in #1480 was wrong, and the correction matters

Renovate is **not** failing to detect this. Its dependency dashboard (#2) carries both:

```
- [ ] chore(deps): update pre-commit hook jebel-quant/rhiza-hooks to v0.8.0
- [ ] chore(deps): update pre-commit hook jebel-quant/rhiza-hooks to v1
```

…under **Pending Approval**. The manager is working; the updates were parked waiting for a human to tick a box. Not a config bug — a workflow one. Nothing in `renovate.json` needed changing, and rhiza-hooks is public, so neither cause the issue speculated about applied.

Worth deciding separately whether these should require approval at all, but that's a Renovate-policy question, not this bump.

## The bump

v0.7.1 → v1.1.0 across all four configs. Safe to take: v1.0.0 went from nine hooks to twelve, v1.1.0 added a CLI — both purely additive. All five ids this repo uses still exist, and every hook passes at the new rev (`make fmt` green).

## The two hooks the Rust and Go layers weren't using

**Both tested against real synced projects before enabling.** A hook's name isn't evidence that it does anything, and this session has already spent time on three separate gates that passed while measuring nothing.

### `check-rust-version-consistency` — a real guard

Fails when `rust-toolchain.toml`'s channel is *below* `Cargo.toml`'s `[package].rust-version`:

```
channel 1.70.0 < rust-version 1.90 → exit 1
  ERROR: Rust version mismatch: rust-toolchain.toml pins channel 1.70.0, but Cargo.toml
  [package] rust-version is 1.90 (the pinned toolchain must be at least the MSRV)
```

The thing worth checking was whether it demands the two be **equal** — it doesn't. Channel `1.85.0` against `rust-version 1.70` passes, so it doesn't contradict `rust-toolchain.toml`'s own comment that MSRV is *"a different promise"* from the development toolchain. Had it insisted on equality, enabling it would have fought the layer's documented stance.

### `check-go-version-consistency` — a real guard, currently dormant

Fails when `.go-version` is below go.mod's `go` directive (verified with 1.21 against `go 1.23`). But **go-core ships no `.go-version`** — go.mod's directives are the source of truth there — so on a fresh Go project the hook has nothing to compare and passes.

Enabled anyway, and the config comment says why: it costs nothing while the file is absent, and guards the mismatch the moment a consumer adds one for `actions/setup-go` — precisely when nobody is watching for it. The comment matters so the next reader doesn't mistake a dormant hook for a working one.

### Left alone

`check-managed-files` refuses edits to template-owned files — a policy decision for consumers, not something the template should impose on itself. `check-bumpversion-config` and `check-template-bundles` stay commented out with their existing reasons.

## Verification

- `make fmt` green at the new rev
- `make test` — 1417 passed, 1 skipped
- Rust and Go e2e `fmt`/`install` gates pass on freshly synced projects, so the two new hooks are clean on a fresh sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)