### PR TITLE
fix(ci): reach the gates through the rhiza-task CLI, not through make

### DIFF
--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -18,6 +18,15 @@ concurrency:
 permissions:
   contents: read
 
+# The rhiza-task pin the gate step below runs through. v1.4.0 retired the synced make
+# layer -- core ships no Makefile and no `.rhiza/rhiza.mk` -- so a consumer that syncs it
+# has no make targets left and the gate dies with `No rule to make target '<gate>'`.
+# Calling the CLI directly drops the dependency on a front door this workflow does not
+# ship. Pinned rather than read from a consumer's `RHIZA_TASK`, which this workflow cannot
+# see: it tracks the tag the workflow is called at.
+env:
+  RHIZA_TASK: rhiza-task@0.3.0
+
 on:
   push:
     branches:
@@ -59,5 +68,5 @@ jobs:
           UV_EXTRA_INDEX_URL: ${{ secrets.UV_EXTRA_INDEX_URL }}
         run: |
           START=$(date +%s)
-          make benchmark
+          uvx "$RHIZA_TASK" benchmark
           echo "Benchmark run: $(($(date +%s) - START))s" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -34,6 +34,15 @@ concurrency:
 permissions:
   contents: read
 
+# The rhiza-task pin the gate step below runs through. v1.4.0 retired the synced make
+# layer -- core ships no Makefile and no `.rhiza/rhiza.mk` -- so a consumer that syncs it
+# has no make targets left and the gate dies with `No rule to make target '<gate>'`.
+# Calling the CLI directly drops the dependency on a front door this workflow does not
+# ship. Pinned rather than read from a consumer's `RHIZA_TASK`, which this workflow cannot
+# see: it tracks the tag the workflow is called at.
+env:
+  RHIZA_TASK: rhiza-task@0.3.0
+
 jobs:
   # Build the book on every commit (any branch). This proves the documentation
   # site still builds and uploads it as an artifact; it publishes nothing. It
@@ -89,7 +98,7 @@ jobs:
           UV_EXTRA_INDEX_URL: ${{ secrets.UV_EXTRA_INDEX_URL }}
         run: |
           START=$(date +%s)
-          make book
+          uvx "$RHIZA_TASK" book
           echo "Docs build: $(($(date +%s) - START))s" >> "$GITHUB_STEP_SUMMARY"
 
       # Upload the book as a downloadable workflow artifact (on every commit).

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -25,6 +25,20 @@ permissions:
   contents: read
   actions: read
 
+# The rhiza-task pin every gate step below runs through. `make <gate>` was the old
+# interface, and v1.4.0 retired the synced make layer -- core ships no Makefile and no
+# `.rhiza/rhiza.mk` -- so a consumer that syncs it is left with no make targets at all and
+# every gate dies with `No rule to make target 'test'` (seen on Jebel-Quant/greeks#118,
+# where the sync deleted the Makefile and nothing regenerated it). Calling the CLI directly
+# drops the dependency on a front door this workflow does not ship. `make` stays the human
+# entry point in a repo that generates the shim; it is simply no longer what CI relies on.
+#
+# Pinned here rather than read from a consumer's `RHIZA_TASK`, which this workflow cannot
+# see -- and should not: the gates a build runs must not move under it. It tracks the tag
+# this workflow is called at, the same rule the OS-matrix step below states for its pin.
+env:
+  RHIZA_TASK: rhiza-task@0.3.0
+
 on:
   push:
   pull_request:
@@ -176,7 +190,7 @@ jobs:
           UV_EXTRA_INDEX_URL: ${{ secrets.UV_EXTRA_INDEX_URL }}
         shell: bash
         run: |
-          make test
+          uvx "$RHIZA_TASK" test
 
       - name: Verify clean working tree
         if: matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest'
@@ -184,7 +198,7 @@ jobs:
         run: |
           status="$(git status --porcelain)"
           if [[ -n "$status" ]]; then
-            echo "Working tree is dirty after make test:"
+            echo "Working tree is dirty after the test gate:"
             printf '%s\n' "$status"
             git diff --exit-code || true
             exit 1
