### PR TITLE
fix(hooks): pin prek's config in the installed git shim, not just in `fmt`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,7 +316,7 @@ Hook targets use double-colon syntax (`pre-install::`, `post-install::`) and can
 >   because prek bakes `--config` into the git shim it generates. Passing it only to
 >   `run` fixed the gate and left the *hook* unpinned, so `git commit` ran a different
 >   set of hooks than `make fmt` — and in this repo failed outright on the nested
->   go-core config. The two halves are one invariant, so
+>   go-core config (#1488). The two halves are one invariant, so
 >   `test_both_prek_entry_points_name_the_config` asserts them together, per layer. A
 >   consumer wanting prek's monorepo behaviour drops the flag from *both* places.
 > - **`fmt` no longer pins an interpreter.** `uvx pre-commit` needed one to run

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,6 +312,13 @@ Hook targets use double-colon syntax (`pre-install::`, `post-install::`) and can
 >   `go.mod` — because a synced project brings its own — and `make fmt` fails on the
 >   mother repo. `.prekignore` is documented for this job but is not honoured by prek
 >   0.4.12.
+> - **Every layer's `install` repeats it as `prek install -c .pre-commit-config.yaml`**,
+>   because prek bakes `--config` into the git shim it generates. Passing it only to
+>   `run` fixed the gate and left the *hook* unpinned, so `git commit` ran a different
+>   set of hooks than `make fmt` — and in this repo failed outright on the nested
+>   go-core config. The two halves are one invariant, so
+>   `test_both_prek_entry_points_name_the_config` asserts them together, per layer. A
+>   consumer wanting prek's monorepo behaviour drops the flag from *both* places.
 > - **`fmt` no longer pins an interpreter.** `uvx pre-commit` needed one to run
 >   pre-commit itself on, so a Rust or Go repo — which ships no `.python-version` — rested
 >   on `rhiza.mk`'s `PYTHON_VERSION` fallback. prek is a binary that provisions each

--- a/bundles/devcontainer/.devcontainer/bootstrap.sh
+++ b/bundles/devcontainer/.devcontainer/bootstrap.sh
@@ -79,11 +79,16 @@ else
 fi
 
 # Initialize pre-commit hooks if configured with fallback
+#
+# prek, and `-c`, to match what `make install` and `make fmt` do. This installed a
+# `pre-commit` shim until now — a leftover from the runner swap (ADR 0009) — so a
+# devcontainer got a commit-time gate driven by a different runner than the one its
+# `make fmt` uses, and pulled the Python pre-commit package to do it.
 if [ -f .pre-commit-config.yaml ]; then
     echo "🔧 Setting up pre-commit hooks..."
-    if ! "$UVX_BIN" pre-commit install 2>/dev/null; then
+    if ! "$UVX_BIN" prek install -c .pre-commit-config.yaml 2>/dev/null; then
         echo "⚠️  WARNING: Pre-commit hook installation failed (non-critical)"
-        echo "   You can manually install later with: uvx pre-commit install"
+        echo "   You can manually install later with: uvx prek install"
         echo "   Continuing with bootstrap..."
     else
         echo "✓ Pre-commit hooks configured successfully"

--- a/bundles/go-core/.rhiza/make.d/go.mk
+++ b/bundles/go-core/.rhiza/make.d/go.mk
@@ -67,12 +67,17 @@ install: pre-install ## install the toolchain and download dependencies
 
 	# Install pre-commit hooks (skip when core.hooksPath is set, e.g. by an
 	# external hook manager — pre-commit refuses to install in that case)
+	#
+	# `-c` for the reason quality.mk's `fmt` passes `--config`, and it must be repeated
+	# here: prek bakes the flag into the generated shim, so without it the commit-time
+	# gate rediscovers nested projects and stops meaning what `make fmt` means. A
+	# consumer who wants prek's monorepo behaviour drops the flag from both places.
 	@if [ -f ".pre-commit-config.yaml" ]; then \
 	  if [ -n "$$(git config --get core.hooksPath 2>/dev/null)" ]; then \
 	    printf "${BLUE}[INFO] Skipping pre-commit hook install: core.hooksPath is set${RESET}\n"; \
 	  else \
 	    printf "${BLUE}[INFO] Installing pre-commit hooks...${RESET}\n"; \
-	    ${UVX_BIN} prek install || { printf "${YELLOW}[WARN] Failed to install pre-commit hooks${RESET}\n"; }; \
+	    ${UVX_BIN} prek install -c .pre-commit-config.yaml || { printf "${YELLOW}[WARN] Failed to install pre-commit hooks${RESET}\n"; }; \
 	  fi; \
 	fi
 

--- a/bundles/python-core/.rhiza/make.d/python.mk
+++ b/bundles/python-core/.rhiza/make.d/python.mk
@@ -81,12 +81,17 @@ install: pre-install install-uv ## install
 
 	# Install pre-commit hooks (skip when core.hooksPath is set, e.g. by an
 	# external hook manager — pre-commit refuses to install in that case)
+	#
+	# `-c` for the reason quality.mk's `fmt` passes `--config`, and it must be repeated
+	# here: prek bakes the flag into the generated shim, so without it the commit-time
+	# gate rediscovers nested projects and stops meaning what `make fmt` means. A
+	# consumer who wants prek's monorepo behaviour drops the flag from both places.
 	@if [ -f ".pre-commit-config.yaml" ]; then \
 	  if [ -n "$$(git config --get core.hooksPath 2>/dev/null)" ]; then \
 	    printf "${BLUE}[INFO] Skipping pre-commit hook install: core.hooksPath is set${RESET}\n"; \
 	  else \
 	    printf "${BLUE}[INFO] Installing pre-commit hooks...${RESET}\n"; \
-	    ${UVX_BIN} prek install || { printf "${YELLOW}[WARN] Failed to install pre-commit hooks${RESET}\n"; }; \
+	    ${UVX_BIN} prek install -c .pre-commit-config.yaml || { printf "${YELLOW}[WARN] Failed to install pre-commit hooks${RESET}\n"; }; \
 	  fi; \
 	fi
 

--- a/bundles/rust-core/.rhiza/make.d/rust.mk
+++ b/bundles/rust-core/.rhiza/make.d/rust.mk
@@ -67,12 +67,17 @@ install: pre-install ## install the toolchain and fetch dependencies
 
 	# Install pre-commit hooks (skip when core.hooksPath is set, e.g. by an
 	# external hook manager — pre-commit refuses to install in that case)
+	#
+	# `-c` for the reason quality.mk's `fmt` passes `--config`, and it must be repeated
+	# here: prek bakes the flag into the generated shim, so without it the commit-time
+	# gate rediscovers nested projects and stops meaning what `make fmt` means. A
+	# consumer who wants prek's monorepo behaviour drops the flag from both places.
 	@if [ -f ".pre-commit-config.yaml" ]; then \
 	  if [ -n "$$(git config --get core.hooksPath 2>/dev/null)" ]; then \
 	    printf "${BLUE}[INFO] Skipping pre-commit hook install: core.hooksPath is set${RESET}\n"; \
 	  else \
 	    printf "${BLUE}[INFO] Installing pre-commit hooks...${RESET}\n"; \
-	    ${UVX_BIN} prek install || { printf "${YELLOW}[WARN] Failed to install pre-commit hooks${RESET}\n"; }; \
+	    ${UVX_BIN} prek install -c .pre-commit-config.yaml || { printf "${YELLOW}[WARN] Failed to install pre-commit hooks${RESET}\n"; }; \
 	  fi; \
 	fi
 

--- a/tests/api/test_language_layer.py
+++ b/tests/api/test_language_layer.py
@@ -26,6 +26,13 @@ from tests.util import run_make, setup_rhiza_git_repo, strip_ansi
 # must keep — the classes below assert it for `python-core` and `rust-core` alike.
 LANGUAGE_LAYER_TARGETS = ("install", "all")
 
+# Both prek entry points and the exact flag each must carry. `fmt` is core's, `install` is
+# the layer's, and they have to agree — see the test that consumes this.
+PREK_CONFIG_INVOCATIONS = (
+    ("fmt", "prek run --all-files --config .pre-commit-config.yaml"),
+    ("install", "prek install -c .pre-commit-config.yaml"),
+)
+
 
 class TestPythonLayerProvidesTheContract:
     """The `python-core` layer defines the target names the rest of the template calls."""
@@ -53,6 +60,22 @@ class TestPythonLayerProvidesTheContract:
         """A missing layer target would surface as 'no rule to make target'."""
         proc = run_make(logger, [target])
         assert "no rule to make target" not in proc.stderr.lower()
+
+    @pytest.mark.parametrize(("target", "expected"), PREK_CONFIG_INVOCATIONS)
+    def test_both_prek_entry_points_name_the_config(self, logger, target, expected):
+        """The commit-time gate has to mean what `make fmt` means.
+
+        Two recipes reach prek — `fmt` in core's quality.mk runs it, the layer's `install`
+        installs its shim — and *both* must name the config, for one reason: prek bakes
+        `--config` into the shim it generates, so a flag passed only to `run` leaves the
+        hook resolving projects its own way. Unpinned, prek treats every nested
+        `.pre-commit-config.yaml` as a separate project; in this repo that is the three
+        layers' template configs, and the commit then dies on go-core's `go vet ./...` in
+        a directory with no go.mod. The two halves drifted exactly this way once, and
+        nothing caught it, because `fmt` was tested and `install` was not.
+        """
+        out = strip_ansi(run_make(logger, [target]).stdout)
+        assert expected in out, f"`make {target}` must pin prek's config:\n{out}"
 
 
 class TestRustLayerKeepsTheSameContract:
@@ -215,6 +238,12 @@ class TestRustLayerKeepsTheSameContract:
             f"`make fmt` still pins an interpreter for prek, which needs none:\n{out}"
         )
 
