### PR TITLE
fix: make the mother repo's own static gates measure something (#1505, #1506, #1507, #1508)

### DIFF
--- a/.rhiza/make.d/bundles.mk
+++ b/.rhiza/make.d/bundles.mk
@@ -4,6 +4,32 @@
 
 .PHONY: explain-bundles sync-self sync-self-check e2e
 
+# Bring utils/ into the four path-scoped gates.
+#
+# Rhiza ships configuration, not a runtime library, so it has no src/ and SOURCE_FOLDER
+# matches nothing. That left `typecheck`, `security` and `deps` exiting 0 having measured
+# nothing, and `docs-coverage` seeing only the test folders (#1505) — on the one repo that
+# ships those gates to everyone else. But real Python does live here: utils/ holds the
+# mother-repo tooling behind `make sync-self` and the sync-self-check CI drift guard.
+#
+# These are the accumulators python.mk exposes for exactly this. This fragment is loaded
+# before python.mk (make.d is read alphabetically), so each `+=` creates the variable and
+# python.mk's `?=` then leaves it alone.
+#
+# It belongs here rather than in the root Makefile because that file is a dogfood symlink
+# into bundles/core/ — editing it would ship rhiza's own layout to every consumer.
+#
+# DEP004 ("imported but declared as a dev dependency") is ignored on the grounds marimo.mk
+# ignores it for notebooks: utils/ *is* development tooling, so importing a dev dependency
+# there is correct rather than misplaced. marimo.mk contributes the same flag when its
+# folder exists; deptry accepts the repeat, and stating it here keeps utils/ from silently
+# depending on the marimo bundle staying adopted.
+TYPECHECK_FOLDERS += utils
+BANDIT_FOLDERS    += utils
+DOCSTRING_FOLDERS += utils
+DEPTRY_FOLDERS    += utils
+DEPTRY_IGNORE     += --ignore DEP004
+
 # Which end-to-end modules `make e2e` runs. One per language layer, so CI can give
 # each its own job (and its own toolchain) by narrowing this:
 #   make e2e E2E_ARGS=tests/e2e/test_go_layer_e2e.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,11 +16,11 @@ make test         # Run all tests with coverage (90% minimum required)
 make fmt          # Run all hooks via prek (ruff format/check, markdownlint, bandit, etc.)
 make deps         # Check for unused/missing dependencies
 make docs-coverage  # Check docstring coverage with interrogate (100% required)
-make typecheck    # Static type checking with pyright
+make typecheck    # Static type checking with ty and mypy --strict (TYPECHECKER=ty|mypy|both)
 make benchmark    # Performance benchmarks
 make hypothesis-test  # Property-based tests only
 make stress       # Load/concurrency tests
-make security     # pip-audit + bandit security scans
+make security     # bandit security scan
 make e2e          # Language-layer end-to-end suite (opt-in, real toolchains; see below)
 make book         # Build documentation
 make marimo       # Start Marimo notebook server
@@ -154,7 +154,7 @@ and tags itself so the changelog lands in the bump commit.
 | `coverage` | pytest-cov | `cargo llvm-cov` (same `_tests/coverage.xml` path) | `go test -coverprofile` + `gocover-cobertura` (same path) |
 | `typecheck` | ty / mypy | `cargo clippy -D warnings` (rustc already type-checks) | `go vet` + golangci-lint (the compiler already type-checks) |
 | `docs-coverage` | interrogate (%) | `RUSTDOCFLAGS=-D missing_docs` (pass/fail) | revive `exported` rule (pass/fail) |
-| `security` | bandit + pip-audit | `cargo deny check advisories` | `govulncheck` |
+| `security` | bandit | `cargo deny check advisories` | `govulncheck` |
 | `license` | pip-licenses | `cargo deny check licenses` | `go-licenses check` |
 | `deps` | `deptry` | `cargo machete` | `go mod tidy -diff` |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,6 +167,27 @@ tool, so `make deps` failed on Python and `make deptry` on the other two. The to
 `tests/bundles/test_bundle_sync.py::TestEveryLayerDefinesTheSameGateNames` now fails on
 the next divergence rather than documenting it.
 
