### PR TITLE
fix(ci): read the OS matrix from rhiza-task, not from .rhiza/rhiza.mk

### DIFF
--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -65,6 +65,22 @@ jobs:
         run: |
           echo "Python versions: ${{ steps.versions-output.outputs.list }}"
 
+      # The matrix comes from the rhiza-task CLI rather than from
+      # `make -f .rhiza/rhiza.mk -s ci-os-matrix`, which is what this step used to run.
+      # Naming that path made a *file* part of the contract, and a consumer that has
+      # replaced the make layer with the CLI then has to keep a stub `.rhiza/rhiza.mk`
+      # alive for this one step and nothing else. Nothing changes for a repo still on
+      # the synced make layer: both readers take the value from `.rhiza/.env`, which
+      # stays the single source of truth.
+      #
+      # The version is pinned here rather than read from a consumer's `RHIZA_TASK`,
+      # which this workflow cannot see — and should not: the matrix a build runs on must
+      # not move under it. It tracks the tag this workflow is called at.
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          version: "0.11.16"
+
       # This workflow serves double duty: it runs on push/PR here, and it is the
       # reusable workflow every consumer's `github-tests` stub delegates to. So the
       # OS matrix has to differ by caller (#1526). Rhiza ships Makefiles and shell
@@ -74,25 +90,27 @@ jobs:
       # itself in and leaves the shipped default alone; a consumer who wants the same
       # coverage sets RHIZA_CI_OS_MATRIX in its own .rhiza/.env.
       #
-      # An empty value is not the same as an unset one to make's `?=`, which treats an
-      # exported empty string as set — hence `ci-os-matrix` resolves through
-      # `$(or ...)`, so the empty branch below falls back to ["ubuntu-latest"].
+      # The empty branch below is what hands the question to a consumer's `.rhiza/.env`,
+      # and it relies on rhiza-task treating an empty setting as unset. That is make's
+      # `$(or ...)` rule, which the CLI applies to every setting rather than to this one
+      # alone (Jebel-Quant/rhiza-task#4) — hence the 0.1.2 pin: 0.1.1 resolved the empty
+      # string to a value and answered `[]`, which GitHub expands to zero jobs rather than
+      # failing, so `test` would vanish and CI would go green having run nothing.
       #
-      # This works only while `.rhiza/.env` leaves RHIZA_CI_OS_MATRIX unset. That file is
-      # `-include`d by rhiza.mk, and a makefile assignment outranks an environment
-      # variable in GNU make (only a command-line `make VAR=...` outranks the file), so a
-      # value pinned there discards whatever this step exports. It was pinned to all three
-      # OSes from #1072, which made the split below dead code from the day it landed in
-      # #1526 — mother repo and consumers alike ran the full three-OS matrix. Removed in
-      # #1545 and pinned by TestExportedCiOsMatrixSurvivesTheShippedEnvFile, which is the
-      # only test that combines a populated .env with an exported value.
+      # One caveat this step used to carry is gone rather than merely restated. Under make,
+      # an assignment in `.rhiza/.env` outranked an exported environment variable (only a
+      # command-line `make VAR=...` beat the file), so a value pinned there silently
+      # discarded whatever this step exported — which is how the split below was dead code
+      # from #1526 until #1545 removed the pin. rhiza-task resolves in the opposite order:
+      # `.rhiza/.env` is layer 2 and the environment is layer 4, so the export wins and the
+      # file answers only when nothing is exported. Verified both ways.
       - id: os
         env:
           RHIZA_CI_OS_MATRIX: >-
             ${{ github.repository == 'jebel-quant/rhiza'
                 && '["ubuntu-latest","macos-latest"]' || '' }}
         run: |
-          OS_MATRIX=$(make -f .rhiza/rhiza.mk -s ci-os-matrix)
+          OS_MATRIX=$(uvx rhiza-task@0.1.2 ci-os-matrix)
           echo "list=$OS_MATRIX" >> "$GITHUB_OUTPUT"
 
       - name: Debug OS matrix

--- a/tests/api/test_ci_workflow.py
+++ b/tests/api/test_ci_workflow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -40,6 +41,35 @@ def test_ci_os_matrix_make_target_can_be_configured(logger):
     )
     assert result.returncode == 0
     assert json.loads(result.stdout.strip()) == ["ubuntu-latest", "windows-latest"]
