### PR TITLE
chore: release v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com),
 and entries are generated from [Conventional Commits](https://www.conventionalcommits.org).
 
+## [1.4.1] - 2026-08-19
+
+### Bug Fixes
+- *(ci)* Reach the gates through the rhiza-task CLI, not through make (#1562)
+
 ## [1.4.0] - 2026-08-19
 
 ### Bug Fixes

--- a/bundles/github-book/.github/workflows/rhiza_book.yml
+++ b/bundles/github-book/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.4.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.4.1
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml
+++ b/bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   devcontainer:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v1.4.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v1.4.1
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-docker/.github/workflows/rhiza_docker.yml
+++ b/bundles/github-docker/.github/workflows/rhiza_docker.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   docker:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v1.4.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v1.4.1
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-marimo/.github/workflows/rhiza_marimo.yml
+++ b/bundles/github-marimo/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.4.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.4.1
     secrets: inherit

--- a/bundles/github-paper/.github/workflows/rhiza_paper.yml
+++ b/bundles/github-paper/.github/workflows/rhiza_paper.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   paper:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v1.4.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v1.4.1
     secrets: inherit
     permissions:
       contents: write

--- a/bundles/github-quality-review/.github/workflows/rhiza_quality_review.yml
+++ b/bundles/github-quality-review/.github/workflows/rhiza_quality_review.yml
@@ -34,5 +34,5 @@ on:
 
 jobs:
   quality-review:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_quality_review.yml@v1.4.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_quality_review.yml@v1.4.1
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_benchmark.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.4.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.4.1
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_ci.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.4.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.4.1
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_codeql.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.4.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.4.1
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/bundles/github-tests/.github/workflows/rhiza_mutation.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_mutation.yml
@@ -42,7 +42,7 @@ jobs:
     # this repo sets the `MUTATION_ENABLED` variable to 'true'. Gating here in
     # the caller keeps it optional regardless of the pinned reusable workflow.
     if: ${{ vars.MUTATION_ENABLED == 'true' }}
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v1.4.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v1.4.1
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github/.github/workflows/rhiza_fuzzing.yml
+++ b/bundles/github/.github/workflows/rhiza_fuzzing.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   fuzzing:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v1.4.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v1.4.1
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github/.github/workflows/rhiza_scorecard.yml
+++ b/bundles/github/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.4.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.4.1
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/bundles/github/.github/workflows/rhiza_weekly.yml
+++ b/bundles/github/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.4.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.4.1
     secrets: inherit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rhiza"
-version = "1.4.0"
+version = "1.4.1"
 description = "Reusable configuration templates for modern Python projects"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -70,7 +70,7 @@ Issues = "https://github.com/jebel-quant/rhiza/issues"
 # python-core bundle no longer ships a `.rhiza/.cfg.toml` copy of this block; the
 # Rust and Go layers ship a root `.bumpversion.toml` instead, since neither
 # language has a discoverable file of its own.
-current_version = "1.4.0"
+current_version = "1.4.1"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:[-]?(?P<release>[a-z]+)[\\.]?(?P<pre_n>\\d+))?(?:\\+build\\.(?P<build_n>\\d+))?"
 serialize = [
     "{major}.{minor}.{patch}-{release}.{pre_n}+build.{build_n}",

--- a/uv.lock
+++ b/uv.lock
@@ -863,7 +863,7 @@ wheels = [
 
 [[package]]
 name = "rhiza"
-version = "1.4.0"
+version = "1.4.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Release **v1.4.0 → v1.4.1** (patch: the single unreleased commit is a `fix(ci)`).

`v1.4.1` strictly increases past every published tag — the highest existing tag is `v1.4.0`, and the guard confirmed it before anything was written.

## Files the bump touched

- `pyproject.toml` — `[project].version` and `[tool.bumpversion].current_version`
- `uv.lock` — regenerated with `uv lock` (the config deliberately leaves the lock's own `rhiza` entry to uv rather than to a search/replace pattern)
- **13 bundle CI stubs** under `bundles/**/.github/workflows/*.yml` — their `jebel-quant/rhiza/...@vX.Y.Z` self-references, so a downstream sync at this tag gets workflows pointing at *this* release rather than the previous one
- `CHANGELOG.md` — one new section, prepended

The **live** `.github/workflows/` are deliberately not in the bump config and were not touched: they reference `jebel-quant/actions` by commit SHA, which carries that repo's version, not this one's. That is also what keeps this release PR mergeable — a self-referential pin would fail at `Set up job` against a tag that does not exist yet.

## Changelog section being added

```markdown
## [1.4.1] - 2026-08-19

### Bug Fixes
- *(ci)* Reach the gates through the rhiza-task CLI, not through make (#1562)
```

Prepended with `git-cliff --unreleased --tag v1.4.1 --prepend`, so no existing section was regenerated or rewritten.

## Merging this PR does not publish the release

There is **no tag yet**, on purpose. A tag must point at a commit that exists on `main`, and a squash-merge replaces this branch's commit with a new one — so the tag is cut *afterwards*, from the merged commit, by a second `/rhiza:release` run. That run re-checks the guard against the merged history before creating anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