+**Where each Python gate looks, and how to add a folder.** python-core's four path-scoped
+gates take their folder list from an accumulator, all seeded from `SOURCE_FOLDER` when it
+exists: `TYPECHECK_FOLDERS`, `BANDIT_FOLDERS`, `DOCSTRING_FOLDERS` and the older
+`DEPTRY_FOLDERS`/`DEPTRY_IGNORE` pair. A bundle or a consuming `Makefile`/`local.mk` adds
+a folder by appending, the way marimo.mk contributes its notebooks.
+
+Only `deps` had that shape before #1505; the other three hard-coded `SOURCE_FOLDER`, so
+Python kept *outside* the source root was unreachable by three of the four static gates.
+The mother repo was the extreme case — it ships configuration, not a library, so it has no
+`src/` at all and `typecheck`, `security` and `deps` each exited **0** having measured
+nothing, on the very repo that ships those gates to everyone else. `utils/` (the tooling
+behind `make sync-self` and the `sync-self-check` drift guard) is contributed from
+`.rhiza/make.d/bundles.mk`, which is mother-repo-only — the root `Makefile` cannot hold it,
+being a dogfood symlink into `bundles/core/`. `tests/utils/test_gate_scope.py` asserts the
+outcome rather than the wiring: each gate must resolve to a non-empty list naming `utils`.
+
+One consequence worth knowing when reading `make -n`: the folder list is expanded by
+**make**, not by the recipe's shell, so a dry run shows the real scope. The `[ -d ... ]`
+form it replaced printed its warning whether or not the branch would fire, which made a
+dry run's warnings meaningless as evidence either way.
+
 All three layers carry `test`/`coverage`/`typecheck` themselves. Python's used to live
 in the separate `tests` bundle, and that was a real inconsistency rather than a
 considered asymmetry: `python.mk`'s own `all` named them while `tests` defined them, and

--- a/bundles/gitlab/.gitlab/COMPARISON.md
+++ b/bundles/gitlab/.gitlab/COMPARISON.md
@@ -11,7 +11,6 @@ This document provides a side-by-side comparison of GitHub Actions and GitLab CI
 | Validation | `rhiza_validate.yml` | `rhiza_validate.yml` | ✅ Complete |
 | Semgrep | `rhiza_validate.yml` (semgrep job) | `rhiza_semgrep.yml` | ✅ Complete |
 | Security | `rhiza_validate.yml` (security job) | `rhiza_validate.yml` (validate:security job) | ✅ Complete |
-| Pip-audit | `rhiza_validate.yml` (pip-audit job) | `rhiza_validate.yml` (validate:pip-audit job) | ✅ Complete |
 | Type checking | `rhiza_validate.yml` (typecheck job) | `rhiza_validate.yml` (validate:typecheck job) | ✅ Complete |
 | License | `rhiza_validate.yml` (license job) | `rhiza_license.yml` | ✅ Complete |
 | Pre-commit | `rhiza_pre-commit.yml` | `rhiza_pre-commit.yml` | ✅ Complete |

--- a/bundles/python-core/.rhiza/make.d/python.mk
+++ b/bundles/python-core/.rhiza/make.d/python.mk
@@ -142,6 +142,31 @@ ifneq ($(wildcard $(SOURCE_FOLDER)),)
 DEPTRY_FOLDERS += $(SOURCE_FOLDER)
 endif
 
+# The same accumulator shape, for the other three path-scoped gates. `deps` has had
+# one since the bundle model began; `typecheck`, `security` and `docs-coverage` each
+# hard-coded SOURCE_FOLDER instead, so any Python a project keeps *outside* its source
+# root was unreachable by three of the four static gates (#1505). The mother repo is
+# the extreme case — it has no `src/` at all, so those three exited 0 having measured
+# nothing — but a downstream project with a `scripts/` or `tools/` directory has the
+# identical hole.
+#
+# Each seeds itself from SOURCE_FOLDER when that folder exists, so a project that never
+# touches these variables gets precisely the previous behaviour. A bundle or a consuming
+# Makefile contributes a folder by appending, exactly as marimo.mk does for DEPTRY_FOLDERS.
+#
+# The folder list is computed here, at make time, rather than by the `[ -d ... ]` tests
+# that used to live in each recipe. That is a deliberate change in what `make -n` prints:
+# the shell form emitted its assignment whether or not the folder existed, so a dry run
+# reported a scope the real run would not use.
+TYPECHECK_FOLDERS ?=
+BANDIT_FOLDERS ?=
+DOCSTRING_FOLDERS ?=
+ifneq ($(wildcard $(SOURCE_FOLDER)),)
+TYPECHECK_FOLDERS += $(SOURCE_FOLDER)
+BANDIT_FOLDERS += $(SOURCE_FOLDER)
+DOCSTRING_FOLDERS += $(SOURCE_FOLDER)
+endif
+
 # Named `deps`, matching rust.mk and go.mk. This was the one gate whose *target name*
 # differed by language (#1474): `deptry` names the tool, which nothing else in the
 # contract does — pytest is `test`, mypy is `typecheck`, bandit is `security`. So
@@ -234,16 +259,13 @@ test:: install ## run all tests
 	done
 
 # The 'typecheck' target runs static type analysis using ty and/or mypy.
