### PR TITLE
fix: wire rhiza-test into CI and correct the coverage note (#1523, #1525, #1526)

### DIFF
--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -65,7 +65,23 @@ jobs:
         run: |
           echo "Python versions: ${{ steps.versions-output.outputs.list }}"
 
+      # This workflow serves double duty: it runs on push/PR here, and it is the
+      # reusable workflow every consumer's `github-tests` stub delegates to. So the
+      # OS matrix has to differ by caller (#1526). Rhiza ships Makefiles and shell
+      # recipes to macOS users, and validating them on Linux alone left BSD-userland
+      # portability untested — but forcing macos-latest on every consumer would spend
+      # their minutes to buy *this* repo's assurance. The mother repo therefore opts
+      # itself in and leaves the shipped default alone; a consumer who wants the same
+      # coverage sets RHIZA_CI_OS_MATRIX in its own .rhiza/.env.
+      #
+      # An empty value is not the same as an unset one to make's `?=`, which treats an
+      # exported empty string as set — hence `ci-os-matrix` resolves through
+      # `$(or ...)`, so the empty branch below falls back to ["ubuntu-latest"].
       - id: os
+        env:
+          RHIZA_CI_OS_MATRIX: >-
+            ${{ github.repository == 'jebel-quant/rhiza'
+                && '["ubuntu-latest","macos-latest"]' || '' }}
         run: |
           OS_MATRIX=$(make -f .rhiza/rhiza.mk -s ci-os-matrix)
           echo "list=$OS_MATRIX" >> "$GITHUB_OUTPUT"
@@ -251,6 +267,39 @@ jobs:
       - name: Run deptry
         run: make deps
 
+  rhiza-test:
+    name: Rhiza template tests
+    # Runs the suite the template syncs into .rhiza/tests/ — the [project] structure
+    # gate, docstring coverage, README validation and release-tag checks. `make all`
+    # has always named this target, but no CI job invoked it (#1523), so those
+    # assertions ran only on a developer's machine and constrained nobody else.
+    # CI budget: ≤5 min (small, dependency-light suite). Last measured: 2026-08-15.
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          version: "0.11.16"
+
+      - name: Configure git auth for private packages
+        uses: jebel-quant/actions/configure-git-auth@6d52725ca371d609489c5b50236965ad70bbe528 # v1
+        with:
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Run the shipped .rhiza/tests suite
+        env:
+          UV_EXTRA_INDEX_URL: ${{ secrets.UV_EXTRA_INDEX_URL }}
+        run: make rhiza-test
+
   pre-commit:
     name: Pre-commit hooks
     # CI budget: ≤5 min (lint/format hooks). Last measured: 2026-05-28.
@@ -385,13 +434,16 @@ jobs:
   ci-gate:
     name: CI gate
     # Roll-up gate: a single required status check that aggregates the test,
-    # typecheck, and lowest-deps jobs. Branch protection requires this context
-    # instead of every per-leg name, so the matrix can change without editing
-    # the ruleset.
+    # typecheck, lowest-deps and rhiza-test jobs. Branch protection requires this
+    # context instead of every per-leg name, so the matrix can change without editing
+    # the ruleset — which is why rhiza-test joined here rather than as a seventh
+    # required context (#1523): the roll-up is the mechanism that exists for exactly
+    # this, and adding a context would mean editing the ruleset, its bundle copy and
+    # the sync test that pins the `ci / ` prefix between them.
     # CI budget: ≤5 min (result aggregation only). Last measured: 2026-06-27.
     timeout-minutes: 5
     if: always()
-    needs: [test, typecheck, lowest-deps]
+    needs: [test, typecheck, lowest-deps, rhiza-test]
     runs-on: ubuntu-latest
 
     steps:
@@ -400,17 +452,19 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Verify test, typecheck, and lowest-deps succeeded
+      - name: Verify test, typecheck, lowest-deps and rhiza-test succeeded
         run: |
-          echo "test result:       ${{ needs.test.result }}"
-          echo "typecheck result:  ${{ needs.typecheck.result }}"
+          echo "test result:        ${{ needs.test.result }}"
+          echo "typecheck result:   ${{ needs.typecheck.result }}"
           echo "lowest-deps result: ${{ needs.lowest-deps.result }}"
+          echo "rhiza-test result:  ${{ needs.rhiza-test.result }}"
           # Accept "success" or "cancelled" (transient runner cancellation).
           # Reject "failure" (real failure) and "skipped" (job never ran).
           if [[ "${{ needs.test.result }}" != "success" && "${{ needs.test.result }}" != "cancelled" \
              || "${{ needs.typecheck.result }}" != "success" && "${{ needs.typecheck.result }}" != "cancelled" \
-             || "${{ needs.lowest-deps.result }}" != "success" && "${{ needs.lowest-deps.result }}" != "cancelled" ]]; then
-            echo "::error::test, typecheck, and/or lowest-deps did not succeed; failing the CI gate."
+             || "${{ needs.lowest-deps.result }}" != "success" && "${{ needs.lowest-deps.result }}" != "cancelled" \
+             || "${{ needs.rhiza-test.result }}" != "success" && "${{ needs.rhiza-test.result }}" != "cancelled" ]]; then
+            echo "::error::test, typecheck, lowest-deps and/or rhiza-test did not succeed; failing the CI gate."
             exit 1
           fi
           echo "All required CI jobs succeeded."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,14 +351,25 @@ Hook targets use double-colon syntax (`pre-install::`, `post-install::`) and can
 > is a required status check in `.github/rulesets/main-branch-protection.json`, so
 > renaming it would leave every PR waiting on a context that never reports.
 