@@ -263,13 +277,13 @@ jobs:
         with:
           token: ${{ secrets.GH_PAT }}
 
-      - name: Run ty and mypy type checkers (make typecheck)
+      - name: Run ty and mypy type checkers (typecheck gate)
         # Runs `uv run ty check <source>` and `uv run mypy --strict <source>`
         # as defined by rhiza-task's `typecheck` task. Set TYPECHECKER=ty or
         # TYPECHECKER=mypy to run only one of the two checkers.
         env:
           UV_EXTRA_INDEX_URL: ${{ secrets.UV_EXTRA_INDEX_URL }}
-        run: make typecheck
+        run: uvx "$RHIZA_TASK" typecheck
 
   deptry:
     name: Check dependencies with deptry
@@ -296,7 +310,7 @@ jobs:
           token: ${{ secrets.GH_PAT }}
 
       - name: Run deptry
-        run: make deps
+        run: uvx "$RHIZA_TASK" deps
 
   rhiza-test:
     name: Rhiza repository checks
@@ -330,10 +344,23 @@ jobs:
         with:
           token: ${{ secrets.GH_PAT }}
 
+      # RHIZA_DOCTEST_FOLDERS is exported rather than left to pytest-rhiza's own
+      # fallback, which is SOURCE_FOLDER in `.rhiza/.env` and then the literal `src`.
+      # rhiza-task does not pass its resolved `source_folder` through to the check
+      # (Jebel-Quant/rhiza-task#18), so without this `test_docstrings` reports
+      #
+      #   SKIPPED  No doctest folder found (looked for: src)
+      #
+      # while the gate still exits 0 -- #1517 exactly: doctest examples unchecked behind a
+      # green gate. The mother repo's Makefile wraps the target for this reason, but that
+      # wrapper is repo-owned and no consumer ever had it, so every consumer running this
+      # workflow had the silent skip. Doing it here fixes it for all of them at once.
       - name: Run the rhiza repository checks
         env:
           UV_EXTRA_INDEX_URL: ${{ secrets.UV_EXTRA_INDEX_URL }}
-        run: make rhiza-test
+        run: |
+          RHIZA_DOCTEST_FOLDERS="$(uvx "$RHIZA_TASK" print source_folder)" \
+            uvx "$RHIZA_TASK" rhiza-test
 
   pre-commit:
     name: Pre-commit hooks
@@ -354,6 +381,15 @@ jobs:
         with:
           token: ${{ secrets.GH_PAT }}
 
+      # This job deliberately had no setup-uv step: `ubuntu-latest` ships no uv, and the
+      # shim's `$(UVX)` rule bootstrapped it as a prerequisite of every target, so
+      # `make fmt` worked on a bare runner. Reaching the CLI directly means the binary has
+      # to be there already -- without this step the job fails with `uvx: command not found`.
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          version: "0.11.16"
+
       - name: Cache prek environments
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
@@ -364,7 +400,7 @@ jobs:
 
       - name: Run prek
         run: |
-          make fmt
+          uvx "$RHIZA_TASK" fmt
 
   docs-coverage:
     # CI budget: ≤10 min (docs quality check). Last measured: 2026-05-28.
@@ -393,7 +429,7 @@ jobs:
         env:
           UV_EXTRA_INDEX_URL: ${{ secrets.UV_EXTRA_INDEX_URL }}
         run: |
-          make docs-coverage
+          uvx "$RHIZA_TASK" docs-coverage
 
   security:
     name: Security scanning
@@ -422,7 +458,7 @@ jobs:
       - name: Run security scans
         env:
           UV_EXTRA_INDEX_URL: ${{ secrets.UV_EXTRA_INDEX_URL }}
-        run: make security
+        run: uvx "$RHIZA_TASK" security
 
   license:
     name: License compliance scan
@@ -451,7 +487,7 @@ jobs:
       - name: Run license check
         env:
           UV_EXTRA_INDEX_URL: ${{ secrets.UV_EXTRA_INDEX_URL }}
-        run: make license
+        run: uvx "$RHIZA_TASK" license
 
       - name: Generate LICENSES.md
         env:

--- a/.github/workflows/rhiza_mutation.yml
+++ b/.github/workflows/rhiza_mutation.yml
@@ -40,6 +40,13 @@ concurrency:
 permissions:
   contents: read
 
+# The rhiza-task pin the gate steps below run through. v1.4.0 retired the synced make
+# layer -- core ships no Makefile and no `.rhiza/rhiza.mk` -- so a consumer that syncs it
+# has no make targets left and each gate dies with `No rule to make target '<gate>'`.
+# Pinned rather than read from a consumer's `RHIZA_TASK`, which this workflow cannot see.
+env:
+  RHIZA_TASK: rhiza-task@0.3.0
+
 on:
   pull_request:
   schedule:
@@ -62,9 +69,17 @@ jobs:
         with:
           python-version: "3.12"
 
-      # `make mutation` bootstraps uv, creates the venv, installs deps, then runs
-      # mutmut. We preserve the gate result, but defer failing until after we
-      # generate and upload the badge/report artifacts.
+      # This job had no setup-uv step: the shim's `$(UVX)` rule bootstrapped uv as a
+      # prerequisite of every target, so `make mutation` worked on a bare runner.
+      # Reaching the CLI directly needs the binary present.
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          version: "0.11.16"
+
+      # The mutation gate creates the venv, installs deps, then runs mutmut. We preserve
+      # the gate result, but defer failing until after we generate and upload the
+      # badge/report artifacts.
       - name: Run mutation tests
         id: run-mutation
         shell: bash
@@ -72,7 +87,7 @@ jobs:
           mkdir -p _tests/mutation
           set +e
           set -o pipefail
-          make mutation 2>&1 | tee _tests/mutation/mutmut.log
+          uvx "$RHIZA_TASK" mutation 2>&1 | tee _tests/mutation/mutmut.log
           status=${PIPESTATUS[0]}
           echo "status=$status" >> "$GITHUB_OUTPUT"
           exit 0
@@ -240,7 +255,7 @@ jobs:
         timeout-minutes: 10
         env:
           UV_EXTRA_INDEX_URL: ${{ secrets.UV_EXTRA_INDEX_URL }}
-        run: make book
+        run: uvx "$RHIZA_TASK" book
 
       - name: Publish mutation badge into pages bundle
         shell: bash

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -22,6 +22,16 @@ concurrency:
 permissions:
   contents: read
 
+# The rhiza-task pin the gate steps below run through. v1.4.0 retired the synced make
+# layer -- core ships no Makefile and no `.rhiza/rhiza.mk` -- so a consumer that syncs it
+# has no make targets left and each gate dies with `No rule to make target '<gate>'`.
+#
+# `gitlab-docker-test` below is deliberately NOT converted: it is a mother-repo-only
+# target defined in this repo's own Makefile, not a rhiza-task task, so make is the only
+# thing that can resolve it.
+env:
+  RHIZA_TASK: rhiza-task@0.3.0
+
 on:
   #push:
   #  branches: [main]
@@ -81,7 +91,7 @@ jobs:
       - name: Run tests
         env:
           UV_EXTRA_INDEX_URL: ${{ secrets.UV_EXTRA_INDEX_URL }}
-        run: make test
+        run: uvx "$RHIZA_TASK" test
 
   semgrep:
     name: Semgrep (numpy)
@@ -108,7 +118,7 @@ jobs:
       - name: Run Semgrep
         env:
           UV_EXTRA_INDEX_URL: ${{ secrets.UV_EXTRA_INDEX_URL }}
-        run: make semgrep
+        run: uvx "$RHIZA_TASK" semgrep
 
   # The one check that the pinned $UV_IMAGE in bundles/gitlab/.gitlab-ci.yml still
   # pulls and runs a job. It is opt-in behind RHIZA_GITLAB_DOCKER because it pulls a

--- a/.rhiza/.gitignore
+++ b/.rhiza/.gitignore
@@ -1,2 +1,0 @@
-# Dedicated rhiza ignore rules
-!.env

--- a/bundles/core/.rhiza/.gitignore
+++ b/bundles/core/.rhiza/.gitignore
@@ -1,2 +1,0 @@
-# Dedicated rhiza ignore rules
-!.env