-# 1. Builds a list of existing Python source folders to check.
+# 1. Takes the folder list from TYPECHECK_FOLDERS (see the accumulator block above).
 # 2. Depending on TYPECHECKER (ty|mypy|both, default: both), runs ty,
 #    mypy in strict mode, or both in sequence as a cross-check.
 typecheck: install ## run ty and/or mypy type checking (TYPECHECKER=ty|mypy|both, default: both)
-	@typecheck_paths=""; \
-	if [ -d "${SOURCE_FOLDER}" ]; then \
-	  typecheck_paths="${SOURCE_FOLDER}"; \
-	fi; \
+	@typecheck_paths="$(strip $(TYPECHECK_FOLDERS))"; \
 	if [ -z "$${typecheck_paths}" ]; then \
-	  printf "${YELLOW}[WARN] No typecheck folders found (SOURCE_FOLDER='${SOURCE_FOLDER}'), skipping typecheck${RESET}\n"; \
+	  printf "${YELLOW}[WARN] No typecheck folders found (TYPECHECK_FOLDERS is empty and SOURCE_FOLDER='${SOURCE_FOLDER}' does not exist), skipping typecheck${RESET}\n"; \
 	  exit 0; \
 	fi; \
 	case "${TYPECHECKER}" in \
@@ -267,28 +289,25 @@ typecheck: install ## run ty and/or mypy type checking (TYPECHECKER=ty|mypy|both
 	    ;; \
 	esac
 
-# The 'security' target runs bandit to find common security issues in the
-# Python source folders that exist.
+# The 'security' target runs bandit over the folders in BANDIT_FOLDERS (see the
+# accumulator block above). Scope *within* those folders is .bandit's job, not this
+# target's — see that file for why it is the single source of truth (#1493).
 security: install ## run security scans (bandit)
-	@bandit_paths=""; \
-	if [ -d "${SOURCE_FOLDER}" ]; then \
-	  bandit_paths="${SOURCE_FOLDER}"; \
-	fi; \
+	@bandit_paths="$(strip $(BANDIT_FOLDERS))"; \
 	if [ -n "$${bandit_paths}" ]; then \
 	  printf "${BLUE}[INFO] Running bandit security scan in:$${bandit_paths}${RESET}\n"; \
 	  ${UVX_BIN} bandit -r $${bandit_paths} -ll -q --ini .bandit; \
 	else \
-	  printf "${YELLOW}[WARN] No bandit scan folders found (SOURCE_FOLDER='${SOURCE_FOLDER}'), skipping bandit${RESET}\n"; \
+	  printf "${YELLOW}[WARN] No bandit scan folders found (BANDIT_FOLDERS is empty and SOURCE_FOLDER='${SOURCE_FOLDER}' does not exist), skipping bandit${RESET}\n"; \
 	fi
 
 # The 'docs-coverage' target checks documentation coverage using interrogate.
-# 1. Builds a list of existing Python source folders to check.
-# 2. Runs interrogate with verbose output against those folders.
+# 1. Takes DOCSTRING_FOLDERS (see the accumulator block above) as the base list.
+# 2. Adds the test folders, which are checked wherever they exist and are not part
+#    of the accumulator: a consumer contributing a folder means source, not tests.
+# 3. Runs interrogate with verbose output against the result.
 docs-coverage: install ## check documentation coverage with interrogate
-	@docstring_paths=""; \
-	if [ -d "${SOURCE_FOLDER}" ]; then \
-	  docstring_paths="${SOURCE_FOLDER}"; \
-	fi; \
+	@docstring_paths="$(strip $(DOCSTRING_FOLDERS))"; \
 	if [ -d "tests" ]; then \
 	  docstring_paths="$${docstring_paths} tests"; \
 	fi; \
@@ -299,7 +318,7 @@ docs-coverage: install ## check documentation coverage with interrogate
 	  printf "${BLUE}[INFO] Checking documentation coverage in:$${docstring_paths}${RESET}\n"; \
 	  ${UV_BIN} run --with interrogate interrogate -vv --fail-under 100 --ignore-init-method --ignore-magic $${docstring_paths}; \
 	else \
-	  printf "${YELLOW}[WARN] No docs-coverage folders found (SOURCE_FOLDER='${SOURCE_FOLDER}'), skipping docs-coverage${RESET}\n"; \
+	  printf "${YELLOW}[WARN] No docs-coverage folders found (DOCSTRING_FOLDERS is empty, SOURCE_FOLDER='${SOURCE_FOLDER}' does not exist, and there are no test folders), skipping docs-coverage${RESET}\n"; \
 	fi
 
 test-pyproject: install ## run pyproject.toml structure tests

