### PR TITLE
fix(devcontainer): stop defaulting UV_SYNC_ARGS to a `lint` group

### DIFF
--- a/bundles/devcontainer/.devcontainer/bootstrap.sh
+++ b/bundles/devcontainer/.devcontainer/bootstrap.sh
@@ -52,9 +52,11 @@ export UV_LINK_MODE=copy
 # Add to current PATH so subsequent commands can find uv
 export PATH="$INSTALL_DIR:$PATH"
 
-# Default to a lightweight dependency set in devcontainers.
+# Default to a lightweight dependency set in devcontainers. Only `test` is named: a
+# `lint` group would make `uv sync` fail outright on the projects that no longer declare
+# one, and it had nothing to install anyway — prek/uvx provision every linter.
 # Override with UV_SYNC_ARGS to install different groups.
-export UV_SYNC_ARGS="${UV_SYNC_ARGS:---group lint --group test}"
+export UV_SYNC_ARGS="${UV_SYNC_ARGS:---group test}"
 
 # Install dependencies with recovery options
 echo "📦 Installing project dependencies..."


### PR DESCRIPTION
## The bug

`bundles/devcontainer/.devcontainer/bootstrap.sh` defaults to:

```sh
export UV_SYNC_ARGS="${UV_SYNC_ARGS:---group lint --group test}"
```

`uv sync` **errors outright** on an undeclared group rather than ignoring it, so in any downstream project that has dropped `lint`, `make install` fails and the `onCreateCommand` takes the whole devcontainer down with it. That is now most of them — the sweep following #1484 removes the group from `futures`, `linalg`, `trends`, `basanos`, `jquantstats` and `shrinkage`.

## Why the group was empty anyway

python-core provisions every linter where it is used: prek for the ruff hooks in `fmt`, `--with ty`/`--with mypy` in `typecheck`, `--with interrogate` in `docs-coverage`. Nothing ever resolved a linter from a project's environment — which is precisely why #1484 removed the shipped `test_pyproject.py` check that required the group to be declared. The mother repo could satisfy that check only with a literal `lint = []`, making it a test of convention rather than of a working project.

## Fix

Default to `--group test` alone. It keeps the lightweight-install intent (the reason the override exists), and `test` is the one group the pyproject gate still requires, so it is valid in every project the bundle can land in. `UV_SYNC_ARGS` remains the override for anyone who wants more.

## Verification

`bash -n` clean; `shellcheck` passes via prek; the devcontainer bundle tests in `tests/bundles/` pass (11 selected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)