+
+
+def test_ci_generate_matrix_reads_the_os_matrix_from_the_cli(root):
+    """The OS matrix must come from a pinned rhiza-task, not from a make file path.
+
+    This step used to run ``make -f .rhiza/rhiza.mk -s ci-os-matrix``, which put a
+    *file path* into the reusable contract: a consumer that has replaced the synced make
+    layer with the ``rhiza-task`` CLI then has to keep a stub at exactly that path, whose
+    only caller is this step. Both readers take the value from ``.rhiza/.env``, so the
+    switch changes nothing for a repo still on the make layer.
+
+    The pin is asserted too. An unpinned ``uvx rhiza-task ci-os-matrix`` would let the
+    matrix a build runs on move under a workflow that is itself called at a tag.
+    """
+    with (root / WORKFLOW_PATH).open(encoding="utf-8") as fh:
+        workflow = yaml.safe_load(fh)
+
+    steps = workflow["jobs"]["generate-matrix"]["steps"]
+    os_step = next(step for step in steps if step.get("id") == "os")
+
+    assert re.search(r"uvx rhiza-task@\d+\.\d+\.\d+ ci-os-matrix", os_step["run"]), (
+        f"the OS matrix step must call a pinned rhiza-task, got: {os_step['run']!r}"
+    )
+    assert ".rhiza/rhiza.mk" not in os_step["run"], (
+        "naming .rhiza/rhiza.mk here forces every migrated consumer to keep a stub at that path for this one step"
+    )
+    assert any("astral-sh/setup-uv@" in step.get("uses", "") for step in steps), (
+        "generate-matrix installs no uv, so `uvx` would not be on PATH"
+    )
 
 
 def test_ci_security_job_runs_security_scans(root):


### PR DESCRIPTION
## Why

`generate-matrix` runs

```yaml
OS_MATRIX=$(make -f .rhiza/rhiza.mk -s ci-os-matrix)
```

which puts a **file path** into the reusable contract. A consumer that has replaced the synced make layer with the `rhiza-task` CLI cannot then delete `.rhiza/rhiza.mk`: jointview keeps four repo-owned lines at exactly that path, whose only caller is this step, and whose own header says "delete this file once the reusable workflows read the matrix from the CLI". This is that.

## What changes

- The step calls `uvx rhiza-task@0.1.2 ci-os-matrix`, and `generate-matrix` gains a `setup-uv` step — it had no reason to install uv before.
- Nothing changes for a repo still on the synced make layer: `ci-os-matrix` stays in `bundles/core/.rhiza/rhiza.mk` (and its two tests still exercise it), and both readers take the value from `.rhiza/.env`, which remains the single source of truth.
- A new test asserts the step calls a *pinned* `rhiza-task`, never `.rhiza/rhiza.mk`, and that some step installs uv — the same shape as the existing assertion that `versions-output` no longer calls `make -f .rhiza/rhiza.mk -s version-matrix`.

## The 0.1.2 floor

This step exports one `RHIZA_CI_OS_MATRIX` for every caller and deliberately leaves it **empty** for consumers, whose own `.rhiza/.env` is meant to answer. make's `?=` treats an exported empty string as set, which is why the retired recipe resolved through `$(or ...)`. rhiza-task 0.1.1 did not:

```console
$ RHIZA_CI_OS_MATRIX='' uvx rhiza-task@0.1.1 ci-os-matrix
[]
```

GitHub does not fail a workflow over an empty matrix — it expands to zero jobs, so `test` would vanish and CI would go green having run nothing. Jebel-Quant/rhiza-task#4 makes an empty setting mean unset and floors the output at `["ubuntu-latest"]`.

**Merge order:** rhiza-task#4 must be merged and released as 0.1.2 first, or this step resolves an unpublished pin.

## Verification

- `uv run pytest tests/api/test_ci_workflow.py tests/api/test_env_defaults.py tests/bundles -q` → 653 passed, 1 skipped (the opt-in Docker GitLab job)
- The patched workflow parses, and `generate-matrix` steps are in order: harden → checkout → versions → versions-output → Debug matrix → Install uv → os → Debug OS matrix
- `ruff check` / `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)