### PR TITLE
fix: close the five quality findings (#1528, #1529, #1530, #1531, #1532)

### DIFF
--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -110,6 +110,48 @@ jobs:
           UV_EXTRA_INDEX_URL: ${{ secrets.UV_EXTRA_INDEX_URL }}
         run: make semgrep
 
+  # The one check that the pinned $UV_IMAGE in bundles/gitlab/.gitlab-ci.yml still
+  # pulls and runs a job. It is opt-in behind RHIZA_GITLAB_DOCKER because it pulls a
+  # large image — and until #1528 nothing anywhere set that variable, so it was
+  # skipped in CI and locally alike while reading as covered. Weekly is the right
+  # cadence: no GitLab pipeline runs in this repo at all, so a retired image tag would
+  # otherwise surface first in a downstream gitlab-project consumer.
+  gitlab-docker:
+    name: GitLab pipeline against the pinned image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          version: "0.11.16"
+
+      - name: Configure git auth for private packages
+        uses: jebel-quant/actions/configure-git-auth@6d52725ca371d609489c5b50236965ad70bbe528 # v1
+        with:
+          token: ${{ secrets.GH_PAT }}
+
+      # The test skips itself when docker or npx is missing, which is correct on a
+      # developer's laptop and useless here: a silent skip is exactly the state #1528
+      # closed. Both are preinstalled on ubuntu-latest, so assert them and fail the
+      # job if a future runner image drops either.
+      - name: Verify docker and npx are available
+        run: |
+          docker --version
+          npx --version
+
+      - name: Run the Docker-backed GitLab job test
+        env:
+          UV_EXTRA_INDEX_URL: ${{ secrets.UV_EXTRA_INDEX_URL }}
+        run: make gitlab-docker-test
+
   link-check:
     name: Check links in README.md
     runs-on: ubuntu-latest

--- a/.rhiza/make.d/bundles.mk
+++ b/.rhiza/make.d/bundles.mk
@@ -2,7 +2,7 @@
 # Provides make explain-bundles for new contributors unfamiliar with the bundle model.
 # Mother-repo-only fragment: no bundle ships it, so it is never synced downstream.
 
-.PHONY: explain-bundles sync-self sync-self-check e2e
+.PHONY: explain-bundles sync-self sync-self-check e2e gitlab-docker-test
 
 # Bring utils/ into the five path-scoped gates.
 #
@@ -10,7 +10,7 @@
 # matches nothing. That left `typecheck`, `security` and `deps` exiting 0 having measured
 # nothing, and `docs-coverage` seeing only the test folders (#1505) — on the one repo that
 # ships those gates to everyone else. But real Python does live here: utils/ holds the
-# mother-repo tooling behind `make sync-self` and the sync-self-check CI drift guard.
+# mother-repo tooling behind `make sync-self` and the `sync-self-check` drift check.
 #
 # `semgrep` joined them in #1511. It has the same shape and had the same hole, but was
 # missed by #1505 because it is owned by core's quality.mk rather than by python.mk — and
@@ -49,7 +49,11 @@ explain-bundles: ## print all bundles and profiles with descriptions and depende
 sync-self: ## relink root dogfood copies as symlinks into bundles/ (mother repo only)
 	@uv run utils/link_dogfood.py
 
-sync-self-check: ## fail if any dogfood symlink is stale/missing without writing (CI drift guard, mother repo only)
+# The local drift check, for use before committing a new bundle file. In CI the same
+# invariant is asserted by tests/bundles/test_bundle_dogfood_symlinks.py inside
+# `make test` — using link_dogfood's own carve-out predicate and bundle index, so the
+# two cannot disagree. No workflow runs this target (#1532).
+sync-self-check: ## fail if any dogfood symlink is stale/missing without writing (local drift check, mother repo only)
 	@uv run utils/link_dogfood.py --check
 
 # The language-layer end-to-end suite: assemble a profile into a temp directory,
@@ -74,3 +78,21 @@ sync-self-check: ## fail if any dogfood symlink is stale/missing without writing
 e2e: install ## run the language-layer end-to-end suite against real toolchains (opt-in, mother repo only)
 	@printf "${BLUE}[INFO] Running end-to-end suite: $(E2E_ARGS)${RESET}\n"
 	@RHIZA_E2E=1 ${UV_BIN} run --with pytest-timeout pytest $(E2E_ARGS) -v
+
+# The Docker-backed half of the GitLab suite: run a real job under gitlab-ci-local
+# against the pinned $UV_IMAGE from bundles/gitlab/.gitlab-ci.yml.
+#
+# Opt-in for the same reason `e2e` is — it pulls a large image and needs Docker and
+# Node — but opt-in without an entry point is how it came to run nowhere at all
+# (#1528): RHIZA_GITLAB_DOCKER was set by no workflow, no target and no .env, so the
+# one check that the pinned image still pulls and runs was skipped in every
+# environment. rhiza_weekly.yml calls this target; the cadence matches the cost, and
+# a retired image tag is a slow failure rather than a sudden one.
+#
+# `-m gitlab_exec` selects by marker (registered in tests/conftest.py) rather than by
+# node id, so a second Docker-backed test is picked up by writing it, not by editing
+# this recipe. The test still skips itself when docker or npx is missing, so this is
+# safe to run on a machine without either.
+gitlab-docker-test: install ## run the Docker-backed GitLab job test against the pinned image (opt-in, mother repo only)
+	@printf "${BLUE}[INFO] Running the Docker-backed GitLab job test${RESET}\n"
+	@RHIZA_GITLAB_DOCKER=1 ${UV_BIN} run pytest tests/bundles/test_gitlab_ci.py -m gitlab_exec -v

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,8 @@ A few files **cannot** be symlinks and stay as **real copies**, kept in sync by 
 
 Plus intentional mother-repo overrides that deliberately diverge from their bundle source: root `.gitignore`, `.pre-commit-config.yaml`, `.python-version`, `SECURITY.md`, `renovate.json`. The exclusion list lives in `utils/link_dogfood.py`. Downstream consumers are unaffected: `rhiza-cli` sparse-checks-out a bundle and dereferences symlinks on copy, so synced projects always receive real files (guarded by `test_no_symlinks_in_*`).
 
+**What guards the invariant in CI is `tests/bundles/test_bundle_dogfood_symlinks.py`, not `make sync-self-check`.** The test runs inside `make test` on every push and PR, and it reuses `link_dogfood`'s own carve-out predicate and bundle index, so the guard and the linker cannot disagree about the rules. `sync-self-check` is the *local* equivalent — the same `--check` pass, for running before you commit a new bundle file — and no workflow invokes it. It was described as "the CI drift guard" in four places until #1532, which is the kind of claim that stops anyone checking whether the real guard still exists.
+
 ### Language layers
 
 `core` used to be a Python project in disguise: it created a virtualenv, ran `uv sync`
@@ -178,7 +180,7 @@ Python kept *outside* the source root was unreachable by three of the four stati
 The mother repo was the extreme case — it ships configuration, not a library, so it has no
 `src/` at all and `typecheck`, `security` and `deps` each exited **0** having measured
 nothing, on the very repo that ships those gates to everyone else. `utils/` (the tooling
-behind `make sync-self` and the `sync-self-check` drift guard) is contributed from
+behind `make sync-self` and the `sync-self-check` drift check) is contributed from
 `.rhiza/make.d/bundles.mk`, which is mother-repo-only — the root `Makefile` cannot hold it,
 being a dogfood symlink into `bundles/core/`. `tests/utils/test_gate_scope.py` asserts the
 outcome rather than the wiring: each gate must resolve to a non-empty list naming `utils`.