-> **Coverage in this repo (mother-repo specifics).** Rhiza has no `src/` and ships no
-> runtime Python, so `make test` prints `Source folder src not found, running tests without
-> coverage` and the main `tests/` suite runs *without* a Python coverage number — by design.
-> Both that suite and `make rhiza-test` (which runs the shipped `.rhiza/tests/` suite) exercise
-> Make targets, YAML, and bundle invariants behaviourally, where there is no Python module to
-> cover. So "no coverage on `make test`" is expected here and does not mean anything is
-> unmeasured. Downstream
-> consumers on the `python-core` layer *do* have a `src/` and get the full 90% `make test` gate.
+> **Coverage in this repo (mother-repo specifics).** Rhiza has no `src/`, so `SOURCE_FOLDER`
+> matches nothing and the coverage scope comes entirely from the `COVERAGE_FOLDERS`
+> accumulator — `.rhiza/make.d/bundles.mk` contributes `utils`, the tooling behind
+> `make sync-self` and the `sync-self-check` drift guard. `make test` therefore prints
+> `Measuring coverage in:utils` and enforces the standard 90% bar, which `utils` currently
+> passes at 100%.
+>
+> **That is recent, and the previous behaviour is worth knowing** because it is the bug the
+> accumulators exist to prevent: until #1516 `test` passed `--cov=$(SOURCE_FOLDER)` behind a
+> `[ -d ... ]`, so on a repo with no `src/` the suite ran and measured no coverage at all —
+> silently, since a missing source folder warns rather than fails. `utils/` was reachable by
+> four gates and invisible to the fifth.
+>
+> What has *not* changed is where this repo's assurance actually comes from. 166 statements
+> of `utils` is a small fraction of it; the `tests/` suite and `make rhiza-test` mostly
+> exercise Make targets, YAML and bundle invariants behaviourally, and no statement-coverage
+> number describes that. A high percentage here is a check on the tooling, not a summary of
+> the suite. Downstream consumers on the `python-core` layer have a real `src/` and get the
+> same 90% gate over it.
 
 ### CI/CD
 

--- a/tests/api/test_ci_workflow.py
+++ b/tests/api/test_ci_workflow.py
@@ -69,11 +69,66 @@ def test_ci_jobs_define_timeout_budgets(root):
         "docs-coverage": 10,
         "security": 10,
         "license": 10,
+        "rhiza-test": 5,
         "ci-gate": 5,
     }
 
     for job_name, timeout in expected.items():
         assert jobs[job_name]["timeout-minutes"] == timeout
