### PR TITLE
chore: release v1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com),
 and entries are generated from [Conventional Commits](https://www.conventionalcommits.org).
 
+## [1.3.3] - 2026-08-11
+
+### Bug Fixes
+- *(python)* The licence gate has never failed on GPL (#1491)
+- *(ci)* Bump BAIPP to v3.0.1 so the matrix survives metadata 2.5 (#1497)
+- *(bandit)* Move the scan scope into .bandit, where every runner can see it (#1502)
+
+### Dependencies
+- *(deps)* Lock file maintenance (#1495)
+- *(deps)* Update pre-commit hook astral-sh/ruff-pre-commit to v0.16.2 (#1498)
+- *(deps)* Update pre-commit hook betterleaks/betterleaks to v1.7.4 (#1500)
+- *(deps)* Update pre-commit hook astral-sh/uv-pre-commit to v0.12.3 (#1499)
+- *(deps)* Update pre-commit hook python-jsonschema/check-jsonschema to v0.38.0 (#1501)
+
+### Maintenance
+- Chore(deps)(deps): bump the github-actions group with 8 updates (#1496)
+
+### Other Changes
+- Update TESTS.md (#1490)
+
 ## [1.3.2] - 2026-08-04
 
 ### New Features

--- a/bundles/github-book/.github/workflows/rhiza_book.yml
+++ b/bundles/github-book/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.3.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.3.3
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml
+++ b/bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   devcontainer:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v1.3.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v1.3.3
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-docker/.github/workflows/rhiza_docker.yml
+++ b/bundles/github-docker/.github/workflows/rhiza_docker.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   docker:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v1.3.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v1.3.3
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-marimo/.github/workflows/rhiza_marimo.yml
+++ b/bundles/github-marimo/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.3.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.3.3
     secrets: inherit

--- a/bundles/github-paper/.github/workflows/rhiza_paper.yml
+++ b/bundles/github-paper/.github/workflows/rhiza_paper.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   paper:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v1.3.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v1.3.3
     secrets: inherit
     permissions:
       contents: write

--- a/bundles/github-quality-review/.github/workflows/rhiza_quality_review.yml
+++ b/bundles/github-quality-review/.github/workflows/rhiza_quality_review.yml
@@ -34,5 +34,5 @@ on:
 
 jobs:
   quality-review:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_quality_review.yml@v1.3.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_quality_review.yml@v1.3.3
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_benchmark.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.3.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.3.3
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_ci.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.3.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.3.3
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_codeql.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.3.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.3.3
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/bundles/github-tests/.github/workflows/rhiza_mutation.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_mutation.yml
@@ -42,7 +42,7 @@ jobs:
     # this repo sets the `MUTATION_ENABLED` variable to 'true'. Gating here in
     # the caller keeps it optional regardless of the pinned reusable workflow.
     if: ${{ vars.MUTATION_ENABLED == 'true' }}
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v1.3.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v1.3.3
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github/.github/workflows/rhiza_fuzzing.yml
+++ b/bundles/github/.github/workflows/rhiza_fuzzing.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   fuzzing:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v1.3.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v1.3.3
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github/.github/workflows/rhiza_scorecard.yml
+++ b/bundles/github/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.3.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.3.3
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/bundles/github/.github/workflows/rhiza_weekly.yml
+++ b/bundles/github/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.3.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.3.3
     secrets: inherit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rhiza"
-version = "1.3.2"
+version = "1.3.3"
 description = "Reusable configuration templates for modern Python projects"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -70,7 +70,7 @@ Issues = "https://github.com/jebel-quant/rhiza/issues"
 # python-core bundle no longer ships a `.rhiza/.cfg.toml` copy of this block; the
 # Rust and Go layers ship a root `.bumpversion.toml` instead, since neither
 # language has a discoverable file of its own.
-current_version = "1.3.2"
+current_version = "1.3.3"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:[-]?(?P<release>[a-z]+)[\\.]?(?P<pre_n>\\d+))?(?:\\+build\\.(?P<build_n>\\d+))?"
 serialize = [
     "{major}.{minor}.{patch}-{release}.{pre_n}+build.{build_n}",

--- a/uv.lock
+++ b/uv.lock
@@ -863,7 +863,7 @@ wheels = [
 
 [[package]]
 name = "rhiza"
-version = "1.3.2"
+version = "1.3.3"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Release **v1.3.2 → v1.3.3** (patch).

## Why now

`generate-matrix` was failing on every repo in the fleet — hatchling started stamping `Metadata-Version: 2.5` and the twine 6 inside BAIPP v2.18.0 rejects it, killing the job that gates all of `(RHIZA) CI`. The fix is on `main` (#1497), but the ten downstream repos pin `rhiza_ci.yml@v1.3.2`, so **they stay red until this tag exists**. Roughly 20 dependabot PRs are blocked behind it.

## What the bump touched

`bump-my-version` rewrote only its declared locations — 14 files, the same shape as the v1.3.2 release commit:

- `pyproject.toml` — `[project].version` and `current_version`
- 13 × `bundles/**/.github/workflows/*.yml` — the `jebel-quant/rhiza/…@v1.3.2` → `@v1.3.3` stub pins, so a synced repo calls this release's reusable workflows rather than the previous one's
- `uv.lock` — regenerated (`rhiza v1.3.2 -> v1.3.3`)
- `CHANGELOG.md` — new `[1.3.3]` section, prepended

The live `.github/workflows/` are deliberately **not** in the bump config, which is what keeps this release PR mergeable: nothing here references a `jebel-quant/rhiza` tag that doesn't exist yet.

## Changelog section being added

### Bug Fixes
- *(python)* The licence gate has never failed on GPL (#1491)
- *(ci)* Bump BAIPP to v3.0.1 so the matrix survives metadata 2.5 (#1497)
- *(bandit)* Move the scan scope into .bandit, where every runner can see it (#1502)

### Dependencies
- Lock file maintenance (#1495); ruff-pre-commit v0.16.2 (#1498); betterleaks v1.7.4 (#1500); uv-pre-commit v0.12.3 (#1499); check-jsonschema v0.38.0 (#1501)

### Maintenance
- github-actions group, 8 updates (#1496)

### Other Changes
- Update TESTS.md (#1490)

## Merging this does not publish the release

The tag is cut afterwards, from the commit that actually merges — a squash-merge replaces this branch's commit, so a tag created now would name a SHA that never lands. Once this is in, phase B tags the merged commit and release CI runs.

After the tag exists I'll bump the `@v1.3.2` pin in the ten downstream repos: basanos, futures, greeks, jquantstats, linalg, nncg, quadprog, shrinkage, trends, rhiza-hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)