### PR TITLE
fix(bandit): move the scan scope into .bandit, where every runner can see it

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,7 +73,8 @@ repos:
     rev: 1.9.4
     hooks:
       - id: bandit
-        args: ["--ini", ".bandit", "--exclude", ".venv,tests,.rhiza/tests,.git,.pytest_cache"]
+        # Scope deliberately lives in .bandit, not here — see that file (#1493).
+        args: ["--ini", ".bandit"]
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.11.0.1

--- a/bundles/python-core/.bandit
+++ b/bundles/python-core/.bandit
@@ -1,2 +1,19 @@
+# Bandit configuration. This file — not the pre-commit hook's args — is the
+# single source of truth for bandit's scope, because it is the only part any
+# other runner can see. CodeFactor, IDE plugins and a contributor typing
+# `bandit -r .` all read `.bandit` and none of them read our hook args, so
+# scope kept in the args made every external analyser disagree with CI (#1493).
+#
+# Both spellings of each path are listed deliberately. Bandit matches an
+# exclude entry against the path string it is handed, and that string depends on
+# how it was invoked: a recursive `bandit -r .` discovers `./tests/foo.py`,
+# whereas pre-commit passes `tests/foo.py`. So `./tests` alone silently covers
+# only the recursive case and `tests` alone only the pre-commit case — a
+# one-spelling list looks correct and half-works. Verified in
+# tests/security/test_security_patterns.py, which runs bandit both ways.
+#
+# Note these are *added* to bandit's own defaults (.git, __pycache__, .tox,
+# .eggs, …), so those need no repeating here.
 [bandit]
+exclude = tests,./tests,.rhiza/tests,./.rhiza/tests,.venv,./.venv
 skips = B101

--- a/bundles/python-core/.pre-commit-config.yaml
+++ b/bundles/python-core/.pre-commit-config.yaml
@@ -68,7 +68,8 @@ repos:
     rev: 1.9.4
     hooks:
       - id: bandit
-        args: ["--ini", ".bandit", "--exclude", ".venv,tests,.rhiza/tests,.git,.pytest_cache"]
+        # Scope deliberately lives in .bandit, not here — see that file (#1493).
+        args: ["--ini", ".bandit"]
 
   - repo: https://github.com/betterleaks/betterleaks
     rev: v1.7.3

--- a/tests/security/test_security_patterns.py
+++ b/tests/security/test_security_patterns.py
@@ -15,6 +15,8 @@ These tests only verify that:
 
 import pathlib
 import re
+import shutil
+import subprocess
 import tomllib
 
 import pytest
@@ -192,6 +194,80 @@ class TestSecurityConfiguration:
 
         content = bandit_ini.read_text()
         assert "[bandit]" in content, ".bandit file must contain a [bandit] section"
+
+    def test_bandit_scope_is_not_kept_in_the_hook_args(self) -> None:
+        """The pre-commit hook must not carry ``--exclude``.
+
+        Scope in the hook args is invisible to every other bandit runner, which
+        is what made CodeFactor scan ``tests/`` and report ten false-positive
+        ``B311`` hits downstream (#1493).  ``.bandit`` is the single source of
+        truth, so the args may name the config and nothing else.
+        """
+        repo_root = pathlib.Path(__file__).parent.parent.parent
+        content = (repo_root / ".pre-commit-config.yaml").read_text()
+
+        bandit_args = [line for line in content.splitlines() if "--ini" in line and ".bandit" in line]
+        assert bandit_args, "expected the bandit hook to pass --ini .bandit"
+        for line in bandit_args:
+            assert "--exclude" not in line, (
+                "bandit's scope must live in .bandit, not in the hook args, so that "
+                f"CodeFactor and local runs agree with CI (#1493). Offending line: {line.strip()}"
+            )
+
+    def test_bandit_config_excludes_tests_however_it_is_invoked(self, tmp_path: pathlib.Path) -> None:
+        """``.bandit`` alone must exclude the test trees in *both* invocation modes.
+
+        This is the actual guarantee #1493 asks for, and it cannot be asserted by
+        reading the file: bandit matches an exclude entry against the path string
+        it is handed, which differs by caller.  ``bandit -r .`` discovers
+        ``./tests/foo.py`` while pre-commit passes ``tests/foo.py``, so a config
+        listing only one spelling passes a substring check and still half-works.
+        Running it both ways is the only check that distinguishes them.
+        """
+        uvx = shutil.which("uvx")
+        if uvx is None:
+            pytest.skip("uvx not available; cannot run bandit out-of-tree")
+
+        repo_root = pathlib.Path(__file__).parent.parent.parent
+        bandit_ini = repo_root / "bundles" / "python-core" / ".bandit"
+        if not bandit_ini.exists():
+            pytest.skip("python-core bundle not present")
+
+        # A tree shaped like a synced consumer: a clean source folder plus test
+        # trees holding a finding that is real but out of scope by policy.
+        offender = "import random\n\n\ndef test_x() -> None:\n    assert random.randint(0, 5) >= 0\n"
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "mod.py").write_text("def f() -> int:\n    return 1\n")
+        for folder in ("tests", ".rhiza/tests"):
+            target = tmp_path / folder
+            target.mkdir(parents=True)
+            (target / "test_r.py").write_text(offender)
+        shutil.copy(bandit_ini, tmp_path / ".bandit")
+
+        def _findings(*args: str) -> str:
+            result = subprocess.run(
+                [uvx, "bandit", "--ini", ".bandit", *args],
+                cwd=tmp_path,
+                capture_output=True,
+                text=True,
+                timeout=300,
+                check=False,
+            )
+            if "No module named" in result.stderr or "error: unrecognized" in result.stderr:
+                pytest.skip(f"bandit unavailable via uvx: {result.stderr[:200]}")
+            return result.stdout
+
+        recursive = _findings("-r", ".")
+        assert "B311" not in recursive, (
+            "`bandit -r .` — how CodeFactor and a contributor reproducing a finding "
+            f"invoke it — scanned the excluded test trees.\n{recursive}"
+        )
+
+        explicit = _findings("tests/test_r.py", ".rhiza/tests/test_r.py", "src/mod.py")
+        assert "B311" not in explicit, (
+            "bandit given explicit paths — how pre-commit invokes it — scanned the "
+            f"excluded test trees. A './'-only exclude list causes exactly this.\n{explicit}"
+        )
 
     @_REQUIRES_GITHUB_BUNDLE
     def test_security_policy_exists(self) -> None:

--- a/tests/security/test_security_patterns.py
+++ b/tests/security/test_security_patterns.py
@@ -245,6 +245,7 @@ class TestSecurityConfiguration:
         shutil.copy(bandit_ini, tmp_path / ".bandit")
 
         def _findings(*args: str) -> str:
+            """Run bandit in the fixture tree with the shipped config and return its report."""
             result = subprocess.run(
                 [uvx, "bandit", "--ini", ".bandit", *args],
                 cwd=tmp_path,


### PR DESCRIPTION
Closes #1493.

## The problem

Bandit's scope lived in the pre-commit hook's arguments:

```yaml
- id: bandit
  args: ["--ini", ".bandit", "--exclude", ".venv,tests,.rhiza/tests,.git,.pytest_cache"]
```

`.bandit` itself carried `skips = B101` and no scope. Nothing outside pre-commit can see a hook argument, so every other bandit runner — CodeFactor, an IDE plugin, a contributor typing `bandit -r .` — got the skip list without the scope and scanned `tests/`. That is how quadprog collected ten false-positive `B311` reports that `make security` and the hook, by construction, could never produce.

## The fix

Scope moves into `.bandit`; the hook args name only the config. Bandit's `--exclude` is documented as *additive* to the config file, so nothing is lost by dropping it — and bandit's own defaults (`.git`, `__pycache__`, `.tox`, `.eggs`) still apply, which is why they need no repeating.

## The wrinkle worth reading

The issue suggests `exclude = ./tests,./.rhiza/tests,./.venv`. That form is only half a fix, and the half that breaks is the one we rely on.

Bandit matches an exclude entry against the path string it is *handed*, and that differs by caller: a recursive `bandit -r .` discovers `./tests/foo.py`, while pre-commit passes `tests/foo.py`. Measured against bandit 1.9.4 (0 findings = correctly excluded):

| `exclude =` | `bandit -r .` | explicit paths (pre-commit) |
|---|---|---|
| `./tests,./.rhiza/tests,./.venv` | ✅ 0 | ❌ 2 |
| `tests,.rhiza/tests,.venv` | ❌ 2 | ✅ 0 |
| `*/tests/*,*/.rhiza/tests/*` | ✅ 0 | ❌ 1 |
| **both spellings** | ✅ 0 | ✅ 0 |

So the `./`-only form would have fixed CodeFactor while silently *un*-excluding the test trees for the hook that currently does exclude them. Both spellings are listed, with a comment in the file explaining why it looks redundant.

## Tests

- `test_bandit_scope_is_not_kept_in_the_hook_args` — pins the invariant that scope may not drift back into the args.
- `test_bandit_config_excludes_tests_however_it_is_invoked` — builds a tree with an out-of-scope `B311` and runs bandit **both** ways against the shipped config. Verified it fails on either single-spelling list; a substring assertion on the config file cannot tell those apart. Skips cleanly when `uvx` is unavailable.

`make fmt` and `tests/security` + `tests/bundles` (668 tests) are green.

## Left for you

The issue's second question — whether `skips = B101` alone is the intended rule-set, given it is ~25 checks stricter than CodeFactor's default — is a policy call, so I have not touched it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)