+
+
+def test_every_gate_named_by_make_all_runs_in_ci(root):
+    """Each target `make all` names must be invoked by some CI job.
+
+    `make all` is the local aggregate, and a target that only ever runs there is a gate
+    in name only: it constrains one developer's habits, not the repo. `rhiza-test` was
+    exactly that (#1523) — it ran the shipped `.rhiza/tests/` suite, including the
+    doctests `RHIZA_DOCTEST_FOLDERS` scopes (#1517), and no workflow ever invoked it.
+
+    Derived from `all`'s own prerequisite list rather than a hand-written set, so adding
+    a gate to `all` without wiring it into CI fails here instead of passing silently.
+    """
+    all_line = next(
+        line
+        for line in (root / ".rhiza" / "make.d" / "python.mk").read_text(encoding="utf-8").splitlines()
+        if line.startswith("all:")
+    )
+    # "all: fmt deps test ... ## run all CI targets locally"
+    gates = all_line.split("##")[0].split(":", 1)[1].split()
+
+    workflows = (root / ".github" / "workflows").glob("*.yml")
+    invoked = "\n".join(wf.read_text(encoding="utf-8") for wf in workflows)
+
+    missing = [gate for gate in gates if f"make {gate}" not in invoked]
+    assert not missing, (
+        f"these targets are named by `make all` but no .github/workflows job runs them: "
+        f"{missing}. A gate that runs only locally cannot block a pull request (#1523)."
+    )
+
+
+def test_ci_gate_rolls_up_rhiza_test(root):
+    """The roll-up gate must depend on rhiza-test, which is what makes it *required*.
+
+    Branch protection requires the "CI gate" context and not the per-job names, so a job
+    absent from `needs` reports its own check run and blocks nothing. Adding rhiza-test
+    to the roll-up is what gave it teeth without a seventh required context — which would
+    have meant editing the ruleset, its bundle copy, and the sync test pinning the
+    `ci / ` prefix between them.
+    """
+    with (root / WORKFLOW_PATH).open(encoding="utf-8") as fh:
+        workflow = yaml.safe_load(fh)
+
+    gate = workflow["jobs"]["ci-gate"]
+    assert "rhiza-test" in gate["needs"], (
+        f"ci-gate needs {gate['needs']}, which omits rhiza-test — so a failing "
+        f"rhiza-test would not block the PR (#1523)."
+    )
+
+    run_script = next(s["run"] for s in gate["steps"] if "needs." in s.get("run", ""))
+    assert "needs.rhiza-test.result" in run_script, (
+        "ci-gate lists rhiza-test in `needs` but never inspects its result, so the job "
+        "runs and its outcome is discarded."
+    )
 
 
 def test_ci_cache_keys_match_audit_policy(root):

--- a/tests/api/test_workflow_stubs.py
+++ b/tests/api/test_workflow_stubs.py
@@ -208,11 +208,15 @@ class TestCiWorkflow:
         or 'skipped' results.
         """
         gate_steps = ci_workflow.get("jobs", {}).get("ci-gate", {}).get("steps", [])
+        # Matched on the step's *shape* rather than its exact title: the title names the
+        # jobs being rolled up, so it changes whenever one joins (rhiza-test did in #1523)
+        # and an equality check would fail for a reason that has nothing to do with the
+        # cancelled-result property under test.
         verify_step = next(
-            (s for s in gate_steps if s.get("name") == "Verify test, typecheck, and lowest-deps succeeded"),
+            (s for s in gate_steps if s.get("name", "").startswith("Verify") and "needs." in s.get("run", "")),
             None,
         )
-        assert verify_step is not None, "CI gate must have a verification step"
+        assert verify_step is not None, "CI gate must have a verification step reading job results"
 
         run_script = verify_step.get("run", "")
         # The gate must not simply check `!= "success"` — it must also allow `cancelled`.

--- a/tests/utils/test_gate_scope.py
+++ b/tests/utils/test_gate_scope.py
@@ -109,6 +109,32 @@ def test_scoped_gate_covers_utils(target: str, gate_scopes: dict[str, str]) -> N
     )
 
 
+def test_claude_md_does_not_claim_the_suite_runs_without_coverage(gate_scopes: dict[str, str]) -> None:
+    """CLAUDE.md must not describe `make test` as coverage-free while the gate resolves a scope.
+
+    The two halves drifted apart in #1525: #1516 gave `test` a COVERAGE_FOLDERS accumulator
+    and `utils` started being measured, but CLAUDE.md's mother-repo note still told readers
+    the suite ran "*without* a Python coverage number — by design". A contributor reading it
+    would conclude a green `make test` proves nothing about coverage, when in fact there is a
+    90% gate they can break.
+
+    Checked against the *resolved* scope rather than a hardcoded expectation, so if this repo
+    ever legitimately returns to measuring nothing, the claim becomes true again and this
+    test stops objecting.
+    """
+    stale_claims = ("running tests without coverage", "without* a Python coverage number")
+    prose = (_ROOT / "CLAUDE.md").read_text(encoding="utf-8")
+
+    if not gate_scopes["test"]:
+        pytest.skip("`make test` resolves an empty coverage scope, so the coverage-free claim holds")
+
+    found = [claim for claim in stale_claims if claim in prose]
+    assert not found, (
+        f"CLAUDE.md still says {found} about this repo, but `make test` resolves a coverage "
+        f"scope of {gate_scopes['test']!r} and enforces COVERAGE_FAIL_UNDER against it (#1525)."
+    )
+
+
 def test_rhiza_test_carries_the_docstring_scope_to_the_shipped_doctests(logger) -> None:
     """`make rhiza-test` must hand the shipped test_docstrings.py the same scope as docs-coverage.
 