--- a/bundles/gitlab-tests/.gitlab/workflows/rhiza_ci.yml
+++ b/bundles/gitlab-tests/.gitlab/workflows/rhiza_ci.yml
@@ -9,6 +9,15 @@
 #
 # Trigger: On push and merge requests.
 
+#
+# RHIZA_TASK is the pin every gate below runs through. v1.4.0 retired the synced make
+# layer -- core ships no Makefile and no `.rhiza/rhiza.mk` -- so a project that syncs it
+# has no make targets left and each gate dies with `No rule to make target '<gate>'`.
+# Calling the CLI directly drops the dependency on a front door rhiza no longer ships.
+
+variables:
+  RHIZA_TASK: "rhiza-task@0.3.0"
+
 ci:test:
   # CI budget: ≤20 min (test matrix execution). Last measured: 2026-05-28.
   timeout: 20m
@@ -29,7 +38,7 @@ ci:test:
     # `make test` bootstraps its own environment via the `install` target, which
     # creates the venv with PYTHON_VERSION (a `?=` default the matrix env var
     # overrides) and provisions test tooling on the fly — no explicit `uv venv`.
-    - make test
+    - uvx "$RHIZA_TASK" test
 
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
@@ -42,7 +51,7 @@ ci:docs-coverage:
   image: $UV_IMAGE
   script:
     - export UV_EXTRA_INDEX_URL="${UV_EXTRA_INDEX_URL}"
-    - make docs-coverage
+    - uvx "$RHIZA_TASK" docs-coverage
 
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
@@ -56,7 +65,7 @@ ci:typecheck:
   image: $UV_IMAGE
   script:
     - export UV_EXTRA_INDEX_URL="${UV_EXTRA_INDEX_URL}"
-    - make typecheck
+    - uvx "$RHIZA_TASK" typecheck
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
     - if: $CI_COMMIT_BRANCH
@@ -68,7 +77,7 @@ ci:deptry:
   needs: []
   image: $UV_IMAGE
   script:
-    - make deps
+    - uvx "$RHIZA_TASK" deps
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
     - if: $CI_COMMIT_BRANCH
@@ -80,7 +89,7 @@ ci:pre-commit:
   needs: []
   image: $UV_IMAGE
   script:
-    - make fmt
+    - uvx "$RHIZA_TASK" fmt
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
     - if: $CI_COMMIT_BRANCH
@@ -93,7 +102,7 @@ ci:security:
   image: $UV_IMAGE
   script:
     - export UV_EXTRA_INDEX_URL="${UV_EXTRA_INDEX_URL}"
-    - make security
+    - uvx "$RHIZA_TASK" security
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
     - if: $CI_COMMIT_BRANCH
@@ -106,7 +115,7 @@ ci:license:
   image: $UV_IMAGE
   script:
     - export UV_EXTRA_INDEX_URL="${UV_EXTRA_INDEX_URL}"
-    - make license
+    - uvx "$RHIZA_TASK" license
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
     - if: $CI_COMMIT_BRANCH

--- a/bundles/gitlab/.gitlab/workflows/rhiza_quality.yml
+++ b/bundles/gitlab/.gitlab/workflows/rhiza_quality.yml
@@ -11,12 +11,21 @@
 #
 # Equivalent GitHub Action: .github/workflows/rhiza_quality.yml
 
+#
+# RHIZA_TASK is the pin every gate below runs through. v1.4.0 retired the synced make
+# layer -- core ships no Makefile and no `.rhiza/rhiza.mk` -- so a project that syncs it
+# has no make targets left and each gate dies with `No rule to make target '<gate>'`.
+# Calling the CLI directly drops the dependency on a front door rhiza no longer ships.
+
+variables:
+  RHIZA_TASK: "rhiza-task@0.3.0"
+
 quality:deptry:
   stage: test
   needs: []
   image: $UV_IMAGE
   script:
-    - make deps
+    - uvx "$RHIZA_TASK" deps
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
     - if: $CI_COMMIT_BRANCH
