### PR TITLE
chore: release v1.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com),
 and entries are generated from [Conventional Commits](https://www.conventionalcommits.org).
 
+## [1.3.4] - 2026-08-18
+
+### New Features
+- Deliver the rhiza checks as pytest-rhiza instead of syncing .rhiza/tests (#1540) (#1547)
+
+### Bug Fixes
+- Make the mother repo's own static gates measure something (#1505, #1506, #1507, #1508) (#1510)
+- Close the four quality findings (#1511, #1512, #1513, #1514) (#1515)
+- Close the six quality findings (#1516, #1517, #1518, #1519, #1520, #1521) (#1522)
+- Wire rhiza-test into CI and correct the coverage note (#1523, #1525, #1526) (#1527)
+- Close the five quality findings (#1528, #1529, #1530, #1531, #1532) (#1533)
+- Make gate scope independent of local.mk, and rescope the interrogate hook (#1534, #1535) (#1536)
+- *(ci)* Read the OS matrix from rhiza-task, not from .rhiza/rhiza.mk (#1546)
+
+### Dependencies
+- *(deps)* Lock file maintenance (#1538)
+
+### Maintenance
+- *(bandit)* Give the scope test a positive control and check both configs (#1504)
+- Chore(deps)(deps): bump the github-actions group with 6 updates (#1543)
+- Drop .rhiza/assets and retire .rhiza/completions from core (#1549)
+
+### Other Changes
+- Delete .github/pull_request_template.md (#1550)
+- Delete bundles/github/.github/pull_request_template.md (#1551)
+
 ## [1.3.3] - 2026-08-11
 
 ### Bug Fixes

--- a/bundles/github-book/.github/workflows/rhiza_book.yml
+++ b/bundles/github-book/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.3.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.3.4
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml
+++ b/bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   devcontainer:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v1.3.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v1.3.4
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-docker/.github/workflows/rhiza_docker.yml
+++ b/bundles/github-docker/.github/workflows/rhiza_docker.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   docker:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v1.3.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v1.3.4
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-marimo/.github/workflows/rhiza_marimo.yml
+++ b/bundles/github-marimo/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.3.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.3.4
     secrets: inherit

--- a/bundles/github-paper/.github/workflows/rhiza_paper.yml
+++ b/bundles/github-paper/.github/workflows/rhiza_paper.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   paper:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v1.3.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v1.3.4
     secrets: inherit
     permissions:
       contents: write

--- a/bundles/github-quality-review/.github/workflows/rhiza_quality_review.yml
+++ b/bundles/github-quality-review/.github/workflows/rhiza_quality_review.yml
@@ -34,5 +34,5 @@ on:
 
 jobs:
   quality-review:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_quality_review.yml@v1.3.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_quality_review.yml@v1.3.4
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_benchmark.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.3.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.3.4
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_ci.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.3.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.3.4
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_codeql.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.3.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.3.4
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/bundles/github-tests/.github/workflows/rhiza_mutation.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_mutation.yml
@@ -42,7 +42,7 @@ jobs:
     # this repo sets the `MUTATION_ENABLED` variable to 'true'. Gating here in
     # the caller keeps it optional regardless of the pinned reusable workflow.
     if: ${{ vars.MUTATION_ENABLED == 'true' }}
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v1.3.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v1.3.4
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github/.github/workflows/rhiza_fuzzing.yml
+++ b/bundles/github/.github/workflows/rhiza_fuzzing.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   fuzzing:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v1.3.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v1.3.4
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github/.github/workflows/rhiza_scorecard.yml
+++ b/bundles/github/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.3.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.3.4
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/bundles/github/.github/workflows/rhiza_weekly.yml
+++ b/bundles/github/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.3.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.3.4
     secrets: inherit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rhiza"
-version = "1.3.3"
+version = "1.3.4"
 description = "Reusable configuration templates for modern Python projects"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -70,7 +70,7 @@ Issues = "https://github.com/jebel-quant/rhiza/issues"
 # python-core bundle no longer ships a `.rhiza/.cfg.toml` copy of this block; the
 # Rust and Go layers ship a root `.bumpversion.toml` instead, since neither
 # language has a discoverable file of its own.
-current_version = "1.3.3"
+current_version = "1.3.4"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:[-]?(?P<release>[a-z]+)[\\.]?(?P<pre_n>\\d+))?(?:\\+build\\.(?P<build_n>\\d+))?"
 serialize = [
     "{major}.{minor}.{patch}-{release}.{pre_n}+build.{build_n}",

--- a/uv.lock
+++ b/uv.lock
@@ -863,7 +863,7 @@ wheels = [
 
 [[package]]
 name = "rhiza"
-version = "1.3.3"
+version = "1.3.4"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Release **v1.3.3 → v1.3.4** (patch).

## Merging this PR does not publish the release

The tag is cut afterwards, from the merged commit, by a second `/rhiza:release` run.
Nothing is published until that tag is pushed.

## Version locations rewritten

Every location is declared in `[tool.bumpversion]`; nothing was hand-edited.

| File | What moved |
| --- | --- |
| `pyproject.toml` | `[project].version` (anchored pattern) and `current_version` |
| `bundles/**/.github/workflows/*.yml` (13 files) | `jebel-quant/rhiza/...@v1.3.3` → `@v1.3.4` — the stub pins synced downstream |
| `uv.lock` | regenerated with `uv lock`; only the `name = "rhiza"` entry changed |

The live `.github/workflows/` are deliberately **not** listed, so this PR's own
required checks resolve against tags that already exist and can go green.

## Changelog

`CHANGELOG.md` gained one `## [1.3.4]` section, prepended — no earlier section was
modified. It covers 14 commits since `v1.3.3`:

- **New Features** — deliver the rhiza checks as pytest-rhiza instead of syncing `.rhiza/tests` (#1540)
- **Bug Fixes** — 7: mother-repo static gate scope (#1510), three quality-finding batches (#1515, #1522, #1533), `rhiza-test` wired into CI (#1527), gate scope independent of `local.mk` (#1536), CI OS matrix read from rhiza-task (#1546)
- **Dependencies** — lock file maintenance (#1538)
- **Maintenance** — bandit scope test control (#1504), github-actions group bump (#1543), drop `.rhiza/assets` and retire `.rhiza/completions` (#1549)
- **Other** — the two PR-template deletions (#1550, #1551)

## Why patch

No commit carries `!` or a `BREAKING CHANGE` trailer. Worth a reviewer's attention
anyway: #1540 and #1549 change what a consumer receives on the next sync — the
`.rhiza/tests/` files become a pinned `pytest-rhiza` dependency, and `.rhiza/assets`
plus `.rhiza/completions` are no longer delivered. Both are inert-on-disk rather than
removed from existing checkouts, which is why this is filed as a patch and not a major.