--- a/bundles/rust-core/deny.toml
+++ b/bundles/rust-core/deny.toml
@@ -5,7 +5,7 @@
 #   make security  -> cargo deny check advisories   (RustSec: known CVEs)
 #   make license   -> cargo deny check licenses     (the allow-list below)
 #
-# The Python layer uses pip-audit + bandit and pip-licenses for the same two jobs.
+# The Python layer uses bandit and pip-licenses for the same two jobs.
 
 [graph]
 # Check every target, not just the host. A dependency that is sound on Linux and

--- a/docs/operations/CI_ENFORCEMENT.md
+++ b/docs/operations/CI_ENFORCEMENT.md
@@ -17,7 +17,7 @@ These fail the pull request when they fail. They run on every PR via
 | Tests | `make test`, `make rhiza-test` | Full suites; `rhiza-test` runs Rhiza's own `.rhiza/tests/` suite. |
 | Dependency hygiene | `make deps` | Unused/missing dependency scan. |
 | Docstring coverage | `make docs-coverage` | interrogate at 100%. |
-| Security | `make security` | pip-audit + bandit. |
+| Security | `make security` | bandit over the folders in `BANDIT_FOLDERS`. |
 | CodeQL | `rhiza_codeql.yml` | Code scanning on PR and push. |
 
 ## Conditional / opt-in gates

--- a/docs/ops/CII_BEST_PRACTICES.md
+++ b/docs/ops/CII_BEST_PRACTICES.md
@@ -41,7 +41,7 @@ to the evidence that already exists in rhiza, so the questionnaire is mostly cop
 | Secured delivery (HTTPS) | GitHub + PyPI over HTTPS |
 | Crypto / no hardcoded secrets | `detect-secrets` pre-commit hook |
 | Dynamic / fuzz analysis | ClusterFuzzLite + Atheris (`rhiza_fuzzing.yml`, `.clusterfuzzlite/`) |
-| Dependency vulnerability monitoring | Dependabot + Renovate + `pip-audit` (`make security`) |
+| Dependency vulnerability monitoring | Dependabot + Renovate (version currency), CodeQL (`rhiza_codeql.yml`), OpenSSF Scorecard (`rhiza_scorecard.yml`), Trivy for images (`rhiza_docker.yml`) |
 | Contribution guide | `CONTRIBUTING.md` |
 | Code review of changes | Branch-protection ruleset (`docs/ops/BRANCH_PROTECTION.md`) |
 | Continuous integration | GitHub Actions + GitLab CI |

--- a/docs/paper/rhiza.tex
+++ b/docs/paper/rhiza.tex
@@ -206,7 +206,7 @@ Rhiza integrates a layered quality stack that operates at multiple stages of the
 
 \paragraph{Pre-commit hooks.} The \texttt{pre-commit} bundle installs hooks that run \texttt{ruff} for linting and formatting, catching issues before they enter the repository.
 
-\paragraph{CI pipelines.} The \texttt{github} and \texttt{gitlab} bundles provide workflows that run on every pull request: unit tests across Python 3.11--3.14, type checking with \texttt{ty}, dependency validation with \texttt{deptry}, security scanning with \texttt{pip-audit} and \texttt{bandit}, and static analysis with \texttt{semgrep}.
+\paragraph{CI pipelines.} The \texttt{github} and \texttt{gitlab} bundles provide workflows that run on every pull request: unit tests across Python 3.11--3.14, type checking with \texttt{ty}, dependency validation with \texttt{deptry}, security scanning with \texttt{bandit}, and static analysis with \texttt{semgrep} and CodeQL.
 
 \paragraph{Automated dependency updates.} A Renovate configuration file, included in the \texttt{core} bundle, opens pull requests whenever a pinned dependency or the template \texttt{ref} is updated upstream. This closes the loop: Rhiza itself is treated as a dependency that can be automatically proposed for upgrade.
 

--- a/docs/reference/GLOSSARY.md
+++ b/docs/reference/GLOSSARY.md
@@ -263,7 +263,7 @@ Multi-phase workflow triggered by version tags. Builds packages, creates GitHub 
 Workflow that synchronizes template files from upstream Rhiza repository.
 
 ### Security Workflow
-Workflow running security scans (pip-audit, bandit) on the codebase.
+Workflow running security scans (bandit, semgrep, CodeQL) on the codebase.
 
 ## Commands Reference
 

--- a/docs/reference/TOOLS_REFERENCE.md
+++ b/docs/reference/TOOLS_REFERENCE.md
@@ -49,8 +49,8 @@ These are the commands you'll use most frequently:
 |---------|-------------|
 | `make deps` | Check for unused/missing dependencies |
 | `make pre-commit` | Run all pre-commit hooks |
