### PR TITLE
chore(deps): bump rhiza-hooks to v1.2.0 and correct the disabled-hook comments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,7 +99,7 @@ repos:
         files: ^src/
 
   - repo: https://github.com/Jebel-Quant/rhiza-hooks
-    rev: v1.1.0  # Use the latest release
+    rev: v1.2.0  # Use the latest release
     hooks:
       # Migrated from rhiza
       - id: check-rhiza-workflow-names
@@ -108,9 +108,14 @@ repos:
       - id: check-rhiza-config
       - id: check-makefile-targets
       - id: check-python-version-consistency
-      # check-bumpversion-config asserts that bump-my-version can actually discover
-      # this repo's version config (issue #1453). Enable it once rhiza-hooks ships a
-      # release containing it — v0.7.1 does not. Until then .rhiza/tests/test_pyproject.py
-      # enforces the same invariant, one gate later.
+      # check-bumpversion-config asserts that bump-my-version can actually discover this
+      # repo's version config (issue #1453) — here, the [tool.bumpversion] table in
+      # pyproject.toml. It ships as of v1.1.0 and passes on this repo; it stays off only
+      # because .rhiza/tests/test_pyproject.py already enforces the same invariant one
+      # gate later, so enabling it buys an earlier failure, not a new one.
       # - id: check-bumpversion-config
+      # check-template-bundles validates a *consumer's* .rhiza/template.yml against the
+      # template repo's remote bundle list. The mother repo has no template.yml — it is
+      # the template — so the hook is inert here. Disabled in #660 (rhiza-hooks 0.3.0)
+      # with no reason recorded.
       # - id: check-template-bundles

--- a/bundles/go-core/.pre-commit-config.yaml
+++ b/bundles/go-core/.pre-commit-config.yaml
@@ -89,7 +89,7 @@ repos:
       - id: betterleaks
 
   - repo: https://github.com/Jebel-Quant/rhiza-hooks
-    rev: v1.1.0  # Use the latest release
+    rev: v1.2.0  # Use the latest release
     hooks:
       - id: check-rhiza-workflow-names
       - id: update-readme-help

--- a/bundles/python-core/.pre-commit-config.yaml
+++ b/bundles/python-core/.pre-commit-config.yaml
@@ -88,7 +88,7 @@ repos:
         files: ^src/
 
   - repo: https://github.com/Jebel-Quant/rhiza-hooks
-    rev: v1.1.0  # Use the latest release
+    rev: v1.2.0  # Use the latest release
     hooks:
       # Migrated from rhiza
       - id: check-rhiza-workflow-names
@@ -97,9 +97,14 @@ repos:
       - id: check-rhiza-config
       - id: check-makefile-targets
       - id: check-python-version-consistency
-      # check-bumpversion-config asserts that bump-my-version can actually discover
-      # this repo's version config (issue #1453). Enable it once rhiza-hooks ships a
-      # release containing it — v0.7.1 does not. Until then .rhiza/tests/test_pyproject.py
-      # enforces the same invariant, one gate later.
+      # check-bumpversion-config asserts that bump-my-version can actually discover the
+      # project's version config (issue #1453) — for this layer, the [tool.bumpversion]
+      # table in pyproject.toml, since python-core deliberately ships no .bumpversion.toml.
+      # It ships as of v1.1.0; it stays off because the .rhiza/tests/test_pyproject.py this
+      # layer also ships enforces the same invariant one gate later.
       # - id: check-bumpversion-config
+      # check-template-bundles validates .rhiza/template.yml against the template repo's
+      # remote bundle list, so it fires only when that file is staged — and unlike in the
+      # mother repo (which has no template.yml) it is live in a synced project. Disabled in
+      # #660 (rhiza-hooks 0.3.0) with no reason recorded.
       # - id: check-template-bundles

--- a/bundles/rust-core/.pre-commit-config.yaml
+++ b/bundles/rust-core/.pre-commit-config.yaml
@@ -83,7 +83,7 @@ repos:
       - id: betterleaks
 
   - repo: https://github.com/Jebel-Quant/rhiza-hooks
-    rev: v1.1.0  # Use the latest release
+    rev: v1.2.0  # Use the latest release
     hooks:
       - id: check-rhiza-workflow-names
       - id: update-readme-help


### PR DESCRIPTION
## Summary

Bumps the `rhiza-hooks` pin from `v1.1.0` to `v1.2.0` everywhere it appears, and
replaces a stale comment that told future readers something no longer true.

The hook-id manifest is **byte-identical** between v1.1.0 and v1.2.0, so no gate
changes behaviour in this repo or downstream. Upstream the release is internal to
rhiza-hooks (its own suite now runs under prek, dependency-group pruning) plus one
bug fix — and it **reverts the `render-precommit` console script that v1.1.0
introduced** (Jebel-Quant/rhiza-hooks#333), which matters to anyone who was about
to pin that CLI.

## Changes

- Bump `rev: v1.1.0` → `v1.2.0` in all four `.pre-commit-config.yaml` files: the
  mother-repo override plus the `python-core`, `rust-core` and `go-core` layer
  templates.
- Correct the comment guarding the two commented-out hooks, in the two files that
  carry it (root and `bundles/python-core`; the Rust and Go layers never had the
  block). Both hooks stay disabled — only the rationale changes:
  - **`check-bumpversion-config`** — the old comment claimed it was not yet shipped
    ("v0.7.1 does not"). It has shipped since v1.1.0, and I confirmed it passes on
    this repo by temporarily enabling it. It stays off for the real reason:
    `.rhiza/tests/test_pyproject.py` already enforces the same invariant one gate
    later, so enabling it buys an earlier failure, not a new one.
  - **`check-template-bundles`** — had no comment at all. It fires only on a staged
    `.rhiza/template.yml`, so it is structurally inert in the mother repo (which has
    no `template.yml` — it *is* the template) and live only in a synced project. The
    python-core copy notes that difference. Git blame records no reason for its
    disabling in #660 (rhiza-hooks 0.3.0), so the comment says that rather than
    inventing one.

## Testing

- [x] `make test` passes locally — 1417 passed, 43 skipped (opt-in e2e + Docker GitLab)
- [x] `make fmt` has been run
- [x] New tests added (or explain why not needed) — not needed: no test pins the
      rhiza-hooks rev, and the change is a pin bump plus comment prose.
      `tests/bundles/` (636 passed) covers the bundle-sync invariants these files
      participate in.

## Checklist

- [x] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `CHANGELOG.md` entry added (or not needed for this change) — not needed, git-cliff generates it at release
- [x] Documentation updated if behaviour changed — no behaviour change; the comment correction *is* the doc fix
- [x] `make deps` passes (no unused or missing dependencies) — unaffected, no dependency touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