+    @pytest.mark.parametrize(("target", "expected"), PREK_CONFIG_INVOCATIONS)
+    def test_both_prek_entry_points_name_the_config(self, logger, target, expected):
+        """As for Python: the shim bakes in `--config`, so `install` must pass it too."""
+        out = strip_ansi(run_make(logger, [target], check=False).stdout)
+        assert expected in out, f"`make {target}` must pin prek's config:\n{out}"
+
 
 class TestGoLayerKeepsTheSameContract:
     """`go-core` is the third peer, assembled into a temp dir like the Rust one.
@@ -344,6 +373,12 @@ class TestGoLayerKeepsTheSameContract:
         assert not re.search(r"prek\b[^\n]*-p \d", out), (
             f"`make fmt` still pins an interpreter for prek, which needs none:\n{out}"
         )
+
+    @pytest.mark.parametrize(("target", "expected"), PREK_CONFIG_INVOCATIONS)
+    def test_both_prek_entry_points_name_the_config(self, logger, target, expected):
+        """As for Python: the shim bakes in `--config`, so `install` must pass it too."""
+        out = strip_ansi(run_make(logger, [target], check=False).stdout)
+        assert expected in out, f"`make {target}` must pin prek's config:\n{out}"
 
 
 class TestCoreAloneHasNoLanguageLayer:


### PR DESCRIPTION
## Summary

`make fmt` passes `--config .pre-commit-config.yaml` (documented at length in
`CLAUDE.md`), but `prek install` did not — and prek **bakes `--config` into the git
shim it generates**. So the flag fixed the gate and left the commit-time hook
unpinned, where it resolved projects its own way and stopped meaning what `make fmt`
means.

In this repo that isn't cosmetic, it's broken: unpinned, prek treats every nested
`.pre-commit-config.yaml` as a separate project, so `git commit` discovers
`bundles/{python,rust,go}-core`'s **template** configs and dies on go-core's
`go vet ./...` in a directory with no `go.mod`. It has been masked because it only
fires when a hook in a nested config has files to act on.

Reproduced in a scratch repo holding a root config plus one nested config — the
nested hook ran and the commit was rejected (`git rev-list --count HEAD` → 0):

```
NESTED TEMPLATE HOOK (must NOT run)......Failed
ROOT HOOK (should run)...................Passed
```

With `prek install -c .pre-commit-config.yaml` the shim carries the flag and only the
root project's hooks run:

```
exec "$PREK" hook-impl ... --config=".pre-commit-config.yaml" -- "$@"
```

The commit that created this PR is the demonstration: the hook printed
`Using config file: .pre-commit-config.yaml` and ran one project, where the previous
commit on this repo ran four.

## Changes

- **`-c .pre-commit-config.yaml` on `prek install`** in all three language layers —
  `python.mk`, `rust.mk`, `go.mk` — each with a comment on why the flag has to be
  repeated rather than inherited from `fmt`. Downstream, where one config sits at the
  root, it is a no-op that keeps hook and gate identical; a consumer wanting prek's
  monorepo behaviour drops it from both places.
- **`bundles/devcontainer/.devcontainer/bootstrap.sh` now installs prek, not
  pre-commit.** A second leftover from the runner swap (ADR 0009): it ran
  `uvx pre-commit install`, so a devcontainer's commit-time gate used a *different
  runner* than its own `make fmt`, and pulled the Python `pre-commit` package to do
  it. This was the only live leftover — the three remaining `uvx pre-commit` mentions
  in `CLAUDE.md`, ADR 0009 and `quality.mk` are historical prose and correctly
  past-tense.
- **`test_both_prek_entry_points_name_the_config`** in each of the three layer test
  classes, asserting `fmt` *and* `install` name the config as the one invariant they
  are. Nothing asserted either half before — `fmt`'s flag was documented but untested,
  `install`'s was neither — and that asymmetry is exactly why the drift survived. I
  confirmed the test bites by reverting the Go flag and watching it fail.
- `CLAUDE.md`: new bullet in the prek section recording the coupling.

## Testing

- [x] `make test` passes locally — 1423 passed, 43 skipped (up 6: the new per-layer tests)
- [x] `make fmt` has been run
- [x] New tests added (or explain why not needed) — added, and verified to fail without the fix

## Checklist

- [x] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `CHANGELOG.md` entry added (or not needed for this change) — not needed, git-cliff generates it at release
- [x] Documentation updated if behaviour changed — `CLAUDE.md` prek section
- [x] `make deps` passes (no unused or missing dependencies) — unaffected, no dependency touched

Independent of #1487 (the rhiza-hooks v1.2.0 pin bump): no overlapping files, so the two
can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