-| `make typecheck` | Run type checking with ty |
-| `make security` | Run security scans (pip-audit and bandit) |
+| `make typecheck` | Run type checking with ty and mypy --strict |
+| `make security` | Run the bandit security scan |
 | `make docs-coverage` | Check documentation coverage |
 
 ### Testing
@@ -340,14 +340,11 @@ uv run ty check path/to/file.py
 ### Security Scanning
 
 ```bash
-# Run all security scans
+# Run the security gate (bandit over BANDIT_FOLDERS, scoped by .bandit)
 make security
 
-# Run pip-audit only
-uv run pip-audit
-
-# Run bandit only
-uv run bandit -r src/
+# Run bandit directly, with the same scope the gate uses
+uvx bandit -r src/ -ll -q --ini .bandit
 ```
 
 ### Dependency Checking

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,20 @@ ignore_missing_version = true
 # *dependency* that happens to sit at the same number, and the lock file is full of
 # third-party versions this repo does not control.
 
+[tool.mypy]
+# `make typecheck` passes both the strictness flag and the paths on the command line
+# (`mypy --strict $TYPECHECK_FOLDERS`), so this table does not drive CI — it makes a
+# *bare* `mypy` measure the same thing CI does (#1507). Without it the two disagreed:
+# the gate checked utils/ in strict mode while a contributor's `uvx mypy` swept the
+# whole tree at default strictness and reported on code this repo does not gate.
+#
+# Keep `files` in step with TYPECHECK_FOLDERS in .rhiza/make.d/bundles.mk, and `strict`
+# in step with the `--strict` in python.mk's typecheck recipe. tests/ is deliberately
+# absent from both: ruff exempts test code from ANN (see ruff.toml's per-file-ignores),
+# so the annotations strict mode would demand are not there by design.
+strict = true
+files = ["utils"]
+
 [tool.deptry.package_module_name_map]
 # uvx runs deptry without the project deps installed, so it cannot read each
 # package's metadata to resolve the import module name. Declaring the mappings

--- a/tests/docs/test_doc_consistency.py
+++ b/tests/docs/test_doc_consistency.py
@@ -322,3 +322,89 @@ class TestProseDrift:
     def test_make_mentions_were_collected(self) -> None:
         """Guard against the make-mention scanner silently collecting nothing."""
         assert len(_make_mention_cases()) > 10, "expected CLAUDE.md/README.md to mention make targets"
+
+
+# Tools whose presence in the toolchain is worth keeping the docs honest about. Each is
+# either invoked somewhere in _INVOCATION_SOURCES or it is not; the test below derives
+# which, rather than hard-coding a "retired" list that would drift in its own right.
+_WATCHED_TOOLS = (
+    "pip-audit",
+    "bandit",
+    "semgrep",
+    "deptry",
+    "interrogate",
+    "govulncheck",
+    "cargo-machete",
+)
+
+# Where a tool would be invoked from: the make fragments and every CI workflow, in this
+# repo and in the bundles it ships.
+_INVOCATION_SOURCES = (
+    *(_ROOT / s for s in _MAKE_SOURCES),
+    *sorted(_ROOT.glob(".github/workflows/*.yml")),
+    *sorted(_ROOT.glob("bundles/*/.rhiza/make.d/*.mk")),
+    *sorted(_ROOT.glob("bundles/*/.github/workflows/*.yml")),
+    *sorted(_ROOT.glob("bundles/*/.gitlab/**/*.yml")),
+    *sorted(_ROOT.glob("bundles/*/.gitlab-ci.yml")),
+)
+
+# Prose files exempt from the claim gate. CHANGELOG.md records what *was* true, and the
+# e2e suite's docstrings name pip-audit as the analogue of govulncheck/cargo-deny — both
+# describe history or comparison rather than claiming the tool runs.
+_CLAIM_GATE_EXEMPT = {"CHANGELOG.md"}
+
+
+def _invoked_tools() -> set[str]:
+    """Return the watched tools that some make fragment or CI workflow actually invokes."""
+    haystack = "\n".join(
+        path.read_text(encoding="utf-8", errors="replace") for path in _INVOCATION_SOURCES if path.is_file()
+    )
+    return {tool for tool in _WATCHED_TOOLS if tool in haystack}
+
+
+def _prose_files() -> list[Path]:
+    """Return the documentation files whose claims about the toolchain are gated."""
+    return [p for p in _markdown_files() if p.name not in _CLAIM_GATE_EXEMPT] + sorted(_ROOT.glob("docs/paper/*.tex"))
+
+
+class TestToolClaims:
+    """Documentation must not credit the project with a tool nothing runs.
+
+    `make security` dropped pip-audit, and a test pins the removal — but nine documents
+    went on describing it, including a self-attestation against the CII best-practices
+    standard and the published paper (#1506). Docstring coverage and markdownlint both
+    stayed green throughout: neither asks whether a claim is *true*. This does.
+
+    The invoked set is derived rather than declared, so reinstating a tool in a workflow
+    re-permits every mention of it in the same commit.
+    """
+
+    @pytest.mark.parametrize(
+        "doc",
+        _prose_files(),
+        ids=lambda p: str(p.relative_to(_ROOT)),
+    )
+    def test_docs_only_claim_tools_that_run(self, doc: Path) -> None:
+        """No prose may name a watched tool that no make fragment or workflow invokes."""
+        invoked = _invoked_tools()
+        text = doc.read_text(encoding="utf-8", errors="replace")
+        claimed_but_absent = [t for t in _WATCHED_TOOLS if t not in invoked and t in text]
+        assert not claimed_but_absent, (
+            f"{doc.relative_to(_ROOT)} names {claimed_but_absent}, which nothing in this "
+            f"repository invokes. Either wire the tool up or drop the claim (#1506)."
+        )
+
+    def test_the_invocation_scan_found_something(self) -> None:
+        """Positive control: an empty invoked set would make the gate above vacuous."""
+        invoked = _invoked_tools()
+        assert {"bandit", "deptry"} <= invoked, (
+            f"expected bandit and deptry to be detected as invoked; got {sorted(invoked)}. "
+            "The invocation scan is probably looking in the wrong places."
+        )
+
+    def test_pip_audit_is_the_known_absent_case(self) -> None:
+        """pip-audit is deliberately not wired up; this pins the fact the gate depends on."""
+        assert "pip-audit" not in _invoked_tools(), (
+            "pip-audit is invoked again — that is fine, but this test and the docs that "
+            "were pruned in #1506 should be revisited together."
+        )

