### PR TITLE
fix(ci): bump BAIPP to v3.0.1 so the matrix survives metadata 2.5

### DIFF
--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -55,7 +55,7 @@ jobs:
 
       - id: versions
         name: Build package metadata and extract supported Python classifiers
-        uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+        uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
 
       - id: versions-output
         run: |


### PR DESCRIPTION
## What broke

`generate-matrix` is failing on **every** repo in the fleet, on PRs and on `main`:

```
Checking dist/greeks-0.1.1-py3-none-any.whl: ERROR
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

hatchling now stamps `Metadata-Version: 2.5` into the wheels it builds. `hynek/build-and-inspect-python-package@v2.18.0` runs `twine check --strict` with twine 6, which does not know metadata 2.5 and hard-fails. Since `generate-matrix` gates the whole `(RHIZA) CI` workflow, everything downstream of it never runs.

Nothing in our code changed — this is pure dependency drift, and it is currently blocking ~20 open dependabot PRs across 10 repos.

## The fix

Bump BAIPP to **v3.0.1**, which ships twine 7 with metadata 2.5 support (per the [v3.0.0 notes](https://github.com/hynek/build-and-inspect-python-package/releases/tag/v3.0.0)). v3 is otherwise a pure dependency refresh — no input or output changes — so `supported_python_classifiers_json_array` still works as before.

Verified locally against a wheel built from `greeks`:

| twine | result |
|---|---|
| 6 (BAIPP v2.18.0) | `InvalidDistribution: '2.5' is not a valid metadata version` |
| 7 (BAIPP v3.0.1) | `PASSED` |

Note v3 no longer force-tags moving `@v3` / `@v3.0` refs — we already pin the full version plus commit hash, so this costs us nothing.

## After this merges

This needs a **v1.3.3 release**; the ten downstream repos pin `rhiza_ci.yml@v1.3.2` and will stay red until their pin moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)