### PR DESCRIPTION
Closes #1523, #1525, #1526. **#1524 is invalid** — see below.

## #1523 — `rhiza-test` never ran in CI

`make all` names eight gates. Enumerating every `make` invocation across `.github/workflows/*.yml` returned seven; `rhiza-test` was in none. The 40 assertions in `.rhiza/tests/` — pyproject structure, README validation, release tags, and the doctest runner scoped by `RHIZA_DOCTEST_FOLDERS` (#1517) — constrained one developer's habits rather than the repo.

Added a `rhiza-test` job and put it in **`ci-gate`'s `needs`** rather than making it a seventh required context. The roll-up exists for exactly this ("so the matrix can change without editing the ruleset"); a new context would have meant editing the ruleset, its bundle copy, and the sync test that pins the `ci / ` prefix between them.

## #1526 — CI exercised one OS

`RHIZA_CI_OS_MATRIX` was set nowhere, so `ci-os-matrix` returned its default `["ubuntu-latest"]`.

Scoped to this repo via `github.repository ==` on the `os` step, **not** a workflow-level `env:`. This file is also the reusable workflow every consumer's `github-tests` stub delegates to, so a blanket setting would spend consumers' minutes to buy the mother repo's assurance. Consumers keep the shipped default and opt in through their own `.rhiza/.env`.

macOS is the useful addition — BSD userland is where recipe portability actually breaks. The full suite already passes on macOS locally (1560 passed on darwin 24.6.0), so this is not a speculative expansion.

## #1525 — stale coverage note

`CLAUDE.md` said `make test` prints `Source folder src not found, running tests without coverage` and runs "*without* a Python coverage number — by design". It actually prints `Measuring coverage in:utils` and enforces the 90% bar at 100%. The paragraph went stale when #1516 gave `test` a `COVERAGE_FOLDERS` accumulator. Rewritten, keeping the genuinely useful half: 166 statements of `utils` is a check on the tooling, not a summary of a suite that is mostly behavioural.

## #1524 — filed in error, closing as invalid

I reported that nothing executed the 23 doctest examples in `utils/`. That was wrong: `.rhiza/tests/test_docstrings.py` runs them, scoped via `RHIZA_DOCTEST_FOLDERS` ← `DOCSTRING_FOLDERS`, which is what #1517 closed. My check grepped `pytest.ini`, `python.mk` and `.pre-commit-config.yaml` for `doctest` and never looked in `.rhiza/tests/` — where the shipped docstring gate lives.

I briefly added a parallel `DOCTEST_FOLDERS` accumulator and reverted it: it would have run the same examples twice per `make all` and duplicated an existing carrier. The real defect was that the gate running them never ran in CI, which is #1523.

## Tests

Three new tests, each checked against a negative control (the fix removed → the test fails):

- `test_every_gate_named_by_make_all_runs_in_ci` — derives the gate list from `all`'s own prerequisites, so a target added to `all` without CI wiring fails here instead of passing silently. This is the test that would have caught #1523.
- `test_ci_gate_rolls_up_rhiza_test` — asserts both that `needs` contains it and that the script inspects its result; listing without inspecting would discard the outcome.
- `test_claude_md_does_not_claim_the_suite_runs_without_coverage` — checked against the *resolved* scope, so if this repo ever legitimately measures nothing again the claim becomes true and the test stops objecting.

`test_ci_gate_tolerates_cancelled_results` matched the verify step by exact title, which named the rolled-up jobs and so broke when one joined. Now matched on shape.

## Verification

`make test` (1560 passed, +3, 45 skipped) · `make fmt` · `make rhiza-test` (40) · `make docs-coverage` (100%) · `make sync-self-check` (49/49, no drift) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