@@ -26,7 +35,7 @@ quality:pre-commit:
   needs: []
   image: $UV_IMAGE
   script:
-    - make fmt
+    - uvx "$RHIZA_TASK" fmt
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
     - if: $CI_COMMIT_BRANCH
@@ -38,7 +47,7 @@ quality:docs-coverage:
   variables:
     UV_EXTRA_INDEX_URL: "${UV_EXTRA_INDEX_URL}"
   script:
-    - make docs-coverage
+    - uvx "$RHIZA_TASK" docs-coverage
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
     - if: $CI_COMMIT_BRANCH

--- a/bundles/gitlab/.gitlab/workflows/rhiza_weekly.yml
+++ b/bundles/gitlab/.gitlab/workflows/rhiza_weekly.yml
@@ -12,13 +12,22 @@
 # Trigger: Scheduled pipeline (configure weekly in GitLab CI/CD Schedules),
 #          or manually via the web UI.
 
+#
+# RHIZA_TASK is the pin every gate below runs through. v1.4.0 retired the synced make
+# layer -- core ships no Makefile and no `.rhiza/rhiza.mk` -- so a project that syncs it
+# has no make targets left and each gate dies with `No rule to make target '<gate>'`.
+# Calling the CLI directly drops the dependency on a front door rhiza no longer ships.
+
+variables:
+  RHIZA_TASK: "rhiza-task@0.3.0"
+
 weekly:semgrep:
   stage: test
   needs: []
   image: $UV_IMAGE
   script:
     - export UV_EXTRA_INDEX_URL="${UV_EXTRA_INDEX_URL}"
-    - make semgrep
+    - uvx "$RHIZA_TASK" semgrep
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_PIPELINE_SOURCE == "web"

--- a/tests/api/test_ci_workflow.py
+++ b/tests/api/test_ci_workflow.py
@@ -59,14 +59,14 @@ def test_ci_generate_matrix_reads_the_os_matrix_from_the_cli(root):
 
 
 def test_ci_security_job_runs_security_scans(root):
-    """CI security job must run the security scans via `make security`."""
+    """CI security job must run the security scans through the rhiza-task CLI."""
     with (root / WORKFLOW_PATH).open(encoding="utf-8") as fh:
         workflow = yaml.safe_load(fh)
 
     security_job = workflow["jobs"]["security"]
     run_steps = [step.get("run", "") for step in security_job.get("steps", [])]
 
-    assert any("make security" in run for run in run_steps)
+    assert any('uvx "$RHIZA_TASK" security' in run for run in run_steps)
 
 
 def test_ci_jobs_define_timeout_budgets(root):
@@ -157,7 +157,11 @@ def test_every_gate_named_by_make_all_runs_in_ci(root):
     workflows = (root / ".github" / "workflows").glob("*.yml")
     invoked = "\n".join(wf.read_text(encoding="utf-8") for wf in workflows)
 
