### PR TITLE
fix: make gate scope independent of local.mk, and rescope the interrogate hook (#1534, #1535)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,12 +92,25 @@ repos:
     hooks:
       - id: uv-lock
 
+  # Mother-repo override (#1535). The bundle ships `files: ^src/`, which is right for a
+  # downstream project and inert here: rhiza ships configuration rather than a runtime
+  # library, so it has no src/ and the hook reported "(no files to check)Skipped" on every
+  # `make fmt` — a line that reads like a check in the output of the gate this repo runs
+  # most. Scoped instead to the folders `make docs-coverage` measures, which is
+  # DOCSTRING_FOLDERS (utils, contributed by .rhiza/make.d/bundles.mk) plus the test
+  # folders that target folds in.
+  #
+  # The settings live in pyproject.toml's [tool.interrogate], which the `--config` below
+  # has always named and which did not exist until now: interrogate falls back to its own
+  # defaults for a missing table rather than failing, so the hook was also a *weaker*
+  # standard than the gate (fail-under 80, magic and __init__ methods counted). One table,
+  # read by both, keeps them from disagreeing.
   - repo: https://github.com/econchick/interrogate
     rev: 1.7.0
     hooks:
       - id: interrogate
         args: [--config=pyproject.toml]
-        files: ^src/
+        files: ^(utils|tests|\.rhiza/tests)/.*\.py$
 
   - repo: https://github.com/Jebel-Quant/rhiza-hooks
     rev: v1.2.0  # Use the latest release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,30 @@ outcome rather than the wiring: each gate must resolve to a non-empty list namin
 One consequence worth knowing when reading `make -n`: the folder list is expanded by
 **make**, not by the recipe's shell, so a dry run shows the real scope. The `[ -d ... ]`
 form it replaced printed its warning whether or not the branch would fire, which made a
-dry run's warnings meaningless as evidence either way.
+dry run's warnings meaningless as evidence either way. Note that this cuts both ways when
+writing an assertion: a dry run prints *both* arms of an `if`, so the presence of a skip
+message proves nothing — only the expanded folder list does.
+
+**The `SOURCE_FOLDER` seed is deferred, and where you set the variable no longer matters.**
+Each accumulator appends `$(wildcard $(SOURCE_FOLDER))` rather than sitting inside an
+`ifneq ($(wildcard $(SOURCE_FOLDER)),)`. `?=` makes these *recursive* variables, so the
+appended text is expanded when a gate reads it — after every makefile has been parsed —
+whereas an `ifneq` is decided where it is written, while python.mk is still being read.
+
+That difference was load-bearing until #1534, because the root `Makefile` reads `local.mk`
+*after* `include .rhiza/rhiza.mk`. A project whose source root is not `src/` and which set
+`SOURCE_FOLDER` there had the conditional already decided against it on the `?= src`
+default, so `deps`, `typecheck`, `security`, `docs-coverage` and `test` all fell through to
+their empty-list branch and exited **0** having measured nothing — the same silent
+measure-nothing failure as #1505, #1511 and #1516, but reached through a documented
+configuration surface rather than a hard-coded path. It survived because every channel the
+override tests cover — the command line, `.rhiza/.env`, the root `Makefile` above the
+include — is read *before* python.mk is parsed, so none of them could see it.
+`tests/api/test_make_variable_overrides.py::TestSourceFolderFromLocalMk` now pins all five
+gates against a `local.mk`-declared source root.
+
+Appending has always worked from `local.mk` and still does; it was only *setting*
+`SOURCE_FOLDER` that was position-dependent.
 
 All three layers carry `test`/`coverage`/`typecheck` themselves. Python's used to live
 in the separate `tests` bundle, and that was a real inconsistency rather than a
@@ -348,6 +371,17 @@ Hook targets use double-colon syntax (`pre-install::`, `post-install::`) and can
 >   on `rhiza.mk`'s `PYTHON_VERSION` fallback. prek is a binary that provisions each
 >   hook's toolchain itself. `test_fmt_target_no_longer_needs_python_version` pins the
 >   absence, so the coupling cannot creep back.
+> - **The root config's interrogate hook is scoped differently from the bundle's, and
+>   that is the override doing its job (#1535).** The bundle ships `files: ^src/`, right
+>   for a downstream project and inert here, so the hook reported
+>   `(no files to check)Skipped` on every `make fmt` — a line that reads like a check, in
+>   the output of the gate this repo runs most. The root copy points instead at the folders
+>   `make docs-coverage` resolves. Its `--config=pyproject.toml` also named a
+>   `[tool.interrogate]` table that did not exist; interrogate falls back to its own
+>   defaults for a missing table rather than failing, so the hook was quietly enforcing 80%
+>   where the gate enforces 100%. `tests/utils/test_gate_scope.py` now pins both halves —
+>   that the pattern matches files the gate measures, and that the table and the recipe
+>   agree on the threshold.
 >
 > The CI job keeps its id `pre-commit` and its display name "Pre-commit hooks": that name
 > is a required status check in `.github/rulesets/main-branch-protection.json`, so

--- a/bundles/python-core/.rhiza/make.d/python.mk
+++ b/bundles/python-core/.rhiza/make.d/python.mk
@@ -138,9 +138,28 @@ all: fmt deps test docs-coverage security license typecheck rhiza-test ## run al
 # for it.
 DEPTRY_FOLDERS ?=
 DEPTRY_IGNORE ?=
-ifneq ($(wildcard $(SOURCE_FOLDER)),)
-DEPTRY_FOLDERS += $(SOURCE_FOLDER)
-endif
+DEPTRY_FOLDERS += $(wildcard $(SOURCE_FOLDER))
+
+# The seed is deferred, and that is the whole point of the `$(wildcard ...)` rather than
+# the `ifneq ($(wildcard $(SOURCE_FOLDER)),)` guard that used to wrap this line (#1534).
+#
+# `?=` (and `+=` on a not-yet-defined variable) creates a *recursive* variable, so the
+# text appended here is expanded when a gate uses it — after every makefile has been
+# read. An `ifneq` is not: it is evaluated where it is written, which is while python.mk
+# itself is being parsed.
+#
+# That difference was load-bearing, because the root Makefile reads `local.mk` *after*
+# `include .rhiza/rhiza.mk`. A project whose source root is not `src/` and which set
+# `SOURCE_FOLDER` there — the file CLAUDE.md points developers at — had the conditional
+# already decided against it on the `?= src` default, so `deps`, `typecheck`, `security`,
+# `docs-coverage` and `test` each fell through to their empty-list branch and exited 0
+# having measured nothing. Silently: an empty folder list warns rather than fails, which
+# is the failure mode #1505, #1511 and #1516 each closed one gate at a time.
+#
+# Deferring it makes the accumulators independent of *where* SOURCE_FOLDER is set —
+# `.rhiza/.env`, the environment, the root Makefile above the include, the command line,
+# or `local.mk` below it all now agree. The non-existent case is unchanged: `$(wildcard)`
+# expands to nothing, so a project without the folder still gets an empty seed.
 
 # The same accumulator shape, for the other four path-scoped gates. `deps` has had
 # one since the bundle model began; `typecheck`, `security` and `docs-coverage` each
@@ -185,12 +204,12 @@ TYPECHECK_FOLDERS ?=
 BANDIT_FOLDERS ?=
 DOCSTRING_FOLDERS ?=
 COVERAGE_FOLDERS ?=
-ifneq ($(wildcard $(SOURCE_FOLDER)),)
-TYPECHECK_FOLDERS += $(SOURCE_FOLDER)
-BANDIT_FOLDERS += $(SOURCE_FOLDER)
-DOCSTRING_FOLDERS += $(SOURCE_FOLDER)
-COVERAGE_FOLDERS += $(SOURCE_FOLDER)
-endif
+# Deferred for the reason spelled out at DEPTRY_FOLDERS above (#1534): expanded at use,
+# so it no longer matters whether SOURCE_FOLDER was set above or below the include.
+TYPECHECK_FOLDERS += $(wildcard $(SOURCE_FOLDER))
+BANDIT_FOLDERS += $(wildcard $(SOURCE_FOLDER))
+DOCSTRING_FOLDERS += $(wildcard $(SOURCE_FOLDER))
+COVERAGE_FOLDERS += $(wildcard $(SOURCE_FOLDER))
 
 # Named `deps`, matching rust.mk and go.mk. This was the one gate whose *target name*
 # differed by language (#1474): `deptry` names the tool, which nothing else in the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,23 @@ ignore_missing_version = true
 strict = true
 files = ["utils"]
 
+[tool.interrogate]
+# The same job [tool.mypy] does above, for the same reason (#1535). The interrogate hook
+# in .pre-commit-config.yaml has always passed `--config=pyproject.toml`, and this table
+# has never existed — interrogate falls back to its own defaults for a missing table
+# rather than failing, so the hook silently enforced fail-under 80 with magic and
+# __init__ methods counted, where `make docs-coverage` enforces 100 with both ignored.
+# A hook that is weaker than the gate it shadows is worse than no hook: it passes on
+# work the gate will reject.
+#
+# Keep these in step with the flags in python.mk's docs-coverage recipe
+# (`interrogate -vv --fail-under 100 --ignore-init-method --ignore-magic`). No `paths`
+# key: the hook is handed the files it matched, and the gate passes DOCSTRING_FOLDERS on
+# the command line, so neither reads a path from here.
+fail-under = 100
+ignore-init-method = true
+ignore-magic = true
+
 [tool.check_test_layout]
 # Rhiza ships configuration templates, not a runtime library: there is no `src/` tree,
 # so there is no module for a `tests/<path>/test_<name>.py` to mirror and never will be.

--- a/tests/api/test_make_variable_overrides.py
+++ b/tests/api/test_make_variable_overrides.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+import pytest
+
 from tests.util import run_make, strip_ansi
 
 
@@ -198,6 +200,68 @@ class TestSourceFolderVariable:
         # marimo.mk is included before quality.mk, so its folder is appended first.
         assert "deptry notebooks mypackage --ignore DEP004" in out, (
             "deptry should scan marimo + source folders in a single call with DEP004 ignored; got:\n" + out[:600]
+        )
+
+
+class TestSourceFolderFromLocalMk:
+    """SOURCE_FOLDER set in ``local.mk`` must still seed the five path-scoped gates (#1534).
+
+    The root Makefile reads ``local.mk`` *after* ``include .rhiza/rhiza.mk``, so the
+    accumulator seeds in python.mk are parsed before it. While those seeds were wrapped in
+    ``ifneq ($(wildcard $(SOURCE_FOLDER)),)`` the conditional had already been decided
+    against the ``?= src`` default, and a project whose source root is not ``src/`` got
+    ``deps``, ``typecheck``, ``security``, ``docs-coverage`` and ``test`` each falling
+    through to their empty-list branch — exiting 0 having measured nothing, the failure
+    mode #1505, #1511 and #1516 each closed one gate at a time.
+
+    The sibling class above covers the channels that always worked (the command line, and
+    ``.rhiza/.env``), which is exactly why the regression survived: every one of them is
+    read *before* python.mk is parsed, so none of them could see this.
+    """
+
+    # Each gate's computed path list, as the recipe assigns it. Asserting on the
+    # assignment rather than on a bare "mypackage" substring is deliberate: four of the
+    # five WARN-and-skip branches interpolate SOURCE_FOLDER into their message
+    # ("...and SOURCE_FOLDER='mypackage' does not exist"), so a substring check would
+    # pass just as happily on the broken behaviour it is meant to catch.
+    GATE_PATHS = (
+        ("typecheck", 'typecheck_paths="mypackage"'),
+        ("security", 'bandit_paths="mypackage"'),
+        ("docs-coverage", 'docstring_paths="mypackage"'),
+        ("test", 'coverage_paths="mypackage"'),
+    )
+
+    @staticmethod
+    def _project_with_local_mk(tmp_path: Path) -> None:
+        """Give the temp project a non-default source root, declared only in local.mk."""
+        (tmp_path / "mypackage").mkdir(exist_ok=True)
+        (tmp_path / "local.mk").write_text("SOURCE_FOLDER = mypackage\n")
+
+    @pytest.mark.parametrize(("target", "expected"), GATE_PATHS, ids=[t for t, _ in GATE_PATHS])
+    def test_gate_scope_honours_local_mk(self, logger, tmp_path: Path, target: str, expected: str) -> None:
+        """Each path-scoped gate must resolve to the source root local.mk declares."""
+        self._project_with_local_mk(tmp_path)
+
+        out = strip_ansi(run_make(logger, [target]).stdout)
+        assert expected in out, (
+            f"`make {target}` should scope to the local.mk SOURCE_FOLDER; expected {expected!r}.\n"
+            f"An empty list here means the accumulator seed was evaluated before local.mk "
+            f"was read (#1534). Got:\n" + out[-800:]
+        )
+
+    def test_deps_scope_honours_local_mk(self, logger, tmp_path: Path) -> None:
+        """`make deps` is checked apart: deptry takes its folders as bare arguments.
+
+        Note that the assertion is on the deptry *invocation*, not on the absence of the
+        recipe's "no deptry folders found" branch. Under ``make -n`` the whole recipe is
+        printed, both arms of the ``if`` included, so an absence check would fail even on
+        correct behaviour — the dry run shows the branch that *would not* be taken.
+        """
+        self._project_with_local_mk(tmp_path)
+
+        out = strip_ansi(run_make(logger, ["deps"]).stdout)
+        assert "deptry mypackage" in out, (
+            "`make deps` should scan the local.mk SOURCE_FOLDER (#1534); got:\n" + out[-800:]
         )
 
 

--- a/tests/utils/test_gate_scope.py
+++ b/tests/utils/test_gate_scope.py
@@ -159,6 +159,74 @@ def test_rhiza_test_carries_the_docstring_scope_to_the_shipped_doctests(logger) 
     )
 
 
+def _interrogate_hook() -> dict:
+    """Return the interrogate hook mapping from the root .pre-commit-config.yaml."""
+    import yaml
+
+    config = yaml.safe_load((_ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8"))
+    for repo in config["repos"]:
+        for hook in repo["hooks"]:
+            if hook["id"] == "interrogate":
+                return hook
+    pytest.fail("the root .pre-commit-config.yaml no longer declares an interrogate hook")
+
+
+def test_interrogate_hook_matches_this_repos_python(gate_scopes: dict[str, str]) -> None:
+    """`make fmt`'s interrogate hook must be scoped to files this repo actually has.
+
+    The same failure as the gates above, one layer out (#1535). The hook shipped
+    ``files: ^src/`` — correct downstream, inert here, because rhiza ships configuration
+    rather than a runtime library. It reported "(no files to check)Skipped" on every
+    ``make fmt``, which in a list of twenty-odd Passed lines reads as a check that ran.
+
+    Checked against the folders ``docs-coverage`` *resolves* rather than a hardcoded list,
+    so the hook and the gate cannot drift apart: whatever the accumulator contributes, the
+    hook must be able to see it.
+    """
+    pattern = re.compile(_interrogate_hook()["files"])
+    folders = gate_scopes["docs-coverage"].split()
+    assert folders, "docs-coverage resolves no folders, so there is nothing to scope the hook to"
+
+    for folder in folders:
+        candidates = sorted((_ROOT / folder).rglob("*.py"))
+        assert candidates, f"docs-coverage names {folder!r} but it holds no Python at all"
+        matched = [p for p in candidates if pattern.match(p.relative_to(_ROOT).as_posix())]
+        assert matched, (
+            f"the interrogate hook's files pattern {pattern.pattern!r} matches none of the "
+            f"{len(candidates)} Python files under {folder}/, which `make docs-coverage` "
+            f"does measure. The hook would report '(no files to check)Skipped' and read as "
+            f"a check that ran (#1535)."
+        )
+
+
+def test_interrogate_hook_and_gate_agree_on_the_threshold() -> None:
+    """The [tool.interrogate] table must enforce what python.mk's docs-coverage enforces.
+
+    The hook passes ``--config=pyproject.toml``; the gate passes its thresholds on the
+    command line. Until #1535 the table did not exist, and interrogate falls back to its
+    own defaults for a missing table rather than failing — so the hook enforced 80% where
+    the gate enforced 100%, and a hook weaker than the gate it shadows passes work the
+    gate will reject.
+    """
+    import tomllib
+
+    recipe = (_BUNDLES / "python-core" / ".rhiza" / "make.d" / "python.mk").read_text(encoding="utf-8")
+    match = re.search(r"interrogate\s+-vv\s+--fail-under\s+(\d+)", recipe)
+    assert match, "could not find the --fail-under flag in python.mk's docs-coverage recipe"
+    gate_threshold = int(match.group(1))
+
+    table = tomllib.loads((_ROOT / "pyproject.toml").read_text(encoding="utf-8"))["tool"]["interrogate"]
+    assert table["fail-under"] == gate_threshold, (
+        f"[tool.interrogate] fail-under is {table['fail-under']} but `make docs-coverage` "
+        f"enforces {gate_threshold}. The pre-commit hook reads the table and the gate reads "
+        f"the flag, so they would disagree about whether the same code passes (#1535)."
+    )
+    for flag in ("ignore-init-method", "ignore-magic"):
+        assert table.get(flag) is True, (
+            f"[tool.interrogate] must set {flag} = true to match the `--{flag}` the docs-coverage recipe passes."
+        )
+
+
 def test_every_declared_accumulator_is_guarded() -> None:
     """Every ``*_FOLDERS ?=`` accumulator in the bundles must be covered by ``_SCOPED_GATES``.
 


### PR DESCRIPTION
Closes #1534. Closes #1535.

Two instances of the same species this repo keeps hunting (#1505, #1511, #1512, #1516):
**a check that exits 0 having measured nothing.**

## #1534 — gate scope no longer depends on *where* `SOURCE_FOLDER` is set

`python.mk` seeded its five path-scoped accumulators inside
`ifneq ($(wildcard $(SOURCE_FOLDER)),)`, which make decides *while parsing python.mk*.
The root Makefile reads `local.mk` **after** `include .rhiza/rhiza.mk`, so a project whose
source root is not `src/` and which set `SOURCE_FOLDER` there — the file `CLAUDE.md` points
developers at — had the conditional already decided against it on the `?= src` default.
`deps`, `typecheck`, `security`, `docs-coverage` and `test` each fell through to their
empty-list branch and passed, silently, because an empty folder list warns rather than fails.

The seed is now deferred:

```make
DEPTRY_FOLDERS    += $(wildcard $(SOURCE_FOLDER))
TYPECHECK_FOLDERS += $(wildcard $(SOURCE_FOLDER))   # + BANDIT, DOCSTRING, COVERAGE
```

`?=` (and `+=` on a not-yet-defined variable) creates a *recursive* variable, so the text is
expanded when a gate reads it — after every makefile has been parsed. All five channels now
agree: the command line, `.rhiza/.env`, the root Makefile above the include, and `local.mk`
below it. The folder-absent case is unchanged — `$(wildcard)` expands to nothing.

**Why it survived.** Every channel the existing override tests cover is read *before*
python.mk is parsed, so none of them could see this. `TestSourceFolderFromLocalMk` covers
the one that is not, across all five gates.

Appending from `local.mk` has always worked and still does; it was only *setting*
`SOURCE_FOLDER` that was position-dependent.

## #1535 — the interrogate hook now measures something

Two problems, and the second was only visible once the first was being fixed.

**Scope.** The root `.pre-commit-config.yaml` carried the bundle's `files: ^src/` — right for
a downstream project, inert here, because rhiza ships configuration rather than a runtime
library. The hook reported `(no files to check)Skipped` on every `make fmt`: a line that reads
like a check that ran, in the output of the gate this repo runs most. It is now scoped to the
folders `make docs-coverage` resolves.

**Threshold.** Its `--config=pyproject.toml` named a `[tool.interrogate]` table that had never
existed. interrogate falls back to its own defaults for a missing table rather than failing, so
the hook was enforcing **fail-under 80 with magic and `__init__` methods counted**, where the
gate enforces **100 with both ignored**. A hook weaker than the gate it shadows is worse than no
hook — it passes work the gate will reject. The table now exists and matches the recipe, in the
same idiom `[tool.mypy]` uses for the same reason (#1507).

`interrogate` now reports **Passed** rather than **Skipped**, at both entry points — `make fmt`
and the prek git shim.

## Tests

Both fixes are pinned by tests that were **verified to fail without them**, rather than merely
added alongside:

- `tests/api/test_make_variable_overrides.py::TestSourceFolderFromLocalMk` — all five gates
  against a `local.mk`-declared source root (5 tests, 5 failures without the fix).
- `tests/utils/test_gate_scope.py::test_interrogate_hook_matches_this_repos_python` — the hook's
  pattern must match files the gate measures, derived from the gate's *resolved* scope rather
  than a hardcoded list, so the two cannot drift.
- `tests/utils/test_gate_scope.py::test_interrogate_hook_and_gate_agree_on_the_threshold` — the
  table and the recipe must name the same number.

One note that generalises, now recorded in `CLAUDE.md`: **`make -n` prints both arms of an
`if`**, so the presence of a skip message proves nothing and only the expanded folder list does.
The first draft of the `deps` test asserted on the absence of the skip branch and failed for
exactly that reason.

## Verification

| Check | Result |
| --- | --- |
| `make all` | green — fmt, deps, test, docs-coverage, security, license, typecheck, rhiza-test |
| `make test` | 1576 passed (+7), 45 skipped, coverage 100% |
| `make e2e E2E_ARGS=tests/e2e/test_python_layer_e2e.py` | 14/14 |
| `make sync-self-check` | 49 correct, 0 pending |

The e2e run is the load-bearing one: it is the only check that a real synced project *with* a
`src/` still gets identical behaviour from the deferred seed, and it exercises the bundle's
unchanged `files: ^src/` hook.

Found by `/rhiza:quality`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