--- a/tests/utils/test_gate_scope.py
+++ b/tests/utils/test_gate_scope.py
@@ -1,0 +1,76 @@
+"""The mother repo's own static gates must actually look at its own Python.
+
+Rhiza ships configuration rather than a runtime library, so it has no ``src/`` and
+``SOURCE_FOLDER`` matches nothing. Three of the four path-scoped gates keyed on that
+variable alone, which meant ``make typecheck``, ``make security`` and ``make deps``
+exited **0** having measured nothing here, and ``docs-coverage`` saw only the test
+folders (#1505). A green ``make all`` therefore said less than it appeared to — on the
+one repository that ships those gates to everyone else.
+
+The fix was to give each gate the accumulator shape ``deps`` already had, and to
+contribute ``utils/`` from ``.rhiza/make.d/bundles.mk``. What these tests pin is the
+*outcome* rather than the wiring: a test that grepped ``bundles.mk`` for ``utils`` would
+still pass if python.mk stopped reading the accumulator, which is precisely the
+regression worth catching.
+
+Each gate's folder list is expanded by **make**, not by the recipe's shell, so it is
+visible in ``make -n`` output and no gate has to run. That distinction is what makes
+these assertions possible: the recipes' ``[ -d ... ]`` warnings are printed by a dry run
+whether or not they would fire, so the presence of a warning proves nothing and only the
+expanded value does.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from tests.util import run_make, strip_ansi
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+# Each gate and the make-expanded fragment that carries its resolved folder list.
+# For the three shell-variable gates that is the assignment itself; for `deps` it is
+# deptry's own argument list, which python.mk expands inline.
+_SCOPED_GATES = [
+    ("typecheck", re.compile(r'typecheck_paths="([^"]*)"')),
+    ("security", re.compile(r'bandit_paths="([^"]*)"')),
+    ("docs-coverage", re.compile(r'docstring_paths="([^"]*)"')),
+    # `(?!on:)` skips the "[INFO] Running deptry on:" banner and matches the invocation.
+    ("deps", re.compile(r"deptry (?!on:)([^\n;\\]*)")),
+]
+
+
+@pytest.fixture(scope="module")
+def gate_scopes() -> dict[str, str]:
+    """Dry-run each scoped gate from the repository root and return its resolved folder list."""
+    import logging
+
+    log = logging.getLogger(__name__)
+    scopes: dict[str, str] = {}
+    for target, pattern in _SCOPED_GATES:
+        out = strip_ansi(run_make(log, [target], cwd=_ROOT).stdout)
+        match = pattern.search(out)
+        assert match, f"could not find the resolved folder list for `make {target}` in:\n{out[-800:]}"
+        scopes[target] = match.group(1).strip()
+    return scopes
+
+
+@pytest.mark.parametrize("target", [g[0] for g in _SCOPED_GATES])
+def test_scoped_gate_resolves_a_non_empty_scope(target: str, gate_scopes: dict[str, str]) -> None:
+    """Each path-scoped gate must resolve to at least one folder, or it measures nothing."""
+    assert gate_scopes[target], (
+        f"`make {target}` resolves an empty folder list, so it would exit 0 having scanned "
+        f"nothing. Contribute a folder via the accumulators in .rhiza/make.d/bundles.mk (#1505)."
+    )
+
+
+@pytest.mark.parametrize("target", [g[0] for g in _SCOPED_GATES])
+def test_scoped_gate_covers_utils(target: str, gate_scopes: dict[str, str]) -> None:
+    """utils/ holds this repo's only non-test Python, so every scoped gate must include it."""
+    assert "utils" in gate_scopes[target], (
+        f"`make {target}` resolves to {gate_scopes[target]!r}, which omits utils/ — the "
+        f"tooling behind `make sync-self` and the sync-self-check CI drift guard."
+    )