-    missing = [gate for gate in gates if f"make {gate}" not in invoked]
+    # Either interface counts: the gates run through `uvx "$RHIZA_TASK" <gate>` since
+    # v1.4.0 retired the make layer, while the mother-repo-only targets (`e2e`,
+    # `gitlab-docker-test`) are real Make rules in this repo's own Makefile. What must
+    # hold is that some workflow invokes the gate.
+    missing = [gate for gate in gates if f'uvx "$RHIZA_TASK" {gate}' not in invoked and f"make {gate}" not in invoked]
     assert not missing, (
         f"these targets are named by `make all` but no .github/workflows job runs them: "
         f"{missing}. A gate that runs only locally cannot block a pull request (#1523)."
@@ -214,13 +218,13 @@ def test_ci_cache_keys_match_audit_policy(root):
 
 
 def test_ci_test_job_runs_make_under_bash(root):
-    """CI test job must run make under bash for Windows compatibility."""
+    """CI test job must run the test gate under bash for Windows compatibility."""
     with (root / WORKFLOW_PATH).open(encoding="utf-8") as fh:
         workflow = yaml.safe_load(fh)
 
     run_tests_step = next(step for step in workflow["jobs"]["test"]["steps"] if step.get("name") == "Run tests")
     assert run_tests_step["shell"] == "bash"
-    assert "make test" in run_tests_step["run"]
+    assert 'uvx "$RHIZA_TASK" test' in run_tests_step["run"]
 
 
 def test_ci_typecheck_job_documents_ty_and_mypy(root):
@@ -229,7 +233,7 @@ def test_ci_typecheck_job_documents_ty_and_mypy(root):
         workflow = yaml.safe_load(fh)
 
     typecheck_steps = workflow["jobs"]["typecheck"]["steps"]
-    typecheck_step = next(step for step in typecheck_steps if step.get("run") == "make typecheck")
+    typecheck_step = next(step for step in typecheck_steps if step.get("run") == 'uvx "$RHIZA_TASK" typecheck')
     assert "ty and mypy" in typecheck_step["name"]
 
 

--- a/tests/bundles/test_profile_ci_parity.py
+++ b/tests/bundles/test_profile_ci_parity.py
@@ -17,14 +17,17 @@ import yaml
 
 from tests.util import sync_bundles
 
+# The gate each job must invoke, keyed by job name. These are rhiza-task task names
+# rather than Make targets: v1.4.0 retired the synced make layer, so both pipelines now
+# reach the CLI directly and `make <gate>` resolves nothing in a synced project.
 PARITY_JOB_COMMANDS = {
-    "test": "make test",
-    "docs-coverage": "make docs-coverage",
-    "typecheck": "make typecheck",
-    "deptry": "make deps",
-    "pre-commit": "make fmt",
-    "security": "make security",
-    "license": "make license",
+    "test": "test",
+    "docs-coverage": "docs-coverage",
+    "typecheck": "typecheck",
+    "deptry": "deps",
+    "pre-commit": "fmt",
+    "security": "security",
+    "license": "license",
 }
 
 
@@ -82,9 +85,20 @@ def _job_commands(job: dict, key: str) -> list[str]:
     return [str(command) for command in commands]
 
 
-def _contains_make_command(commands: str, target: str) -> bool:
-    """Return True when commands invoke the given Make target with or without -f."""
-    return any(candidate in commands for candidate in (f"make {target}", f"make -f .rhiza/rhiza.mk {target}"))
+def _contains_gate_invocation(commands: str, target: str) -> bool:
+    """Return True when the commands invoke the given gate, by either interface.
+
+    The CLI form is what both pipelines ship now. The Make forms are still accepted
+    because a consumer pinned to an older tag, or one that kept a repo-owned target
+    shadowing the catch-all, invokes the same gate through them -- what this asserts is
+    that the job runs the gate at all, not which front door it uses.
+    """
+    candidates = (
+        f'uvx "$RHIZA_TASK" {target}',
+        f"make {target}",
+        f"make -f .rhiza/rhiza.mk {target}",
+    )
+    return any(candidate in commands for candidate in candidates)
 
 
 class TestGitlabProjectProfileSync:
@@ -189,9 +203,8 @@ class TestGitlabProjectProfileSync:
         )
         gitlab_commands = "\n".join(_job_commands(gitlab_job, "script"))
 
-        target = command.removeprefix("make ")
-        assert _contains_make_command(github_commands, target)
-        assert _contains_make_command(gitlab_commands, target)
+        assert _contains_gate_invocation(github_commands, command)
+        assert _contains_gate_invocation(gitlab_commands, command)
 
     def test_gitlab_ci_jobs_define_timeout_budgets(self) -> None:
         """GitLab CI core jobs must define explicit timeout budgets."""


### PR DESCRIPTION
Fixes the CI breakage v1.4.0 shipped, plus one unrelated cleanup. Two commits, separable.

## The bug

v1.4.0 retired the synced make layer — `core` ships no `Makefile` and no `.rhiza/rhiza.mk` — and rhiza-cli prunes what a bundle stops shipping. So the sync **deleted every front door a consumer had**, while the reusable workflows still invoked `make <gate>`.