@@ -302,7 +304,7 @@ The root `Makefile` is intentionally thin (~10 lines) and only `include`s `.rhiz
 | `paper.mk` | paper | LaTeX paper compilation |
 | `lfs.mk` | lfs | Git LFS install/track/status |
 | `github.mk` | github | GitHub repo/workflow helpers |
-| `bundles.mk` | *(mother-repo only — no bundle ships it)* | `explain-bundles`, `sync-self`, `sync-self-check`, `e2e` |
+| `bundles.mk` | *(mother-repo only — no bundle ships it)* | `explain-bundles`, `sync-self`, `sync-self-check`, `e2e`, `gitlab-docker-test` |
 
 Hook targets use double-colon syntax (`pre-install::`, `post-install::`) and can be defined multiple times to chain behaviour. Add project-specific hooks directly in the root `Makefile` above the include line. Developer-local shortcuts go in `local.mk` (not committed).
 
@@ -354,7 +356,7 @@ Hook targets use double-colon syntax (`pre-install::`, `post-install::`) and can
 > **Coverage in this repo (mother-repo specifics).** Rhiza has no `src/`, so `SOURCE_FOLDER`
 > matches nothing and the coverage scope comes entirely from the `COVERAGE_FOLDERS`
 > accumulator — `.rhiza/make.d/bundles.mk` contributes `utils`, the tooling behind
-> `make sync-self` and the `sync-self-check` drift guard. `make test` therefore prints
+> `make sync-self` and the `sync-self-check` drift check. `make test` therefore prints
 > `Measuring coverage in:utils` and enforces the standard 90% bar, which `utils` currently
 > passes at 100%.
 >
@@ -381,4 +383,6 @@ This repo runs on **GitHub Actions only**: `.github/workflows/` — CI, e2e, rel
 
 GitLab support ships as a **template for downstream consumers**, not as active CI in this repo: the `gitlab` bundle (`bundles/gitlab/`) materializes a `.gitlab-ci.yml` plus `.gitlab/` pipelines into projects that adopt the `gitlab-project` profile, mirroring the GitHub Actions coverage there.
 
-Because no GitLab pipeline runs here, `tests/bundles/test_gitlab_ci.py` validates the GitLab templates without a GitLab host: it assembles a `gitlab-project` and (1) checks every container image the pipeline/Dockerfiles reference actually exists on its registry (the guard that catches a retired tag like the removed `uv:*-bookworm`), (2) runs `gitlab-ci-local` (pinned, via `npx`) to resolve every `include:` and validate the merged pipeline against GitLab's JSON schema. A third test actually runs a job in Docker against the pinned `$UV_IMAGE` — it needs Docker and is opt-in: `RHIZA_GITLAB_DOCKER=1 make test` (or run it directly). All three skip cleanly when their dependency (network / Node / Docker) is absent, so `make test` stays green offline.
+Because no GitLab pipeline runs here, `tests/bundles/test_gitlab_ci.py` validates the GitLab templates without a GitLab host: it assembles a `gitlab-project` and (1) checks every container image the pipeline/Dockerfiles reference actually exists on its registry (the guard that catches a retired tag like the removed `uv:*-bookworm`), (2) runs `gitlab-ci-local` (pinned, via `npx`) to resolve every `include:` and validate the merged pipeline against GitLab's JSON schema. A third test actually runs a job in Docker against the pinned `$UV_IMAGE` — it needs Docker and Node and is opt-in behind `RHIZA_GITLAB_DOCKER`, reached as **`make gitlab-docker-test`**. All three skip cleanly when their dependency (network / Node / Docker) is absent, so `make test` stays green offline.
+
+That third one is the reason the target exists (#1528). Opt-in was correct — it pulls a large image — but the variable was set by no workflow, no target and no `.env`, so the only check that the pinned image still pulls and runs was skipped in *every* environment while reading as covered. `.github/workflows/rhiza_weekly.yml` now calls the target on the weekly schedule, and asserts `docker`/`npx` are present first so a runner image that drops either fails the job instead of quietly reinstating the skip. Weekly matches the cost, and matches the risk: no GitLab pipeline runs here, so a retired image tag would otherwise surface first in a downstream consumer.

--- a/tests/utils/test_doctests.py
+++ b/tests/utils/test_doctests.py
@@ -48,18 +48,7 @@ def _load(root: Path, name: str):  # type: ignore[no-untyped-def]
     return module
 
 
-@pytest.fixture
-def _in_root(root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Run from the repository root.
-
-    ``explain_bundles`` opens ``.rhiza/template-bundles.yml`` at *import* time via a
-    relative path, so it is only importable with the root as the working directory.
-    """
-    monkeypatch.chdir(root)
-
-
 @pytest.mark.parametrize("name", _MODULES)
-@pytest.mark.usefixtures("_in_root")
 def test_doctests_pass(root: Path, name: str) -> None:
     """Every doctest example in the module must evaluate to its documented output."""
     module = _load(root, name)
@@ -72,7 +61,6 @@ def test_doctests_pass(root: Path, name: str) -> None:
 
 
 @pytest.mark.parametrize("name", _MODULES)
-@pytest.mark.usefixtures("_in_root")
 def test_module_carries_examples(root: Path, name: str) -> None:
     """Each module must carry at least one example, or the check above measures nothing."""
     module = _load(root, name)

--- a/tests/utils/test_explain_bundles.py
+++ b/tests/utils/test_explain_bundles.py
@@ -161,11 +161,16 @@ def test_config_path_falls_back_to_the_repo_that_ships_the_script(root, monkeypa
 
 
 def test_main_exits_with_guidance_when_no_config_exists(root, monkeypatch, tmp_path):
-    """A missing config must fail loudly rather than print an empty summary."""
+    """A missing config must fail loudly rather than print an empty summary.
+
+    The expected text is built from the module's own ``_CONFIG_REL`` rather than
+    written out: it is a ``Path``, so it renders with a backslash on Windows, and
+    hard-coding the POSIX form failed the whole Windows matrix while passing locally.
+    """
     module = _load_module(root, monkeypatch, tmp_path, "bundles: {}\nprofiles: {}\n")
     monkeypatch.setattr(module, "_config_path", lambda: tmp_path / "absent" / "template-bundles.yml")
 
-    with pytest.raises(SystemExit, match=re.escape("No .rhiza/template-bundles.yml found")):
+    with pytest.raises(SystemExit, match=re.escape(f"No {module._CONFIG_REL} found")):
         module.main()
 
 

--- a/tests/utils/test_explain_bundles.py
+++ b/tests/utils/test_explain_bundles.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import builtins
 import importlib.util
+import re
 import sys
 from pathlib import Path
 from textwrap import dedent
@@ -14,7 +15,11 @@ from tests.util import strip_ansi
 
 
 def _load_module(root: Path, monkeypatch, tmp_path: Path, yaml_text: str):
-    """Load explain_bundles.py against a temp project whose template-bundles.yml holds yaml_text."""
+    """Load explain_bundles.py against a temp project whose template-bundles.yml holds yaml_text.
+
+    Since #1530 the import itself reads nothing — the chdir is what makes
+    ``_config_path`` prefer the temp project once ``main`` is called.
+    """
     module_path = root / "utils" / "explain_bundles.py"
     config_dir = tmp_path / ".rhiza"
     config_dir.mkdir()
@@ -85,8 +90,8 @@ def test_print_bundle_renders_dependencies_and_standalone_tag(root, monkeypatch,
     assert "Additional detail" not in output
 
 
-def test_import_prints_grouped_bundle_and_profile_sections(root, monkeypatch, tmp_path, capsys):
-    """Importing the script should render bundle and profile summaries from YAML."""
+def test_main_prints_grouped_bundle_and_profile_sections(root, monkeypatch, tmp_path, capsys):
+    """Running main should render bundle and profile summaries from YAML."""
     module = _load_module(
         root,
         monkeypatch,
@@ -106,15 +111,62 @@ def test_import_prints_grouped_bundle_and_profile_sections(root, monkeypatch, tm
             bundles: [core, github-tests]
         """,
     )
+    capsys.readouterr()
+
+    assert module.main() == 0
 
     output = strip_ansi(capsys.readouterr().out)
-    assert module.groups["base"] == {"core": {"description": "Core bundle"}}
+    assert module.group_bundles({"core": {"description": "Core bundle"}})["base"] == {
+        "core": {"description": "Core bundle"}
+    }
     assert "Bundles  (3 total)" in output
     assert "Core & Feature  (1)" in output
     assert "GitHub  (1)" in output
     assert "GitLab  (1)" in output
     assert "Profiles  (1 total)" in output
     assert "expands to: core, github-tests" in output
+
+
+def test_import_reads_nothing_and_works_outside_a_project(root, monkeypatch, tmp_path, capsys):
+    """The module must import from a directory holding no config, printing nothing (#1530).
+
+    The regression this pins is the original defect: the config was opened at import
+    time via a *relative* path, so importing from anywhere but a project root raised
+    ``FileNotFoundError`` before a single function could be called.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    spec = importlib.util.spec_from_file_location("explain_bundles_no_project", root / "utils" / "explain_bundles.py")
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+    assert capsys.readouterr().out == ""
+    assert module._bundle_group("github-tests") == "github"
+
+
+def test_config_path_falls_back_to_the_repo_that_ships_the_script(root, monkeypatch, tmp_path):
+    """With no config in the current directory, the script explains its own repo.
+
+    This is the half that makes the module usable from anywhere: the fallback is
+    resolved from ``__file__``, not from the process working directory.
+    """
+    module = _load_module(root, monkeypatch, tmp_path, "bundles: {}\nprofiles: {}\n")
+    assert module._config_path() == tmp_path / ".rhiza" / "template-bundles.yml"
+
+    monkeypatch.chdir(tmp_path / ".rhiza")  # a directory with no .rhiza/ of its own
+    assert module._config_path() == root / ".rhiza" / "template-bundles.yml"
+
+
+def test_main_exits_with_guidance_when_no_config_exists(root, monkeypatch, tmp_path):
+    """A missing config must fail loudly rather than print an empty summary."""
+    module = _load_module(root, monkeypatch, tmp_path, "bundles: {}\nprofiles: {}\n")
+    monkeypatch.setattr(module, "_config_path", lambda: tmp_path / "absent" / "template-bundles.yml")
+
+    with pytest.raises(SystemExit, match=re.escape("No .rhiza/template-bundles.yml found")):
+        module.main()
 
 
 def test_import_exits_with_install_hint_when_pyyaml_is_missing(root, monkeypatch, tmp_path):

--- a/tests/utils/test_link_dogfood.py
+++ b/tests/utils/test_link_dogfood.py
@@ -362,3 +362,44 @@ def test_relink_scans_bundles_and_git_when_given_no_index(root, tmp_path) -> Non
     assert (tmp_path / "ruff.toml").is_symlink()
     # The bundle source itself must never be linked to itself.
     assert not source.is_symlink()
+
+
+def test_parse_args_defaults_to_write_mode(root) -> None:
+    """With no flags the tool writes — the historical default, preserved (#1531)."""
+    module = _load_module(root)
+
+    assert module._parse_args([]).check is False
+
+
+def test_parse_args_accepts_the_check_flag(root) -> None:
+    """``--check`` selects the non-writing drift check."""
+    module = _load_module(root)
+
+    assert module._parse_args(["--check"]).check is True
+
+
+def test_parse_args_rejects_an_unknown_flag(root, capsys) -> None:
+    """A mistyped flag must fail, not silently fall through to the writing run.
+
+    This is the whole point of #1531: the previous ``"--check" in sys.argv[1:]`` scan
+    treated ``--checks`` as "no flag given", so a user who asked for a preview got the
+    run that rewrites tracked files as symlinks instead.
+    """
+    module = _load_module(root)
+
+    with pytest.raises(SystemExit) as excinfo:
+        module._parse_args(["--checks"])
+
+    assert excinfo.value.code == 2
+    assert "unrecognized arguments: --checks" in capsys.readouterr().err
+
+
+def test_parse_args_documents_check_in_its_help(root, capsys) -> None:
+    """``--help`` must describe ``--check`` rather than leaving it to be read in the source."""
+    module = _load_module(root)
+
+    with pytest.raises(SystemExit) as excinfo:
+        module._parse_args(["--help"])
+
+    assert excinfo.value.code == 0
+    assert "--check" in capsys.readouterr().out

--- a/utils/explain_bundles.py
+++ b/utils/explain_bundles.py
@@ -4,22 +4,29 @@
 # ///
 """Print all Rhiza bundles and profiles with descriptions and dependencies.
 
-Run as a script from a project root that contains ``.rhiza/template-bundles.yml``.
-It reads that file, groups every bundle into the base, GitHub, and GitLab families,
-and prints a colourised summary of each bundle (with its ``requires``/``recommends``
-dependencies) followed by the profiles and the bundles they expand to.
+It reads ``.rhiza/template-bundles.yml``, groups every bundle into the base, GitHub,
+and GitLab families, and prints a colourised summary of each bundle (with its
+``requires``/``recommends`` dependencies) followed by the profiles and the bundles
+they expand to.
+
+Importing this module has **no side effects**: the YAML is read and the summary
+printed only when :func:`main` runs. That is deliberate (#1530) — the config used to
+be opened at import time through a *relative* path, so the module was importable only
+from the repository root, and every consumer (a doctest, a test, another script) had
+to chdir first.
 
 Example:
     Invoke through the Makefile target (the supported entry point)::
 
         $ make explain-bundles
 
-    or run the module directly from the repository root::
+    or run the module directly, from any directory::
 
         $ python utils/explain_bundles.py
 """
 
 import sys
+from pathlib import Path
 
 try:
     import yaml  # type: ignore[import-untyped]
@@ -33,11 +40,8 @@ YELLOW = "\033[33m"
 DIM = "\033[2m"
 RESET = "\033[0m"
 
-with open(".rhiza/template-bundles.yml") as f:
-    data = yaml.safe_load(f)
-
-bundles = data.get("bundles", {})
-profiles = data.get("profiles", {})
+# The config's path relative to whichever project root holds it.
+_CONFIG_REL = Path(".rhiza") / "template-bundles.yml"
 
 
 def _is_github(name: str) -> bool:
@@ -150,33 +154,86 @@ def _print_bundle(name: str, info: dict) -> None:  # type: ignore[type-arg]
         print(f"  {'':24}{DIM}recommends: {', '.join(recommends)}{RESET}")
 
 
-groups: dict[str, dict] = {"base": {}, "github": {}, "gitlab": {}}  # type: ignore[type-arg]
-for name, info in bundles.items():
-    groups[_bundle_group(name)][name] = info
+def _config_path() -> Path:
+    """Locate ``.rhiza/template-bundles.yml``.
 
-base_bundles = groups["base"]
-github_bundles = groups["github"]
-gitlab_bundles = groups["gitlab"]
+    The current directory wins when it holds a config, so the script still explains
+    *this* project when run from a project root. Otherwise the path is resolved
+    relative to this file, which is what makes the module usable from anywhere —
+    including from a test or a doctest that never changes directory.
 
-print(f"\n{BOLD}Bundles{RESET}  ({len(bundles)} total)\n" + "─" * 72)
+    Returns:
+        The config path to read. It is not guaranteed to exist; :func:`main` reports
+        a missing file rather than letting ``open`` raise.
+    """
+    local = Path.cwd() / _CONFIG_REL
+    if local.is_file():
+        return local
+    return Path(__file__).resolve().parent.parent / _CONFIG_REL
 
-print(f"\n  {BOLD}Core & Feature{RESET}  ({len(base_bundles)})\n")
-for name, info in base_bundles.items():
-    _print_bundle(name, info)
 
-print(f"\n  {BOLD}GitHub{RESET}  ({len(github_bundles)})\n")
-for name, info in github_bundles.items():
-    _print_bundle(name, info)
+def group_bundles(bundles: dict) -> dict[str, dict]:  # type: ignore[type-arg]
+    """Split every bundle into its display group.
 
-print(f"\n  {BOLD}GitLab{RESET}  ({len(gitlab_bundles)})\n")
-for name, info in gitlab_bundles.items():
-    _print_bundle(name, info)
+    Args:
+        bundles: The ``bundles`` mapping from ``template-bundles.yml``.
 
-print(f"\n{BOLD}Profiles{RESET}  ({len(profiles)} total)\n" + "─" * 72)
-for name, info in profiles.items():
-    desc = info.get("description", "").strip().splitlines()[0]
-    members = info.get("bundles", [])
-    print(f"  {GREEN}{BOLD}{name:<24}{RESET}{desc}")
-    print(f"  {'':24}{DIM}expands to: {', '.join(members)}{RESET}")
+    Returns:
+        A mapping with exactly the keys ``base``, ``github`` and ``gitlab``, each
+        holding the bundles that belong to that family. Empty families are kept so
+        callers can render a heading with a count of zero.
 
-print()
+    Examples:
+        >>> groups = group_bundles({"core": {}, "github-tests": {}})
+        >>> sorted(groups)
+        ['base', 'github', 'gitlab']
+        >>> list(groups["base"])
+        ['core']
+        >>> list(groups["github"])
+        ['github-tests']
+        >>> groups["gitlab"]
+        {}
+    """
+    groups: dict[str, dict] = {"base": {}, "github": {}, "gitlab": {}}  # type: ignore[type-arg]
+    for name, info in bundles.items():
+        groups[_bundle_group(name)][name] = info
+    return groups
+
+
+def main() -> int:
+    """Read the bundle config and print the bundle and profile summary.
+
+    Returns:
+        ``0`` on success. A missing config exits non-zero with guidance instead of
+        returning, so the caller never prints an empty summary and claims success.
+    """
+    config = _config_path()
+    if not config.is_file():
+        sys.exit(f"{YELLOW}No {_CONFIG_REL} found — run from a project root that has one.{RESET}")
+
+    with open(config) as f:
+        data = yaml.safe_load(f)
+
+    bundles = data.get("bundles", {})
+    profiles = data.get("profiles", {})
+    groups = group_bundles(bundles)
+
+    print(f"\n{BOLD}Bundles{RESET}  ({len(bundles)} total)\n" + "─" * 72)
+    for heading, key in (("Core & Feature", "base"), ("GitHub", "github"), ("GitLab", "gitlab")):
+        print(f"\n  {BOLD}{heading}{RESET}  ({len(groups[key])})\n")
+        for name, info in groups[key].items():
+            _print_bundle(name, info)
+
+    print(f"\n{BOLD}Profiles{RESET}  ({len(profiles)} total)\n" + "─" * 72)
+    for name, info in profiles.items():
+        desc = info.get("description", "").strip().splitlines()[0]
+        members = info.get("bundles", [])
+        print(f"  {GREEN}{BOLD}{name:<24}{RESET}{desc}")
+        print(f"  {'':24}{DIM}expands to: {', '.join(members)}{RESET}")
+
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/utils/link_dogfood.py
+++ b/utils/link_dogfood.py
@@ -31,6 +31,7 @@ Example:
 
 from __future__ import annotations
 
+import argparse
 import os
 import shutil
 import subprocess  # nosec B404  # git is invoked with a fixed, non-user argument list
@@ -311,6 +312,57 @@ def _report(*, check: bool, linked: int, unchanged: int, ambiguous: list[str], p
     return 1 if (ambiguous or pending) else 0
 
 
+def _resolve_inputs(root: Path, index: dict[str, list[Path]] | None) -> tuple[dict[str, list[Path]], list[str]]:
+    """Settle what to scan: the bundle index and the candidate root paths.
+
+    Split out of :func:`relink` so that function is a loop over an already-decided
+    input rather than a loop wrapped in setup. The caller-supplied-index branch is
+    the one unit tests take, which is exactly why it is worth isolating: it must stay
+    equivalent to the scan without duplicating it.
+
+    Args:
+        root: The repository root containing ``bundles/`` and the dogfood files.
+        index: A pre-built bundle index, or None to scan ``bundles/`` and ``git ls-files``.
+
+    Returns:
+        The bundle index and the list of root-relative paths to classify.
+    """
+    if index is not None:
+        return index, list(index.keys())
+    bundles_dir = root / "bundles"
+    if not bundles_dir.is_dir():
+        sys.exit(f"{YELLOW}No bundles/ directory found at {root} — run from the rhiza repo root.{RESET}")
+    return _bundle_index(bundles_dir), _tracked_files(root)
+
+
+def _apply(root: Path, rel: str, source: Path, *, check: bool) -> str:
+    """Link ``rel`` to ``source`` — or, in check mode, report that it would be.
+
+    This holds the whole check-versus-write distinction, so :func:`relink` never
+    branches on ``check`` itself and simply files each path under the verdict it gets
+    back.
+
+    Args:
+        root: The repository root.
+        rel: The dogfood file path relative to ``root``.
+        source: The owning bundle file the symlink should target.
+        check: When True, print and classify without writing anything.
+
+    Returns:
+        One of ``"pending"`` (check mode, not yet linked), ``"linked"`` (a symlink was
+        created) or ``"unchanged"`` (already correct).
+    """
+    if check:
+        if _link_is_current(root, rel, source):
+            return "unchanged"
+        print(f"  {YELLOW}would link{RESET} {rel} {DIM}->{RESET} {source.relative_to(root)}")
+        return "pending"
+    if _link_one(root, rel, source):
+        print(f"  {GREEN}linked{RESET}    {rel} {DIM}->{RESET} {source.relative_to(root)}")
+        return "linked"
+    return "unchanged"
+
+
 def relink(
     root: Path,
     index: dict[str, list[Path]] | None = None,
@@ -324,9 +376,13 @@ def relink(
     more than one bundle) are skipped with a warning rather than guessed.
 
     In ``check`` mode nothing is written: the function only reports the copies that
-    *would* be linked and returns non-zero if any are pending. This is the CI drift
-    guard — it fails a build when someone adds a bundle file (or lets a copy reappear)
-    without running ``make sync-self``.
+    *would* be linked and returns non-zero if any are pending — the local drift check,
+    reached as ``make sync-self-check``, for use before committing a new bundle file.
+
+    In CI the same invariant is asserted by ``tests/bundles/test_bundle_dogfood_symlinks.py``
+    inside ``make test``, which reuses this module's own carve-out predicate and bundle
+    index so the two can never disagree. No workflow calls ``sync-self-check`` itself
+    (#1532).
 
     Args:
         root: The repository root containing ``bundles/`` and the dogfood files.
@@ -342,41 +398,56 @@ def relink(
         Process exit code: ``0`` on success, ``1`` if any file was ambiguous or (in
         ``check`` mode) if any eligible copy is not yet linked.
     """
-    if index is None:
-        bundles_dir = root / "bundles"
-        if not bundles_dir.is_dir():
-            sys.exit(f"{YELLOW}No bundles/ directory found at {root} — run from the rhiza repo root.{RESET}")
-        index = _bundle_index(bundles_dir)
-        files: list[str] = _tracked_files(root)
-    else:
-        files = list(index.keys())
-
-    linked = 0
-    unchanged = 0
-    ambiguous: list[str] = []
-    pending: list[str] = []
+    index, files = _resolve_inputs(root, index)
+    verdicts: dict[str, list[str]] = {"linked": [], "unchanged": [], "pending": [], "ambiguous": []}
 
     for rel in files:
         kind, source = _classify_dogfood(root, rel, index)
         if kind == "ambiguous":
-            ambiguous.append(rel)
-            continue
-        if kind == "skip" or source is None:
-            continue
-        if check:
-            if _link_is_current(root, rel, source):
-                unchanged += 1
-            else:
-                print(f"  {YELLOW}would link{RESET} {rel} {DIM}->{RESET} {source.relative_to(root)}")
-                pending.append(rel)
-        elif _link_one(root, rel, source):
-            print(f"  {GREEN}linked{RESET}    {rel} {DIM}->{RESET} {source.relative_to(root)}")
-            linked += 1
-        else:
-            unchanged += 1
+            verdicts["ambiguous"].append(rel)
+        elif kind == "link" and source is not None:
+            verdicts[_apply(root, rel, source, check=check)].append(rel)
 
-    return _report(check=check, linked=linked, unchanged=unchanged, ambiguous=ambiguous, pending=pending)
+    return _report(
+        check=check,
+        linked=len(verdicts["linked"]),
+        unchanged=len(verdicts["unchanged"]),
+        ambiguous=verdicts["ambiguous"],
+        pending=verdicts["pending"],
+    )
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse the command line.
+
+    Uses argparse rather than scanning ``sys.argv`` (#1531). The distinction is not
+    cosmetic on this tool: the default mode *rewrites tracked files as symlinks*, so a
+    mistyped ``--check`` must be an error rather than silently falling through to the
+    writing run.
+
+    Args:
+        argv: Arguments to parse, or None to read ``sys.argv[1:]``.
+
+    Returns:
+        The parsed namespace, carrying the boolean ``check``.
+    """
+    parser = argparse.ArgumentParser(
+        prog="link_dogfood.py",
+        description=(
+            "Relink the mother repo's dogfood copies as relative symlinks into bundles/. "
+            "Mother-repo tooling; run it via `make sync-self`."
+        ),
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help=(
+            "report what would be linked and exit non-zero if anything is pending, "
+            "without writing (`make sync-self-check`)"
+        ),
+    )
+    return parser.parse_args(argv)
 
 
 if __name__ == "__main__":
-    sys.exit(relink(Path(__file__).resolve().parent.parent, check="--check" in sys.argv[1:]))
+    sys.exit(relink(Path(__file__).resolve().parent.parent, check=_parse_args().check))


### PR DESCRIPTION
Closes the five findings from a `/rhiza:quality` run on the mother repo.

## #1528 — the Docker-backed GitLab test ran nowhere

`RHIZA_GITLAB_DOCKER` was set by no workflow, no target and no `.env`, so
`test_pinned_uv_image_runs_in_docker` — the only check that the pinned `$UV_IMAGE`
still pulls and runs a job — was skipped in **every** environment while reading as
covered. It matters more than usual here: no GitLab pipeline runs in this repo, so a
retired image tag would otherwise surface first in a downstream `gitlab-project`
consumer.

Adds `make gitlab-docker-test` (mother-repo-only, in `bundles.mk` next to `e2e`, which
has the same opt-in shape for the same reason) and calls it from a weekly job. The job
asserts `docker` and `npx` are present *before* running the test, because the test skips
itself when they are missing — correct on a laptop, and exactly the silent state this
closes on a runner.

**It passes**: pulls the image and runs a job in ~68s locally.

## #1529 — `relink` was CC 10

The only block above 8. `_resolve_inputs` takes the index-or-scan setup; `_apply` takes
the whole check-versus-write distinction, so `relink` never branches on `check` and just
files each path under the verdict it gets back.

```
before   F 314:0 relink - B (10)      average A (4.69)
after    F 366:0 relink - A (5)       average A (3.84)
```

The three remaining B blocks (`_owner_by_content` 8, `_classify_dogfood` 7, `_report` 7)
are short and already split along their natural seams — `_owner_by_content` was itself
factored out of `_classify_dogfood` with a comment saying why. Splitting them further to
chase a rank would cost more readability than it buys, so they are left alone. This is
narrower than the "no block above rank A" criterion in the issue, which was stricter
than the defect it described.

## #1530 — `explain_bundles` read its config at import time

Through a *relative* path, so the module was importable only from the repository root;
`tests/utils/test_doctests.py` carried an `_in_root` fixture solely to work around it.

The load and the printing move into `main()`. `_config_path()` prefers the current
directory's config — so the script still explains *this* project when run from a project
root, which the tests rely on — and otherwise resolves one relative to `__file__`. A
missing config now exits with guidance rather than letting `open` raise. The fixture is
gone, and a new test pins the regression: importing from a directory with no config must
succeed and print nothing.

## #1531 — `link_dogfood` ignored unknown flags

`"--check" in sys.argv[1:]` meant `--help` printed nothing, and `--checks` or `-c` fell
through to `check=False` — i.e. to the run that **rewrites tracked files as symlinks**.
Now argparse: `--help` documents `--check`, an unknown flag exits 2.

## #1532 — `sync-self-check` is not the CI drift guard

It was described that way in four places, but no workflow invokes it. The invariant *is*
guarded — by `tests/bundles/test_bundle_dogfood_symlinks.py` inside `make test`, which
reuses `link_dogfood`'s own carve-out predicate and bundle index so the guard and the
linker cannot disagree. `sync-self-check` is the local equivalent. Documentation-only fix
across `bundles.mk`, `link_dogfood.py` and `CLAUDE.md`.

## Gates

All green, locally: `fmt`, `typecheck` (ty + `mypy --strict`), `docs-coverage` (100.0%),
`deps`, `security`, `rhiza-test` (40 passed) and `test` — **1569 passed, 45 skipped**,
coverage on `utils` held at **100%** (four new tests cover `_parse_args`, four cover the
`explain_bundles` restructuring).

Closes #1528
Closes #1529
Closes #1530
Closes #1531
Closes #1532

🤖 Generated with [Claude Code](https://claude.com/claude-code)
