### PR TITLE
chore: release v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com),
 and entries are generated from [Conventional Commits](https://www.conventionalcommits.org).
 
+## [1.4.0] - 2026-08-19
+
+### Bug Fixes
+- *(marimo)* Read MARIMO_FOLDER from rhiza-task, not from make's namespace (#1553)
+
+### Maintenance
+- Retire core's .rhiza/.env, point settings at [tool.rhiza-task] (#1555)
+- Migrate this repo to the rhiza-task shim, retiring its own make layer (#1556)
+- Stop shipping the make layer; keep the five fragments with no CLI task (#1557)
+- Retire the last five make fragments, and the folder with them (#1559)
+- Remove the .clusterfuzzlite config, which had no harness to build (#1560)
+
 ## [1.3.4] - 2026-08-18
 
 ### New Features

--- a/bundles/github-book/.github/workflows/rhiza_book.yml
+++ b/bundles/github-book/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.3.4
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.4.0
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml
+++ b/bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   devcontainer:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v1.3.4
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v1.4.0
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-docker/.github/workflows/rhiza_docker.yml
+++ b/bundles/github-docker/.github/workflows/rhiza_docker.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   docker:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v1.3.4
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v1.4.0
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-marimo/.github/workflows/rhiza_marimo.yml
+++ b/bundles/github-marimo/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.3.4
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.4.0
     secrets: inherit

--- a/bundles/github-paper/.github/workflows/rhiza_paper.yml
+++ b/bundles/github-paper/.github/workflows/rhiza_paper.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   paper:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v1.3.4
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v1.4.0
     secrets: inherit
     permissions:
       contents: write

--- a/bundles/github-quality-review/.github/workflows/rhiza_quality_review.yml
+++ b/bundles/github-quality-review/.github/workflows/rhiza_quality_review.yml
@@ -34,5 +34,5 @@ on:
 
 jobs:
   quality-review:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_quality_review.yml@v1.3.4
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_quality_review.yml@v1.4.0
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_benchmark.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.3.4
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.4.0
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_ci.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.3.4
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.4.0
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_codeql.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.3.4
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.4.0
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/bundles/github-tests/.github/workflows/rhiza_mutation.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_mutation.yml
@@ -42,7 +42,7 @@ jobs:
     # this repo sets the `MUTATION_ENABLED` variable to 'true'. Gating here in
     # the caller keeps it optional regardless of the pinned reusable workflow.
     if: ${{ vars.MUTATION_ENABLED == 'true' }}
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v1.3.4
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v1.4.0
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github/.github/workflows/rhiza_fuzzing.yml
+++ b/bundles/github/.github/workflows/rhiza_fuzzing.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   fuzzing:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v1.3.4
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v1.4.0
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github/.github/workflows/rhiza_scorecard.yml
+++ b/bundles/github/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.3.4
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.4.0
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/bundles/github/.github/workflows/rhiza_weekly.yml
+++ b/bundles/github/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.3.4
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.4.0
     secrets: inherit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rhiza"
-version = "1.3.4"
+version = "1.4.0"
 description = "Reusable configuration templates for modern Python projects"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -70,7 +70,7 @@ Issues = "https://github.com/jebel-quant/rhiza/issues"
 # python-core bundle no longer ships a `.rhiza/.cfg.toml` copy of this block; the
 # Rust and Go layers ship a root `.bumpversion.toml` instead, since neither
 # language has a discoverable file of its own.
-current_version = "1.3.4"
+current_version = "1.4.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:[-]?(?P<release>[a-z]+)[\\.]?(?P<pre_n>\\d+))?(?:\\+build\\.(?P<build_n>\\d+))?"
 serialize = [
     "{major}.{minor}.{patch}-{release}.{pre_n}+build.{build_n}",

--- a/uv.lock
+++ b/uv.lock
@@ -863,7 +863,7 @@ wheels = [
 
 [[package]]
 name = "rhiza"
-version = "1.3.4"
+version = "1.4.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Bumps this repo from **v1.3.4** to **v1.4.0**.

## Why minor

No commit in the range is marked `!` or carries `BREAKING CHANGE`, and the log is 5 `chore:` plus 1 `fix:`. But the five chores retire the synced make layer from the bundles — `core` no longer ships a `Makefile` or `.rhiza/rhiza.mk`, and `.rhiza/make.d/` is gone from every bundle — so what a downstream sync *delivers* changes materially. Minor reflects that without claiming an API break.

Note for consumers syncing past this release: a sync that stops delivering a file does not delete it, and an explicit rule beats the shim's `%:` catch-all. A repo that still carries `.rhiza/make.d/` will run the **old** fragments rather than the CLI, so those need removing by hand.

## Files the bump touched

| File | What moved |
| --- | --- |
| `pyproject.toml` | `[project].version` and `[tool.bumpversion].current_version` |
| `uv.lock` | the `name = "rhiza"` entry, regenerated by the `uv-lock` hook |
| `bundles/**/.github/workflows/*.yml` (13 files) | `jebel-quant/rhiza/...@v1.3.4` → `@v1.4.0` |
| `CHANGELOG.md` | new `## [1.4.0]` section, prepended |

Every location is a declared `[[tool.bumpversion.files]]` entry — nothing was hand-edited. The **live** `.github/workflows/` are deliberately not in the config and were not touched, so this PR carries no self-referencing pin to a tag that does not exist yet and its checks can go green normally.

## Changelog section added

```markdown
## [1.4.0] - 2026-08-19

### Bug Fixes
- *(marimo)* Read MARIMO_FOLDER from rhiza-task, not from make's namespace (#1553)

### Maintenance
- Retire core's .rhiza/.env, point settings at [tool.rhiza-task] (#1555)
- Migrate this repo to the rhiza-task shim, retiring its own make layer (#1556)
- Stop shipping the make layer; keep the five fragments with no CLI task (#1557)
- Retire the last five make fragments, and the folder with them (#1559)
- Remove the .clusterfuzzlite config, which had no harness to build (#1560)
```

Prepended with `git-cliff --unreleased --tag v1.4.0 --prepend`, so no existing section was regenerated or lost.

## Merging this does not publish the release

**No tag exists yet.** `v1.4.0` is cut afterwards, from the commit this PR merges as — a second `/rhiza:release` run does that, which is also where the strictly-increases guard runs again against the merged history. The two-phase split exists because a squash-merge would otherwise strand the tag on a SHA that never reaches `main`.