[Jebel-Quant/greeks#118](https://github.com/Jebel-Quant/greeks/pull/118) is the first repo to sync past it. All eight gates died identically:

```
ci / test                make: *** No rule to make target 'test'.  Stop.
ci / Type checking       make: *** No rule to make target 'typecheck'.  Stop.
ci / docs-coverage       make: *** No rule to make target 'docs-coverage'.  Stop.
ci / Security scanning   make: *** No rule to make target 'security'.  Stop.
ci / License compliance  make: *** No rule to make target 'license'.  Stop.
ci / deptry              make: *** No rule to make target 'deps'.  Stop.
ci / Pre-commit hooks    make: *** No rule to make target 'fmt'.  Stop.
ci / Rhiza repo checks   make: *** No rule to make target 'rhiza-test'.  Stop.
```

Worth noting for anyone reading that log: GNU make prints `No rule to make target 'test'` — not `No targets specified and no makefile found` — whenever an explicit target is given. The message does **not** imply a Makefile was present. On greeks' branch there is none.

## The fix — CI calls the CLI directly

`RHIZA_TASK` pinned at workflow level, and `make <gate>` → `uvx "$RHIZA_TASK" <gate>` across **19 sites**: `rhiza_ci`'s eight, plus book, benchmark, mutation, weekly, and the eleven GitLab bundle templates. All twelve task names verified present in `rhiza-task@0.3.0`.

The pin is deliberately *not* read from a consumer's own `RHIZA_TASK`: this workflow cannot see it, and should not — the gates a build runs must not move under it. That is the rule the OS-matrix step already states for its pin.

`make` stays the human front door in a repo that generates the shim. It is simply no longer what CI depends on.

### Three things that are not swaps

- **`pre-commit` and `mutation` had no `setup-uv` step.** The shim's `$(UVX)` rule bootstrapped uv as a prerequisite of every target, so `make fmt` worked on a bare runner. Calling `uvx` directly does not, so both jobs now install uv. Missing this would have traded one red job for another.

- **`rhiza-test` exports `RHIZA_DOCTEST_FOLDERS`.** pytest-rhiza reads its scope from that variable and rhiza-task does not pass `source_folder` through ([rhiza-task#18](https://github.com/Jebel-Quant/rhiza-task/issues/18)), so a bare delegation reports `SKIPPED  No doctest folder found (looked for: src)` while the gate still exits 0 — #1517. The mother repo's Makefile wraps the target for exactly this, but that wrapper is repo-owned and **no consumer ever had it** — so every consumer has been running this check silently skipped. Doing it in the workflow fixes all of them at once.

- **`e2e` and `gitlab-docker-test` stay on `make`** — mother-repo-only targets in this repo's own Makefile, not rhiza-task tasks.

`test_profile_ci_parity`'s helper now accepts either interface: what it asserts is that a job runs the gate, not which front door it uses, so a consumer pinned to an older tag still satisfies it.

## Second commit — remove `.rhiza/.gitignore`

Its entire payload was `!.env`, negating the root `.gitignore`'s `.env` rule (the one filed under *"Don't expose API keys, etc."*), so `.rhiza/.env` was **not** ignored here or in any project that synced `core`.

That negation existed to let a template-shipped `.rhiza/.env` be committed, and #1555 retired that file — `core` ships none, and the documented settings home is `[tool.rhiza-task]` in `pyproject.toml`.

Removing it reconciles the tree with what three places already assert: `CLAUDE.md`, `tests/utils/test_gate_scope.py:187` and `tests/integration/test_docs_targets.py:98` all explain their design by stating `.rhiza/.env` is gitignored — which was false while the negation stood. Verified both ways in an isolated repo: with the file `check-ignore` exits 1, without it 0.

A consumer that already tracks `.rhiza/.env` is unaffected — gitignore does not untrack a tracked file.

## Verification

- Full suite: **1310 passed, 46 skipped**
- `make fmt`: all hooks pass, actionlint and GitHub-workflow validation included
- The exact new `rhiza-test` step run locally: `print source_folder` → `utils`, 34 checks passed, **none skipped**

## This does not turn greeks green by itself

greeks pins `jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.4.0` — the broken version. It needs, in order: merge this → release **v1.4.1** → re-run `/rhiza:update` on greeks so its stub moves to `@v1.4.1`.