--- a/utils/link_dogfood.py
+++ b/utils/link_dogfood.py
@@ -173,11 +173,45 @@ def _link_one(root: Path, rel: str, source: Path) -> bool:
     return True
 
 
+def _owner_by_content(root_path: Path, owners: list[Path]) -> tuple[str, Path | None]:
+    """Pick the single bundle source whose bytes match ``root_path``.
+
+    Split out of :func:`_classify_dogfood` so that function stays a short ladder of
+    *eligibility* questions and this one holds the *content* comparison. Both halves
+    return the same ``(kind, source)`` verdict, so the split is invisible to callers.
+
+    Size is compared before content deliberately: a dogfood copy that diverges from
+    its bundle source usually differs in length, so the cheap check settles most
+    non-matches without reading either file. ``tests/utils/test_link_dogfood.py``
+    pins that ordering.
+
+    Args:
+        root_path: The concrete root file being classified.
+        owners: The bundle files that claim ``root_path``'s bundle-relative path.
+
+    Returns:
+        A ``(kind, source)`` verdict — see :func:`_classify_dogfood` for the vocabulary.
+    """
+    root_size = root_path.stat().st_size
+    same_size_owners = [o for o in owners if o.stat().st_size == root_size]
+    if not same_size_owners:
+        return ("skip", None)  # diverges from every owner — an (undeclared) override; leave it real
+    root_bytes = root_path.read_bytes()
+    identical = [o for o in same_size_owners if o.read_bytes() == root_bytes]
+    if not identical:
+        return ("skip", None)  # diverges from every owner — an (undeclared) override; leave it real
+    if len(identical) > 1:
+        return ("ambiguous", None)
+    return ("link", identical[0])
+
+
 def _classify_dogfood(root: Path, rel: str, index: dict[str, list[Path]]) -> tuple[str, Path | None]:
     """Classify a tracked root path for dogfood linking.
 
     This is the eligibility decision for a single file, factored out of
     :func:`relink` so the loop there stays a straight-line consumer of the verdict.
+    The byte-level comparison lives in :func:`_owner_by_content`; what remains here
+    is the ladder of reasons a path never reaches it.
 
     Args:
         root: The repository root.
@@ -209,17 +243,7 @@ def _classify_dogfood(root: Path, rel: str, index: dict[str, list[Path]]) -> tup
     # so the sole owner is the answer — and with several, the linker must not guess.
     if root_path.is_symlink() and not root_path.exists():
         return ("link", owners[0]) if len(owners) == 1 else ("ambiguous", None)
-    root_size = root_path.stat().st_size
-    same_size_owners = [o for o in owners if o.stat().st_size == root_size]
-    if not same_size_owners:
-        return ("skip", None)  # diverges from every owner — an (undeclared) override; leave it real
-    root_bytes = root_path.read_bytes()
-    identical = [o for o in same_size_owners if o.read_bytes() == root_bytes]
-    if not identical:
-        return ("skip", None)  # diverges from every owner — an (undeclared) override; leave it real
-    if len(identical) > 1:
-        return ("ambiguous", None)
-    return ("link", identical[0])
+    return _owner_by_content(root_path, owners)
 
 
 def _report(*, check: bool, linked: int, unchanged: int, ambiguous: list[str], pending: list[str]) -> int:


### PR DESCRIPTION
Fixes #1505, #1506, #1507, #1508 — the four findings from a `/rhiza:quality` run on this repo.

They share a root cause worth stating plainly: **rhiza is the one repo where its own gates were least exercised.** It ships configuration rather than a runtime library, so it has no `src/`, and three of the four path-scoped Python gates keyed on `SOURCE_FOLDER` alone. `make typecheck` and `make security` printed a warning and exited **0**; `make deps` scanned one notebook; `docs-coverage` saw only the test folders. All four are prerequisites of `all`, so a green `make all` here proved considerably less than it looked like it did — and nothing pointed that out, because an exit code of 0 is an exit code of 0.

## What changed

### `fix(gates)` — a folder accumulator for the other three gates (#1505)

`deps` already took its list from `DEPTRY_FOLDERS`, which any bundle could append to. `TYPECHECK_FOLDERS`, `BANDIT_FOLDERS` and `DOCSTRING_FOLDERS` now mirror that shape, each seeding itself from `SOURCE_FOLDER` when it exists — so **a project that never touches them behaves exactly as before**. This also closes the same hole for any downstream project with a `scripts/` or `tools/` directory.

`utils/` is contributed from `.rhiza/make.d/bundles.mk`. That fragment rather than the root `Makefile`, because the root `Makefile` turns out to be a dogfood symlink into `bundles/core/` — editing it would ship rhiza's own layout to every consumer.

Repointing `SOURCE_FOLDER` would have been the smaller diff and the wrong one: it also drives `--cov`, and `utils/` sits at 81% against a 90% gate.

One deliberate behaviour change: the folder list is expanded by **make** rather than by each recipe's shell, so `make -n` now shows the real scope. The old `[ -d ... ]` form printed its assignment whether or not the branch would fire, i.e. a dry run reported a scope the real run would not use.

### `docs` — stop claiming pip-audit, and gate the claim (#1506)

pip-audit runs nowhere: not in `make security`, not in `.github/workflows/`, not in the `github` bundle. The removal was deliberate and is pinned by `tests/api/test_makefile_targets.py:190`. Ten documents went on describing it anyway.

Two had teeth — `docs/ops/CII_BEST_PRACTICES.md` is a self-attestation against an external standard, and `docs/paper/rhiza.tex` is published prose. The GitLab `COMPARISON.md` row was doubly stale, crediting a `rhiza_validate.yml` that exists in neither platform's bundle.

Dependency-CVE coverage actually rests on Dependabot + Renovate, CodeQL, OpenSSF Scorecard, and Trivy for images. **Whether to reinstate a lockfile scanner is a separate question** — this only corrects the record.

Also fixes an adjacent error found in the same block: `CLAUDE.md` claimed `make typecheck` uses *pyright*, when it runs ty and `mypy --strict`.

### `fix(typecheck)` — a mypy config (#1507)

No type-checker config existed anywhere. The gate itself was never ambiguous (it passes `--strict` and the paths on the command line), but `uvx mypy` gave a contributor default strictness over the whole tree. `[tool.mypy]` with `strict = true` and `files = ["utils"]` makes the two agree.

### `refactor(dogfood)` — `_classify_dogfood` (#1508)

C (14), the only C-or-worse block outside the test suite. **My diagnosis in the issue was wrong about the cause**: I guessed the carve-out list, but that is already data (`_EXCLUDE`, `_NO_FOLLOW_NAMES`, `is_dogfood_carveout`). The complexity came from the size-then-bytes ladder, which moves to `_owner_by_content`. `utils/` now averages A (4.69) with no C-rank block.

## Two new regression guards, both with positive controls

- `tests/utils/test_gate_scope.py` — each gate must resolve a non-empty scope naming `utils`. It asserts the **outcome, not the wiring**: a test grepping `bundles.mk` for `utils` would still pass if `python.mk` stopped reading the accumulator. Verified to fail under `TYPECHECK_FOLDERS=`.
- `TestToolClaims` in `test_doc_consistency.py` — derives which tools are actually invoked from the make fragments and workflows, then fails any doc naming one that isn't. Derived rather than declared, so wiring a tool back up re-permits every mention of it in the same commit.

That second guard earned its place immediately: while running its own positive control I used `git checkout` on `GLOSSARY.md`, which silently reverted a real fix along with the test line. The gate caught it on the next `make all`. It covers a failure class no existing gate did — interrogate asks whether a docstring *exists* and markdownlint whether the markdown is *well-formed*; neither asks whether the claim is *true*.

## Verification

- `make all` green: **1510 passed, 45 skipped** (was 1429 — 81 new tests, all skips unchanged and opt-in)
- All four gates now measure real code: ty + `mypy --strict` clean over `utils/`, bandit clean, deptry across 3 files, docs-coverage 100% over 1046 items
- **`make e2e E2E_ARGS=tests/e2e/test_python_layer_e2e.py` — all 14 gates pass against a real scaffold that does have a `src/`**, which is the check that matters for downstream consumers
- `make sync-self-check` — no dogfood drift
- Rust and Go layers untouched by the `python.mk` change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
