### PR TITLE
fix: close the six quality findings (#1516, #1517, #1518, #1519, #1520, #1521)

### DIFF
--- a/.rhiza/make.d/bundles.mk
+++ b/.rhiza/make.d/bundles.mk
@@ -34,6 +34,7 @@ BANDIT_FOLDERS    += utils
 DOCSTRING_FOLDERS += utils
 DEPTRY_FOLDERS    += utils
 SEMGREP_FOLDERS   += utils
+COVERAGE_FOLDERS  += utils
 DEPTRY_IGNORE     += --ignore DEP004
 
 # Which end-to-end modules `make e2e` runs. One per language layer, so CI can give

--- a/.rhiza/template-bundles.yml
+++ b/.rhiza/template-bundles.yml
@@ -313,7 +313,7 @@ bundles:
     description: "Optional Python testing extras: benchmark, hypothesis-test, stress and mutation gates"
     standalone: true
     requires:
-      - book
+      - book          # ships docs/development/TESTS.md, which needs the book's docs/ tree
       - core
       - python-core   # test.mk reads TESTS_FOLDER and pytest.ini from the layer
     notes: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,6 +291,7 @@ The root `Makefile` is intentionally thin (~10 lines) and only `include`s `.rhiz
 | `go.mk` | go-core | `install`, `all`, and the go-backed gates |
 | `doctor.mk` | core | `make doctor` environment checks |
 | `quality.mk` | core | `fmt`, `todos`, `semgrep`, `rhiza-test` — the language-neutral gates |
+| `completions.mk` | core | `install-completions` — shell tab-completion for make targets (`SHELL_KIND=bash\|zsh\|both`) |
 | `custom-env.mk` | core | example stub: project variables |
 | `custom-task.mk` | core | example stub: project targets/hooks |
 | `test.mk` | tests | `benchmark`, `hypothesis-test`, `stress`, `mutation` — the optional extras |

--- a/bundles/core/.rhiza/make.d/quality.mk
+++ b/bundles/core/.rhiza/make.d/quality.mk
@@ -93,8 +93,19 @@ semgrep: install ## run Semgrep static analysis
 # `test_a_profile_never_selects_two_bundles_from_one_layer` and
 # `test_every_profile_selects_a_language_layer` bracket that from both sides. A
 # core-only tree is not a shipped configuration; there, this fails naming `install`.
+#
+# RHIZA_DOCTEST_FOLDERS carries the doctest scope to the shipped test_docstrings.py, which
+# had resolved `src` and nothing else — so a project keeping Python outside its source root
+# had its docstring examples skipped rather than checked (#1517). DOCSTRING_FOLDERS is the
+# same accumulator `make docs-coverage` reads, so "has a docstring" and "the example in it
+# still works" cannot end up scoped differently.
+#
+# Naming a python-core variable from core is safe in the way `install` above is: on a Rust
+# or Go layer the variable is simply undefined, the value is empty, and the suite falls
+# back to SOURCE_FOLDER exactly as before.
 rhiza-test: install ## run rhiza's own tests (if any)
 	@if [ -d ".rhiza/tests" ]; then \
+		RHIZA_DOCTEST_FOLDERS="$(strip $(DOCSTRING_FOLDERS))" \
 		${UV_BIN} run --with pytest --with pytest-timeout --with python-dotenv --with packaging pytest .rhiza/tests; \
 	else \
 		printf "${YELLOW}[WARN] No .rhiza/tests directory found, skipping rhiza-tests${RESET}\n"; \

--- a/bundles/python-core/.rhiza/make.d/python.mk
+++ b/bundles/python-core/.rhiza/make.d/python.mk
@@ -142,13 +142,24 @@ ifneq ($(wildcard $(SOURCE_FOLDER)),)
 DEPTRY_FOLDERS += $(SOURCE_FOLDER)
 endif
 
-# The same accumulator shape, for the other three path-scoped gates. `deps` has had
+# The same accumulator shape, for the other four path-scoped gates. `deps` has had
 # one since the bundle model began; `typecheck`, `security` and `docs-coverage` each
 # hard-coded SOURCE_FOLDER instead, so any Python a project keeps *outside* its source
 # root was unreachable by three of the four static gates (#1505). The mother repo is
 # the extreme case — it has no `src/` at all, so those three exited 0 having measured
 # nothing — but a downstream project with a `scripts/` or `tools/` directory has the
 # identical hole.
+#
+# COVERAGE_FOLDERS joined them in #1516, and it is the same bug one gate later: `test`
+# still passed `--cov=$(SOURCE_FOLDER)` behind a `[ -d ... ]`, so on a project with no
+# `src/` the suite ran and measured no coverage at all — silently, since a missing
+# source folder is a warning rather than a failure. `utils/` in this very repo was the
+# proof: reachable by four gates, invisible to the fifth.
+#
+# It is a *separate* accumulator from the other four rather than a reuse of one, because
+# the questions differ. A folder can be worth type-checking or scanning without being
+# worth a coverage percentage (generated code, a vendored tree), and DEPTRY_FOLDERS in
+# particular already carries folders — marimo.mk's notebooks — that no test imports.
 #
 # Each seeds itself from SOURCE_FOLDER when that folder exists, so a project that never
 # touches these variables gets precisely the previous behaviour. A bundle or a consuming
@@ -158,13 +169,27 @@ endif
 # that used to live in each recipe. That is a deliberate change in what `make -n` prints:
 # the shell form emitted its assignment whether or not the folder existed, so a dry run
 # reported a scope the real run would not use.
+# One asymmetry here is deliberate rather than an oversight, and is recorded because it
+# reads as one (#1518): `docs-coverage` folds in the test folders on top of this list,
+# while `typecheck` does not. So a repo's tests are held to the docstring bar and not to
+# the typing bar.
+#
+# The reason is that `typecheck` runs mypy in --strict mode, and strict mode's
+# no-untyped-def is a poor fit for a pytest suite: fixtures arrive untyped from pytest,
+# parametrize decorators erase signatures, and monkeypatch stand-ins must match a
+# signature they cannot import. Measured on this repo, extending the scope reports 627
+# errors in 66 files, none of which is a defect. A consumer who does want its tests
+# type-checked appends them: `TYPECHECK_FOLDERS += tests` in the root Makefile or
+# local.mk, which is the accumulator's whole purpose.
 TYPECHECK_FOLDERS ?=
 BANDIT_FOLDERS ?=
 DOCSTRING_FOLDERS ?=
+COVERAGE_FOLDERS ?=
 ifneq ($(wildcard $(SOURCE_FOLDER)),)
 TYPECHECK_FOLDERS += $(SOURCE_FOLDER)
 BANDIT_FOLDERS += $(SOURCE_FOLDER)
 DOCSTRING_FOLDERS += $(SOURCE_FOLDER)
+COVERAGE_FOLDERS += $(SOURCE_FOLDER)
 endif
 
 # Named `deps`, matching rust.mk and go.mk. This was the one gate whose *target name*
@@ -222,28 +247,29 @@ license: install ## run license compliance scan (fail on GPL, LGPL, AGPL)
 # 0% coverage on the next run.
 test:: install ## run all tests
 	@rm -rf _tests
-	@if [ -z "$$(find ${TESTS_FOLDER} -name 'test_*.py' -o -name '*_test.py' 2>/dev/null)" ]; then \
+	@coverage_paths="$(strip $(COVERAGE_FOLDERS))"; \
+	if [ -z "$$(find ${TESTS_FOLDER} -name 'test_*.py' -o -name '*_test.py' 2>/dev/null)" ]; then \
 	  printf "${YELLOW}[WARN] No test files found in ${TESTS_FOLDER}, skipping tests.${RESET}\n"; \
 	  exit 0; \
 	fi; \
-	if [ -d ${SOURCE_FOLDER} ]; then \
-	  set -- -n auto \
-	    --ignore=${TESTS_FOLDER}/benchmarks \
-	    --ignore=${TESTS_FOLDER}/stress \
-	    --cov=${SOURCE_FOLDER} \
+	set -- -n auto \
+	  --ignore=${TESTS_FOLDER}/benchmarks \
+	  --ignore=${TESTS_FOLDER}/stress; \
+	if [ -n "$${coverage_paths}" ]; then \
+	  printf "${BLUE}[INFO] Measuring coverage in:$${coverage_paths}${RESET}\n"; \
+	  for coverage_path in $${coverage_paths}; do \
+	    set -- "$$@" --cov="$${coverage_path}"; \
+	  done; \
+	  set -- "$$@" \
 	    --cov-report=term \
 	    --cov-report=html:_tests/html-coverage \
 	    --cov-fail-under=$(COVERAGE_FAIL_UNDER) \
 	    --cov-report=json:_tests/coverage.json \
-	    --cov-report=xml:_tests/coverage.xml \
-	    --html=_tests/html-report/report.html; \
+	    --cov-report=xml:_tests/coverage.xml; \
 	else \
-	  printf "${YELLOW}[WARN] Source folder ${SOURCE_FOLDER} not found, running tests without coverage${RESET}\n"; \
-	  set -- -n auto \
-	    --ignore=${TESTS_FOLDER}/benchmarks \
-	    --ignore=${TESTS_FOLDER}/stress \
-	    --html=_tests/html-report/report.html; \
+	  printf "${YELLOW}[WARN] No coverage folders found (COVERAGE_FOLDERS is empty and SOURCE_FOLDER='${SOURCE_FOLDER}' does not exist), running tests without coverage${RESET}\n"; \
 	fi; \
+	set -- "$$@" --html=_tests/html-report/report.html; \
 	attempt=1; max_attempts=2; \
 	while :; do \
 	  rm -f .coverage .coverage.* _tests/coverage.xml _tests/coverage.json 2>/dev/null || true; \

--- a/bundles/python-core/.rhiza/tests/test_docstrings.py
+++ b/bundles/python-core/.rhiza/tests/test_docstrings.py
@@ -4,12 +4,31 @@ This file and its associated tests flow down via a SYNC action from the jebel-qu
 (https://github.com/jebel-quant/rhiza).
 
 Automatically discovers all packages and runs doctests for each.
+
+**Scope.** The folders searched come from ``RHIZA_DOCTEST_FOLDERS``, which ``quality.mk``
+sets from python-core's ``DOCSTRING_FOLDERS`` accumulator — the same list ``make
+docs-coverage`` uses. With the variable unset (running pytest by hand, say) it falls back
+to ``SOURCE_FOLDER`` from ``.rhiza/.env``, defaulting to ``src``.
+
+That indirection exists because this gate used to resolve ``src`` and nothing else, so a
+project keeping Python outside its source root had its docstring examples silently
+skipped — the mother repo being the extreme case, with no ``src/`` at all and 23 unchecked
+examples in ``utils/`` (#1517). It is the same hole #1505 closed for the Makefile gates
+and #1516 for coverage, in the shipped suite rather than in make.
+
+**Two layouts, deliberately.** A folder may hold packages (``src/mypkg/__init__.py``) or
+loose scripts (``utils/link_dogfood.py``); both carry docstrings worth checking, so both
+are discovered. A module that cannot be imported is reported as a warning and skipped, not
+failed: a loose script may execute at import, and "we could not measure this" is a
+different statement from "this example is wrong".
 """
 
 from __future__ import annotations
 
 import doctest
 import importlib
+import importlib.util
+import os
 import warnings
 from pathlib import Path
 
@@ -18,6 +37,9 @@ from dotenv import dotenv_values
 
 # Read .rhiza/.env at collection time (no environment side-effects).
 RHIZA_ENV_PATH = Path(".rhiza/.env")
+
+# Set by `make rhiza-test` from DOCSTRING_FOLDERS; whitespace-separated.
+DOCTEST_FOLDERS_ENV = "RHIZA_DOCTEST_FOLDERS"
 
 
 def _iter_modules_from_path(logger, package_path: Path, src_path: Path):
@@ -49,62 +71,129 @@ def _find_packages(src_path: Path):
             yield package_dir
 
 
+def _doctest_folders(root: Path, values: dict) -> list[Path]:
+    """Return the existing folders whose docstrings should be doctested.
+
+    Args:
+        root: The repository root.
+        values: The parsed ``.rhiza/.env`` mapping.
+
+    Returns:
+        Each configured folder that exists, in order, without duplicates.
+    """
+    configured = os.environ.get(DOCTEST_FOLDERS_ENV, "").split()
+    if not configured:
+        configured = [values.get("SOURCE_FOLDER") or "src"]
+
+    folders: list[Path] = []
+    for name in configured:
+        path = root / name
+        if path.is_dir() and path not in folders:
+            folders.append(path)
+    return folders
+
+
+def _iter_loose_modules(logger, folder: Path):
+    """Import the top-level ``*.py`` files in ``folder`` that are not part of a package.
+
+    A folder of standalone scripts (``utils/``, ``scripts/``, ``tools/``) has no
+    ``__init__.py``, so :func:`_find_packages` never reaches it even though its docstrings
+    may carry examples. Each file is loaded from its path rather than by module name, so
+    no ``sys.path`` manipulation is needed and two folders may hold same-named scripts.
+
+    Args:
+        logger: The test logger.
+        folder: The directory to scan (not recursed — a package below it is the other
+            discovery path's job).
+
+    Yields:
+        Each imported module. A module that raises on import is warned about and skipped:
+        a loose script may run code at import time, and being unable to measure an example
+        is not the same as the example being wrong.
+    """
+    if (folder / "__init__.py").exists():
+        return  # a package; _find_packages handles it
+
+    for path in sorted(folder.glob("*.py")):
+        spec = importlib.util.spec_from_file_location(path.stem, path)
+        if spec is None or spec.loader is None:  # pragma: no cover - defensive
+            continue
+        module = importlib.util.module_from_spec(spec)
+        try:
+            spec.loader.exec_module(module)
+        except BaseException as e:  # noqa: BLE001 - a script may raise or SystemExit on import
+            warnings.warn(f"Could not import {path}: {e}", stacklevel=2)
+            logger.warning("Could not import loose module %s: %s", path, e)
+            continue
+        yield module
+
+
 def test_doctests(logger, root, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]):
-    """Run doctests for each package directory."""
+    """Run doctests for every module in the configured folders."""
     values = dotenv_values(root / RHIZA_ENV_PATH) if (root / RHIZA_ENV_PATH).exists() else {}
-    source_folder = values.get("SOURCE_FOLDER", "src")
-    src_path = root / source_folder
+    folders = _doctest_folders(root, values)
 
-    logger.info("Starting doctest discovery in: %s", src_path)
-    if not src_path.exists():
-        logger.info("Source directory not found: %s — skipping doctests", src_path)
-        pytest.skip(f"Source directory not found: {src_path}")
-
-    # Add source path to sys.path with automatic cleanup
-    monkeypatch.syspath_prepend(str(src_path))
-    logger.debug("Prepended to sys.path: %s", src_path)
+    logger.info("Starting doctest discovery in: %s", [str(f) for f in folders] or "(nothing configured)")
+    if not folders:
+        configured = os.environ.get(DOCTEST_FOLDERS_ENV) or values.get("SOURCE_FOLDER") or "src"
+        logger.info("No doctest folder exists (looked for: %s) — skipping doctests", configured)
+        pytest.skip(f"No doctest folder found (looked for: {configured})")
 
     total_tests = 0
     total_failures = 0
     failed_modules = []
 
-    # Find all packages in the source path (supports namespace packages)
-    for package_dir in _find_packages(src_path):
-        if package_dir.is_dir() and (package_dir / "__init__.py").exists():
-            # Import the package
-            package_name = package_dir.name
-            logger.info("Discovered package: %s", package_name)
-            try:
-                modules = list(_iter_modules_from_path(logger, package_dir, src_path))
-                logger.debug("%d module(s) found in package %s", len(modules), package_name)
+    def _run(module) -> None:
+        """Run one module's doctests and fold the result into the running totals."""
+        nonlocal total_tests, total_failures
+        logger.debug("Running doctests for module: %s", module.__name__)
+        # Disable pytest's stdout capture during doctest to avoid interference
+        with capsys.disabled():
+            results = doctest.testmod(
+                module,
+                verbose=False,
+                optionflags=(doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE),
+            )
+        total_tests += results.attempted
 
-                for module in modules:
-                    logger.debug("Running doctests for module: %s", module.__name__)
-                    # Disable pytest's stdout capture during doctest to avoid interference
-                    with capsys.disabled():
-                        results = doctest.testmod(
-                            module,
-                            verbose=False,
-                            optionflags=(doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE),
-                        )
-                    total_tests += results.attempted
+        if results.failed:
+            logger.warning(
+                "Doctests failed for %s: %d/%d failed",
+                module.__name__,
+                results.failed,
+                results.attempted,
+            )
+            total_failures += results.failed
+            failed_modules.append((module.__name__, results.failed, results.attempted))
+        else:
+            logger.debug("Doctests passed for %s (%d test(s))", module.__name__, results.attempted)
 
-                    if results.failed:
-                        logger.warning(
-                            "Doctests failed for %s: %d/%d failed",
-                            module.__name__,
-                            results.failed,
-                            results.attempted,
-                        )
-                        total_failures += results.failed
-                        failed_modules.append((module.__name__, results.failed, results.attempted))
-                    else:
-                        logger.debug("Doctests passed for %s (%d test(s))", module.__name__, results.attempted)
+    for src_path in folders:
+        # Add the folder to sys.path with automatic cleanup
+        monkeypatch.syspath_prepend(str(src_path))
+        logger.debug("Prepended to sys.path: %s", src_path)
 
-            except ImportError as e:
-                warnings.warn(f"Could not import package {package_name}: {e}", stacklevel=2)
-                logger.warning("Could not import package %s: %s", package_name, e)
-                continue
+        # Find all packages in the folder (supports namespace packages)
+        for package_dir in _find_packages(src_path):
+            if package_dir.is_dir() and (package_dir / "__init__.py").exists():
+                # Import the package
+                package_name = package_dir.name
+                logger.info("Discovered package: %s", package_name)
+                try:
+                    modules = list(_iter_modules_from_path(logger, package_dir, src_path))
+                    logger.debug("%d module(s) found in package %s", len(modules), package_name)
+
+                    for module in modules:
+                        _run(module)
+
+                except ImportError as e:
+                    warnings.warn(f"Could not import package {package_name}: {e}", stacklevel=2)
+                    logger.warning("Could not import package %s: %s", package_name, e)
+                    continue
+
+        # And the loose scripts, which no package walk reaches
+        for module in _iter_loose_modules(logger, src_path):
+            _run(module)
 
     if failed_modules:
         formatted = "\n".join(f"  {name}: {failed}/{attempted} failed" for name, failed, attempted in failed_modules)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,3 +161,16 @@ marimo = "marimo"
 numpy = "numpy"
 plotly = "plotly"
 pandas = "pandas"
+
+[tool.coverage.report]
+# `make test` now measures COVERAGE_FOLDERS rather than a hard-coded SOURCE_FOLDER
+# (#1516), which brought utils/ under the coverage gate for the first time. These are
+# the conventional non-executable exclusions; without them the `__main__` guard at the
+# foot of each script counts as a missed statement it is not possible to cover from a
+# test that imports the module.
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+    "raise NotImplementedError",
+]

--- a/tests/api/test_makefile_targets.py
+++ b/tests/api/test_makefile_targets.py
@@ -157,7 +157,14 @@ class TestMakefile:
         assert "--cov-report=xml:_tests/coverage.xml" in out
 
     def test_test_target_without_source_folder(self, logger, tmp_path):
-        """Test target should run without coverage when SOURCE_FOLDER doesn't exist."""
+        """Test target should run without coverage when no coverage folder resolves.
+
+        Asserts the *resolved scope* rather than the shell that computes it. This test
+        used to pin the literal `if [ -d nonexistent_src ]`, which #1516 replaced with the
+        COVERAGE_FOLDERS accumulator every other path-scoped gate already used — so it was
+        testing the wiring, and broke on a change that preserved the behaviour exactly.
+        `coverage_paths` is expanded by make, so a dry run shows the real scope.
+        """
         # Update .env to set SOURCE_FOLDER to a non-existent directory
         env_file = tmp_path / ".rhiza" / ".env"
         env_content = env_file.read_text()
@@ -170,11 +177,27 @@ class TestMakefile:
 
         proc = run_make(logger, ["test"])
         out = proc.stdout
-        # Should see warning about missing source folder
-        assert "if [ -d nonexistent_src ]" in out
-        # Should still run pytest but without coverage flags
+        # The accumulator seeds itself only from a SOURCE_FOLDER that exists, so nothing
+        # contributes one here and the gate measures no coverage.
+        assert 'coverage_paths=""' in out
+        # Should still run pytest, and still write the HTML test report.
         assert "uv run --with pytest" in out
         assert "--html=_tests/html-report/report.html" in out
+
+    def test_test_target_measures_the_source_folder_when_it_exists(self, logger, tmp_path):
+        """The default case: an existing SOURCE_FOLDER seeds COVERAGE_FOLDERS by itself.
+
+        The companion to the test above, and the reason #1516 is not a behaviour change
+        for a project laid out conventionally: it gets exactly the previous scope without
+        setting anything.
+        """
+        (tmp_path / "src").mkdir(exist_ok=True)
+        (tmp_path / "tests").mkdir(exist_ok=True)
+
+        proc = run_make(logger, ["test"])
+        out = proc.stdout
+        assert 'coverage_paths="src"' in out
+        assert "--cov-fail-under=" in out
 
     def test_docs_coverage_target_dry_run(self, logger):
         """Docs coverage should run interrogate over the docstring paths."""

--- a/tests/docs/test_doc_consistency.py
+++ b/tests/docs/test_doc_consistency.py
@@ -186,6 +186,60 @@ class TestBundleDocumentation:
         )
 
 
+def _make_module_names() -> list[str]:
+    """Return the basename of every ``.rhiza/make.d/*.mk`` fragment that ships or runs here.
+
+    The union of two sources, because neither alone is complete: the bundle sources carry
+    ``rust.mk`` and ``go.mk``, which the mother repo never materialises (it runs one
+    language layer), while ``bundles.mk`` exists only at the root because no bundle ships
+    it.
+    """
+    names = {p.name for p in _ROOT.glob("bundles/*/.rhiza/make.d/*.mk")}
+    names |= {p.name for p in (_ROOT / ".rhiza" / "make.d").glob("*.mk")}
+    return sorted(names)
+
+
+def _claude_md_make_module_table() -> set[str]:
+    """Return the ``.rhiza/make.d/`` filenames listed in CLAUDE.md's ownership table.
+
+    Reads the table itself rather than the whole document on purpose: the gap this
+    guards against is a fragment mentioned somewhere in the prose while missing from the
+    map a contributor actually uses to find its owning bundle.
+    """
+    claude_md = (_ROOT / "CLAUDE.md").read_text(encoding="utf-8")
+    header = "| `.rhiza/make.d/` file | owner bundle | provides |"
+    assert header in claude_md, "CLAUDE.md no longer contains the .rhiza/make.d ownership table header"
+    body = claude_md.split(header, 1)[1].split("\n\n", 1)[0]
+    return set(re.findall(r"^\|\s*`([^`]+\.mk)`\s*\|", body, re.MULTILINE))
+
+
+class TestMakeModuleDocumentation:
+    """Verify CLAUDE.md's ``.rhiza/make.d`` ownership table lists every shipped fragment.
+
+    The bundle tables are guarded in both directions; this one used to be guarded only
+    doc-to-repo (``test_mentioned_make_targets_exist``), so a fragment could be added
+    without ever being mapped to its owner. ``completions.mk`` reached main that way.
+    """
+
+    @pytest.mark.parametrize("module_name", _make_module_names())
+    def test_make_module_documented_in_claude_md(self, module_name: str) -> None:
+        """Every shipped .rhiza/make.d fragment must have a row in the ownership table."""
+        assert module_name in _claude_md_make_module_table(), (
+            f"'{module_name}' ships in .rhiza/make.d/ but has no row in CLAUDE.md's ownership table — "
+            "add one naming its owner bundle, so a contributor knows which bundle source to edit"
+        )
+
+    def test_the_table_lists_no_unknown_modules(self) -> None:
+        """The table must not name a fragment that no bundle ships and the root lacks."""
+        unknown = _claude_md_make_module_table() - set(_make_module_names())
+        assert not unknown, f"CLAUDE.md's ownership table names .rhiza/make.d fragments that do not exist: {unknown}"
+
+    def test_the_table_was_parsed(self) -> None:
+        """Guard against the table scanner silently collecting nothing."""
+        assert len(_claude_md_make_module_table()) > 10, "expected the ownership table to list many fragments"
+        assert len(_make_module_names()) > 10, "expected to discover many .rhiza/make.d fragments"
+
+
 _BUNDLE_TAXONOMY = _ROOT / "docs" / "reference" / "BUNDLE_TAXONOMY.md"
 
 

--- a/tests/utils/test_gate_scope.py
+++ b/tests/utils/test_gate_scope.py
@@ -29,8 +29,17 @@ written to prevent, for as long as the bug existed.
 
 So ``test_every_declared_accumulator_is_guarded`` derives the expected set from the
 bundle sources: every ``*_FOLDERS ?=`` declaration across ``bundles/*/.rhiza/make.d/`` is
-an accumulator some gate reads, and each must appear below. Adding a sixth path-scoped
+an accumulator some gate reads, and each must appear below. Adding a further path-scoped
 gate now fails this suite until it is guarded, rather than joining silently.
+
+That guard did its job, and also showed where it ends. ``coverage`` was the *sixth*
+path-scoped gate and #1505 never converted it: ``test`` still passed
+``--cov=$(SOURCE_FOLDER)`` behind a ``[ -d ... ]``, so here the suite ran and measured no
+coverage whatsoever. Deriving from declarations catches a gate that has an accumulator and
+is unguarded; it is structurally blind to one that never declared an accumulator at all.
+#1516 gave ``coverage`` the same shape as the rest, which is what brings it into range of
+the derivation — the lesson being that this file's completeness argument holds only once a
+gate has opted into the convention.
 """
 
 from __future__ import annotations
@@ -56,6 +65,7 @@ _SCOPED_GATES = [
     ("security", "BANDIT_FOLDERS", re.compile(r'bandit_paths="([^"]*)"')),
     ("docs-coverage", "DOCSTRING_FOLDERS", re.compile(r'docstring_paths="([^"]*)"')),
     ("semgrep", "SEMGREP_FOLDERS", re.compile(r'semgrep_paths="([^"]*)"')),
+    ("test", "COVERAGE_FOLDERS", re.compile(r'coverage_paths="([^"]*)"')),
     # `(?!on:)` skips the "[INFO] Running deptry on:" banner and matches the invocation.
     ("deps", "DEPTRY_FOLDERS", re.compile(r"deptry (?!on:)([^\n;\\]*)")),
 ]
@@ -96,6 +106,30 @@ def test_scoped_gate_covers_utils(target: str, gate_scopes: dict[str, str]) -> N
     assert "utils" in gate_scopes[target], (
         f"`make {target}` resolves to {gate_scopes[target]!r}, which omits utils/ — the "
         f"tooling behind `make sync-self` and the sync-self-check CI drift guard."
+    )
+
+
+def test_rhiza_test_carries_the_docstring_scope_to_the_shipped_doctests(logger) -> None:
+    """`make rhiza-test` must hand the shipped test_docstrings.py the same scope as docs-coverage.
+
+    Not a member of ``_SCOPED_GATES``: ``RHIZA_DOCTEST_FOLDERS`` is not an accumulator of
+    its own but a *carrier* for ``DOCSTRING_FOLDERS``, so the derivation above would flag
+    it as stale. The property is worth pinning separately, because the two halves are one
+    invariant — ``docs-coverage`` asking whether a docstring exists while the doctest
+    runner looks somewhere else is exactly the split that let 23 examples in ``utils/`` go
+    unchecked (#1517).
+    """
+    out = strip_ansi(run_make(logger, ["rhiza-test"], cwd=_ROOT).stdout)
+    match = re.search(r'RHIZA_DOCTEST_FOLDERS="([^"]*)"', out)
+    assert match, f"`make rhiza-test` no longer passes RHIZA_DOCTEST_FOLDERS:\n{out[-800:]}"
+    scope = match.group(1).strip()
+    assert scope, (
+        "`make rhiza-test` resolves an empty doctest scope, so test_docstrings.py would "
+        "skip and the repo's docstring examples would go unchecked (#1517)."
+    )
+    assert "utils" in scope, (
+        f"`make rhiza-test` scopes doctests to {scope!r}, which omits utils/ — where this "
+        f"repo's only non-test Python, and its only docstring examples, live."
     )
 
 

--- a/tests/utils/test_link_dogfood.py
+++ b/tests/utils/test_link_dogfood.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import importlib.util
+import os
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -122,3 +125,240 @@ def test_classify_dogfood_refuses_to_guess_a_dangling_symlink_with_two_owners(ro
         owners.append(owner)
 
     assert module._classify_dogfood(tmp_path, rel, {rel: owners}) == ("ambiguous", None)
+
+
+# The tests below were added with #1516, which brought utils/ under the coverage gate for
+# the first time: `make test` had measured only SOURCE_FOLDER, which does not exist here,
+# so this module's happy paths — every branch that actually writes a symlink — had never
+# been executed by anything. They are grouped by the function under test rather than
+# interleaved above, so the pre-existing regression tests stay legible as a set.
+
+
+def test_link_one_creates_a_relative_symlink(root, tmp_path) -> None:
+    """The write path must produce a *relative* link and report that it created one."""
+    module = _load_module(root)
+    rel = "file.txt"
+    source = tmp_path / "bundles" / "core" / "file.txt"
+    source.parent.mkdir(parents=True)
+    source.write_text("content", encoding="utf-8")
+    (tmp_path / rel).write_text("content", encoding="utf-8")
+
+    assert module._link_one(tmp_path, rel, source) is True
+
+    link = tmp_path / rel
+    assert link.is_symlink()
+    # Relative, not absolute: an absolute target would break for every other checkout.
+    assert os.readlink(link) == os.path.join("bundles", "core", "file.txt")
+    assert link.read_text(encoding="utf-8") == "content"
+
+
+def test_link_one_is_idempotent(root, tmp_path) -> None:
+    """A second run over an already-correct link must be a no-op, not a rewrite.
+
+    This is what makes `make sync-self` safe to run repeatedly and what lets
+    `sync-self-check` distinguish "already linked" from "would link".
+    """
+    module = _load_module(root)
+    rel = "file.txt"
+    source = tmp_path / "bundles" / "core" / "file.txt"
+    source.parent.mkdir(parents=True)
+    source.write_text("content", encoding="utf-8")
+    (tmp_path / rel).write_text("content", encoding="utf-8")
+
+    assert module._link_one(tmp_path, rel, source) is True
+    assert module._link_one(tmp_path, rel, source) is False
+
+
+def test_link_one_removes_the_temp_link_when_replace_fails(root, tmp_path, monkeypatch) -> None:
+    """A failure *after* the temporary symlink exists must not leave it behind.
+
+    The `finally` branch is the only thing standing between a crashed run and a
+    repository littered with `.file.txt.XXXX` symlinks that git would then report.
+    """
+    module = _load_module(root)
+    rel = "file.txt"
+    source = tmp_path / "source.txt"
+    source.write_text("content", encoding="utf-8")
+    (tmp_path / rel).write_text("original", encoding="utf-8")
+
+    def _raise_replace(self: Path, target) -> None:
+        """Stand-in for ``Path.replace`` that always fails."""
+        msg = "replace failed"
+        raise OSError(msg)
+
+    monkeypatch.setattr(Path, "replace", _raise_replace)
+
+    with pytest.raises(OSError, match="replace failed"):
+        module._link_one(tmp_path, rel, source)
+
+    leftovers = [p.name for p in tmp_path.iterdir() if p.name.startswith(".file.txt.")]
+    assert leftovers == [], f"temporary symlinks left behind: {leftovers}"
+    assert (tmp_path / rel).read_text(encoding="utf-8") == "original"
+
+
+def test_owner_by_content_skips_when_sizes_match_but_bytes_differ(root, tmp_path) -> None:
+    """Equal size is only the cheap pre-filter — differing bytes still mean 'leave it real'."""
+    module = _load_module(root)
+    root_file = tmp_path / "file.txt"
+    root_file.write_text("aaa", encoding="utf-8")
+    owner = tmp_path / "owner.txt"
+    owner.write_text("bbb", encoding="utf-8")  # same length, different content
+
+    assert module._owner_by_content(root_file, [owner]) == ("skip", None)
+
+
+def test_owner_by_content_is_ambiguous_when_two_owners_match(root, tmp_path) -> None:
+    """Byte-identical to two bundles: refuse to guess an owner rather than pick one."""
+    module = _load_module(root)
+    root_file = tmp_path / "file.txt"
+    root_file.write_text("content", encoding="utf-8")
+    owners = []
+    for name in ("a.txt", "b.txt"):
+        owner = tmp_path / name
+        owner.write_text("content", encoding="utf-8")
+        owners.append(owner)
+
+    assert module._owner_by_content(root_file, owners) == ("ambiguous", None)
+
+
+@pytest.mark.parametrize(
+    "rel",
+    [
+        "bundles/core/ruff.toml",  # a bundle source itself
+        ".python-version",  # a declared mother-repo override
+        ".github/dependabot.yml",  # GitHub does not resolve symlinks
+        ".rhiza/.gitignore",  # git opens this with O_NOFOLLOW
+    ],
+)
+def test_classify_dogfood_skips_bundle_sources_and_carveouts(root, tmp_path, rel: str) -> None:
+    """Every carve-out reason must short-circuit before any content comparison."""
+    module = _load_module(root)
+    target = tmp_path / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("content", encoding="utf-8")
+    owner = tmp_path / "owner.txt"
+    owner.write_text("content", encoding="utf-8")
+
+    assert module._classify_dogfood(tmp_path, rel, {rel: [owner]}) == ("skip", None)
+
+
+def test_classify_dogfood_skips_a_path_with_no_bundle_owner(root, tmp_path) -> None:
+    """A root-only file (no bundle claims its path) is not a dogfood copy."""
+    module = _load_module(root)
+    (tmp_path / "root_only.txt").write_text("content", encoding="utf-8")
+
+    assert module._classify_dogfood(tmp_path, "root_only.txt", {}) == ("skip", None)
+
+
+def test_report_names_each_ambiguous_path_and_fails(root, capsys) -> None:
+    """An ambiguous match must be named on stdout, not just counted, and must exit non-zero."""
+    module = _load_module(root)
+
+    rc = module._report(check=False, linked=0, unchanged=1, ambiguous=["shared.toml"], pending=[])
+
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "shared.toml" in out
+    assert "ambiguous" in out
+
+
+def test_report_succeeds_when_nothing_is_ambiguous_or_pending(root, capsys) -> None:
+    """The all-clear path returns 0 and still prints a summary line."""
+    module = _load_module(root)
+
+    rc = module._report(check=False, linked=2, unchanged=3, ambiguous=[], pending=[])
+
+    assert rc == 0
+    assert "2 linked, 3 already correct" in capsys.readouterr().out
+
+
+def test_relink_exits_when_there_is_no_bundles_directory(root, tmp_path) -> None:
+    """Run from the wrong directory, the linker must say so rather than link nothing quietly."""
+    module = _load_module(root)
+
+    with pytest.raises(SystemExit) as excinfo:
+        module.relink(tmp_path)
+
+    assert "No bundles/ directory found" in str(excinfo.value)
+
+
+def test_relink_write_mode_links_skips_and_flags_ambiguity(root, tmp_path, capsys) -> None:
+    """One pass must link the eligible copy, skip the carve-out, and flag the ambiguous one."""
+    module = _load_module(root)
+
+    linkable = tmp_path / "linkable.txt"
+    linkable.write_text("linkable", encoding="utf-8")
+    source = tmp_path / "source.txt"
+    source.write_text("linkable", encoding="utf-8")
+
+    # A declared mother-repo override: it has an owner but must stay a real file.
+    carveout = tmp_path / ".python-version"
+    carveout.write_text("3.12", encoding="utf-8")
+    carveout_owner = tmp_path / "owner-version.txt"
+    carveout_owner.write_text("3.12", encoding="utf-8")
+
+    shared = tmp_path / "shared.toml"
+    shared.write_text("shared", encoding="utf-8")
+    shared_owners = []
+    for name in ("owner_a.toml", "owner_b.toml"):
+        owner = tmp_path / name
+        owner.write_text("shared", encoding="utf-8")
+        shared_owners.append(owner)
+
+    index = {
+        "linkable.txt": [source],
+        ".python-version": [carveout_owner],
+        "shared.toml": shared_owners,
+    }
+
+    rc = module.relink(tmp_path, index)
+
+    assert rc == 1, "an ambiguous match must fail the run"
+    assert linkable.is_symlink(), "the eligible copy should have been linked"
+    assert not carveout.is_symlink(), "a declared override must stay a real file"
+    assert not shared.is_symlink(), "an ambiguous match must not be guessed"
+
+    out = capsys.readouterr().out
+    assert "1 linked, 0 already correct, 1 ambiguous" in out
+
+
+def test_relink_counts_an_already_correct_link_as_unchanged(root, tmp_path, capsys) -> None:
+    """Re-running over a linked tree must report it unchanged and succeed."""
+    module = _load_module(root)
+    source = tmp_path / "source.txt"
+    source.write_text("content", encoding="utf-8")
+    (tmp_path / "linked.txt").symlink_to("source.txt")
+
+    rc = module.relink(tmp_path, {"linked.txt": [source]})
+
+    assert rc == 0
+    assert "0 linked, 1 already correct, 0 ambiguous" in capsys.readouterr().out
+
+
+def test_relink_scans_bundles_and_git_when_given_no_index(root, tmp_path) -> None:
+    """With no index, the real entry point reads bundles/ and `git ls-files`.
+
+    This is the only test that exercises `_bundle_index` and `_tracked_files` together,
+    i.e. the path `make sync-self` actually takes.
+    """
+    module = _load_module(root)
+    git = shutil.which("git")
+    if git is None:  # pragma: no cover - git is present on every supported runner
+        pytest.skip("git is not installed")
+
+    source = tmp_path / "bundles" / "core" / "ruff.toml"
+    source.parent.mkdir(parents=True)
+    source.write_text("line-length = 120\n", encoding="utf-8")
+    (tmp_path / "ruff.toml").write_text("line-length = 120\n", encoding="utf-8")
+
+    for args in (
+        ["init", "-q"],
+        ["-c", "user.email=t@example.com", "-c", "user.name=T", "add", "-A"],
+        ["-c", "user.email=t@example.com", "-c", "user.name=T", "commit", "-qm", "initial"],
+    ):
+        subprocess.run([git, *args], cwd=tmp_path, check=True, capture_output=True)
+
+    assert module.relink(tmp_path) == 0
+    assert (tmp_path / "ruff.toml").is_symlink()
+    # The bundle source itself must never be linked to itself.
+    assert not source.is_symlink()

--- a/utils/link_dogfood.py
+++ b/utils/link_dogfood.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 
 import os
 import shutil
-import subprocess  # nosec B404 - git is invoked with a fixed, non-user argument list
+import subprocess  # nosec B404  # git is invoked with a fixed, non-user argument list
 import sys
 import tempfile
 from pathlib import Path
@@ -160,7 +160,7 @@ def _tracked_files(root: Path) -> list[str]:
     Returns:
         The list of tracked file paths reported by ``git ls-files``.
     """
-    result = subprocess.run(  # noqa: S603  # nosec B603 - resolved git path, fixed args, no shell
+    result = subprocess.run(  # noqa: S603  # nosec B603  # resolved git path, fixed args, no shell
         [_GIT, "ls-files"],
         cwd=root,
         capture_output=True,


### PR DESCRIPTION
Closes #1516, closes #1517, closes #1518, closes #1519, closes #1520, closes #1521.

All six came out of a `/rhiza:quality` run on this repo. Two of them are the same bug #1505 fixed, one gate later each; the rest are documentation and hygiene.

## The two that matter

**#1516 — `coverage` was the fifth path-scoped gate and the only one #1505 never converted.**

`test` still passed `--cov=$(SOURCE_FOLDER)` behind a `[ -d ... ]`, so on a project with no `src/` the suite ran and measured no coverage at all — and because a missing source folder is a warning rather than a failure, silently. `utils/` was the proof: reachable by `typecheck`, `security`, `docs-coverage` and `deps`, invisible to the fifth gate, on the repo that ships all five.

It now has a `COVERAGE_FOLDERS` accumulator like the rest, `bundles.mk` contributes `utils`, and `test_gate_scope.py` guards it.

Worth noting *why* the existing guard missed it. `test_every_declared_accumulator_is_guarded` derives its expectation from every `*_FOLDERS ?=` declaration in the bundle sources — airtight for a gate that has an accumulator, and structurally blind to one that never declared any. The completeness argument in that file only holds once a gate has opted into the convention, which is now recorded there.

Enabling the gate meant earning the 90% floor:

```
utils/explain_bundles.py      59      0   100%
utils/link_dogfood.py        107      0   100%
Required test coverage of 90% reached. Total coverage: 100.00%
```

`link_dogfood.py` was at 80%, and the gap was entirely the write paths — every branch that actually creates a symlink had never been executed by anything. Twelve tests cover them, including the `finally` cleanup that keeps a crashed run from leaving `.file.txt.XXXX` symlinks behind, and the real `relink()` entry point over a git repo.

**#1517 — the shipped docstring gate had the same hole.**

`test_docstrings.py` resolved `src` and skipped when absent, so this repo's 23 docstring examples in `utils/` were never run. `make rhiza-test` reported a clean 39 passed / 1 skipped while checking none of them.

It now takes its scope from `RHIZA_DOCTEST_FOLDERS`, which `quality.mk` sets from `DOCSTRING_FOLDERS` — the same list `docs-coverage` reads, so "has a docstring" and "the example in it still works" cannot end up scoped differently. It also discovers loose scripts rather than only packages: `utils/` has no `__init__.py`, so it was doubly invisible, and a `scripts/`or `tools/` directory downstream has the identical shape.

A module that raises on import is warned about and skipped rather than failed. A loose script may execute at import, and being unable to measure an example is a different statement from the example being wrong.

`make rhiza-test` now reports **40 passed**, running all 23 examples.

## #1518 — left as it is, deliberately

`docs-coverage` folds in the test folders; `typecheck` does not, so tests are held to the docstring bar and not the typing bar. I measured the alternative before choosing: extending `mypy --strict` to `tests/` reports **627 errors in 66 files**, essentially all `no-untyped-def` on pytest fixtures, parametrize-erased signatures and monkeypatch stand-ins. None is a defect.

So the asymmetry is now recorded at the accumulator block with that measurement and the one-line opt-in (`TYPECHECK_FOLDERS += tests`), which is the accumulator's whole purpose. This is the second branch of that issue's `done when`.

## The rest

- **#1519** — `completions.mk` was missing from CLAUDE.md's `.rhiza/make.d` ownership table. The bundle tables are guarded in both directions; this one was guarded only doc→repo, so a fragment could be added without ever being mapped to its owner. `TestMakeModuleDocumentation` parses the table itself rather than the whole document — a mention in prose shouldn't satisfy it, since the gap is precisely a documented feature with no row in the map. I confirmed it fails on exactly that regression before restoring the row.
- **#1521** — the `tests` bundle's `requires: book` now names the file that causes it (`docs/development/TESTS.md`), matching the justification its `python-core` sibling already carried. From `test.mk` alone the edge looks stale, and it isn't.
- **#1520** — two `# nosec` comments used a ` - ` separator, which bandit parses as further test ids; every scan emitted 17 `Test in comment:` warnings. The rationale is preserved, just attached where bandit stops reading.

## A test that pinned the wiring

`test_test_target_without_source_folder` asserted the literal `if [ -d nonexistent_src ]` — the construct this change removes — so it broke on a change that preserves the behaviour exactly. It now asserts the resolved scope (`coverage_paths=""`), which `make` expands so a dry run shows the real value. Added a companion test for the ordinary case where `src/` exists, which nothing covered.

## Verification

`make all` green, and because `python.mk`, `quality.mk` and `test_docstrings.py` all ship downstream, every language layer's e2e suite was run against real toolchains rather than trusting the dry-run assertions:

| suite | result |
| --- | --- |
| `make all` | 1557 passed, 45 skipped; coverage 100% |
| `tests/e2e/test_python_layer_e2e.py` | 14 passed |
| `tests/e2e/test_rust_layer_e2e.py` | 15 passed |
| `tests/e2e/test_go_layer_e2e.py` | 14 passed |

The e2e runs are the load-bearing ones here: they cover `test_test_gate_runs_pytest_and_writes_the_reports_book_mk_reads`, `test_rhiza_test_gate_actually_runs_the_shipped_suite` on all three layers, and `test_all_runs_the_whole_gate_set`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
