### PR TITLE
chore: bump rhiza-task to 0.3.1, retiring two mother-repo workarounds

### DIFF
--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -25,7 +25,7 @@ permissions:
 # ship. Pinned rather than read from a consumer's `RHIZA_TASK`, which this workflow cannot
 # see: it tracks the tag the workflow is called at.
 env:
-  RHIZA_TASK: rhiza-task@0.3.0
+  RHIZA_TASK: rhiza-task@0.3.1
 
 on:
   push:

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -41,7 +41,7 @@ permissions:
 # ship. Pinned rather than read from a consumer's `RHIZA_TASK`, which this workflow cannot
 # see: it tracks the tag the workflow is called at.
 env:
-  RHIZA_TASK: rhiza-task@0.3.0
+  RHIZA_TASK: rhiza-task@0.3.1
 
 jobs:
   # Build the book on every commit (any branch). This proves the documentation

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -37,7 +37,7 @@ permissions:
 # see -- and should not: the gates a build runs must not move under it. It tracks the tag
 # this workflow is called at, the same rule the OS-matrix step below states for its pin.
 env:
-  RHIZA_TASK: rhiza-task@0.3.0
+  RHIZA_TASK: rhiza-task@0.3.1
 
 on:
   push:
@@ -128,7 +128,7 @@ jobs:
             ${{ github.repository == 'jebel-quant/rhiza'
                 && '["ubuntu-latest","macos-latest"]' || '' }}
         run: |
-          OS_MATRIX=$(uvx rhiza-task@0.2.0 ci-os-matrix)
+          OS_MATRIX=$(uvx rhiza-task@0.3.1 ci-os-matrix)
           echo "list=$OS_MATRIX" >> "$GITHUB_OUTPUT"
 
       - name: Debug OS matrix

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -81,7 +81,7 @@ jobs:
           #
           # Pinned for the reason the OS matrix is pinned (#1546): the folder a build
           # discovers notebooks in must not move under a workflow called at a tag.
-          NOTEBOOK_DIR=$(uvx rhiza-task@0.2.0 print marimo_folder)
+          NOTEBOOK_DIR=$(uvx rhiza-task@0.3.1 print marimo_folder)
 
           echo "Searching notebooks in: $NOTEBOOK_DIR"
           # Check if directory exists

--- a/.github/workflows/rhiza_mutation.yml
+++ b/.github/workflows/rhiza_mutation.yml
@@ -45,7 +45,7 @@ permissions:
 # has no make targets left and each gate dies with `No rule to make target '<gate>'`.
 # Pinned rather than read from a consumer's `RHIZA_TASK`, which this workflow cannot see.
 env:
-  RHIZA_TASK: rhiza-task@0.3.0
+  RHIZA_TASK: rhiza-task@0.3.1
 
 on:
   pull_request:

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -30,7 +30,7 @@ permissions:
 # target defined in this repo's own Makefile, not a rhiza-task task, so make is the only
 # thing that can resolve it.
 env:
-  RHIZA_TASK: rhiza-task@0.3.0
+  RHIZA_TASK: rhiza-task@0.3.1
 
 on:
   #push:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -471,11 +471,18 @@ are a section of the root `Makefile` now — not `local.mk`, which is gitignored
 
 **And why `rhiza-test` is wrapped rather than delegated.** pytest-rhiza's `test_docstrings` reads
 its scope from the `RHIZA_DOCTEST_FOLDERS` environment variable; `quality.mk` exported it from
-`DOCSTRING_FOLDERS`, and rhiza-task does not (Jebel-Quant/rhiza-task#18). On a bare delegation the
-check reported `SKIPPED  No doctest folder found (looked for: src)` while the gate still said
+`DOCSTRING_FOLDERS`, and rhiza-task 0.3.0 did not (Jebel-Quant/rhiza-task#18). On a bare delegation
+the check reported `SKIPPED  No doctest folder found (looked for: src)` while the gate still said
 `ok rhiza-test` — #1517 exactly, this repo's only doctest examples unchecked behind a green gate.
 `.rhiza/.env` cannot carry the value because that file is gitignored.
-`tests/utils/test_gate_scope.py` fails if the export goes.
+
+**0.3.1 passes it through itself**, so the wrapper stopped being a fix and became a probe: the
+export is the one form of the property `tests/utils/test_gate_scope.py` can read out of a `make -n`
+— no network, no lockfile, no tags — and the test fails if it goes. A bare delegation would move
+the property inside the pin, where only a real run reveals a regression. The two other mother-repo
+workarounds 0.3.1 retired did not need that treatment and are gone: the shim now ships the `PATH`
+export (rhiza-task#19), and `mkdocstrings[python]` is the default for `mkdocs-extra-packages`,
+which this repo's `pyproject.toml` now merely restates.
 
 ### Dependency Management
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 #
 # RHIZA_TASK is the entire version contract. Bumping it is the migration that used to be
 # `/rhiza:update` re-syncing eleven .mk files and reconciling whatever had been shadowed.
-RHIZA_TASK ?= rhiza-task@0.3.0
+RHIZA_TASK ?= rhiza-task@0.3.1
 
 # The one thing the shim cannot delegate to the CLI: uv itself, because uv is what runs
 # the CLI. `bootstrap.mk` had an `install-uv` target for exactly this, and the make layer's
@@ -20,28 +20,24 @@ RHIZA_TASK ?= rhiza-task@0.3.0
 # that only ran `uvx` would turn a required status check red on the day a repo migrated.
 #
 # So the bootstrap survives, minus the parts the CLI took over: no `bin/uv`, no clean-up,
-# just the one binary needed to reach the pin above.
+# just the one binary needed to reach the pin above -- and the PATH export, because
+# reaching the CLI is not the same as letting it run. Every task body shells out to a bare
+# `uv` or `uvx` (`uv.py` resolves both with `shutil.which`, which reads the PATH it
+# inherits), so provisioning `./bin/uvx` and then not exporting `./bin` gets as far as the
+# first gate that shells out and dies with `FileNotFoundError: 'uvx'` -- after a bootstrap
+# that looked like it worked. `version`, `print` and `list` are pure-CLI and stay green,
+# which is how this reached a required status check: the `pre-commit` job runs `make fmt`
+# with no astral-sh/setup-uv step, and `Pre-commit hooks` is required in
+# .github/rulesets/main-branch-protection.json.
+#
+# Prepended, not appended: with `$(INSTALL_DIR)` last, a runner carrying an older uv
+# earlier on PATH resolves differently from a bare one, and `RHIZA_TASK` quietly stops
+# being the whole version contract the header above claims it is.
+#
+# This block was a mother-repo addition until 0.3.1 (Jebel-Quant/rhiza-task#19); the
+# shipped shim carries it now, so the two are one file again.
 INSTALL_DIR ?= $(abspath ./bin)
 UVX ?= $(shell command -v uvx 2>/dev/null || echo $(INSTALL_DIR)/uvx)
-
-# --- mother-repo addition: the PATH export the shim drops, which it must not.
-#
-# The shipped shim says "no PATH export" and reaches the CLI by absolute path, which is
-# enough to *start* it and not enough to let it work. rhiza-task's task bodies shell out to
-# bare `uv` and `uvx` (`uv.py`'s `uv_run`/`uvx` helpers), so on a runner with no uv the shim
-# provisions ./bin/uvx, invokes it, and then the CLI dies with
-#
-#   FileNotFoundError: [Errno 2] No such file or directory: 'uvx'
-#
-# which is what turned the required `Pre-commit hooks` check red on the first push of this
-# migration: that job runs `make fmt` with no astral-sh/setup-uv step. `bootstrap.mk`
-# exported PATH for exactly this reason.
-#
-# Prepended rather than appended, so the bootstrapped binary is the one every gate uses --
-# otherwise a runner with an older uv earlier on PATH would resolve differently from a bare
-# one, and the pin above would stop being the whole version contract.
-#
-# Reported upstream as Jebel-Quant/rhiza-task#19; remove when the shipped shim carries it.
 export PATH := $(INSTALL_DIR):$(PATH)
 
 .DEFAULT_GOAL := help
@@ -174,21 +170,26 @@ gitlab-docker-test: install $(UV) ## run the Docker-backed GitLab job test again
 	@printf "\033[36m[INFO] Running the Docker-backed GitLab job test\033[0m\n"
 	@RHIZA_GITLAB_DOCKER=1 $(UV) run pytest tests/bundles/test_gitlab_ci.py -m gitlab_exec -v
 
-# `rhiza-test` is wrapped rather than delegated, for one reason the CLI cannot yet cover.
+# `rhiza-test` is wrapped rather than delegated. As of 0.3.1 the wrapper no longer *fixes*
+# anything; it is what makes the fix assertable here.
 #
 # pytest-rhiza's `test_docstrings` takes its scope from the RHIZA_DOCTEST_FOLDERS
 # environment variable, falling back to SOURCE_FOLDER in `.rhiza/.env` and then to `src`.
-# `quality.mk` used to export it from DOCSTRING_FOLDERS; rhiza-task does not, and it cannot
-# read `[tool.rhiza-task] source-folder` either. So on a bare delegation the check reported
+# `quality.mk` used to export it from DOCSTRING_FOLDERS; rhiza-task 0.3.0 did not, so on a
+# bare delegation the check reported
 #
 #   SKIPPED  No doctest folder found (looked for: src)
 #
 # and the gate still said `ok rhiza-test` — #1517 exactly: this repo's only doctest examples
-# unchecked, silently, behind a green gate. `.rhiza/.env` cannot carry it because that file
-# is gitignored, so CI would never see it.
+# unchecked, silently, behind a green gate. `.rhiza/.env` cannot carry the value because that
+# file is gitignored, so CI would never see it.
 #
-# Remove this wrapper once rhiza-task passes source_folder through to the check
-# (Jebel-Quant/rhiza-task#18). tests/utils/test_gate_scope.py fails if the skip returns.
+# rhiza-task 0.3.1 passes `source_folder` through as that variable itself
+# (Jebel-Quant/rhiza-task#18), so this recipe now exports the value the CLI would export
+# anyway — same folder, from the same setting. It stays because it is where the property can
+# be checked cheaply: tests/utils/test_gate_scope.py reads the expanded variable out of a
+# `make -n`, needing no network, no lockfile and no tags, and fails if the export goes. A
+# bare delegation moves the property inside the pin, where only a real run reveals it.
 rhiza-test: $(UVX) ## run the rhiza repository checks, with this repo's doctest scope
 	@RHIZA_DOCTEST_FOLDERS="$(shell $(UVX) $(RHIZA_TASK) print source_folder)" \
 		$(UVX) $(RHIZA_TASK) rhiza-test

--- a/bundles/gitlab-marimo/.gitlab/workflows/rhiza_marimo.yml
+++ b/bundles/gitlab-marimo/.gitlab/workflows/rhiza_marimo.yml
@@ -37,7 +37,7 @@ marimo:notebooks:
       #
       # The version is pinned rather than read from RHIZA_TASK: this pipeline cannot see a
       # consumer's Makefile, and a value a job depends on must not move under it.
-      NOTEBOOK_DIR=$(uvx rhiza-task@0.2.0 print marimo_folder 2>/dev/null || echo "marimo")
+      NOTEBOOK_DIR=$(uvx rhiza-task@0.3.1 print marimo_folder 2>/dev/null || echo "marimo")
       echo "Searching notebooks in: $NOTEBOOK_DIR"
 
       if [ ! -d "$NOTEBOOK_DIR" ]; then

--- a/bundles/gitlab-tests/.gitlab/workflows/rhiza_ci.yml
+++ b/bundles/gitlab-tests/.gitlab/workflows/rhiza_ci.yml
@@ -16,7 +16,7 @@
 # Calling the CLI directly drops the dependency on a front door rhiza no longer ships.
 
 variables:
-  RHIZA_TASK: "rhiza-task@0.3.0"
+  RHIZA_TASK: "rhiza-task@0.3.1"
 
 ci:test:
   # CI budget: ≤20 min (test matrix execution). Last measured: 2026-05-28.

--- a/bundles/gitlab/.gitlab/workflows/rhiza_quality.yml
+++ b/bundles/gitlab/.gitlab/workflows/rhiza_quality.yml
@@ -18,7 +18,7 @@
 # Calling the CLI directly drops the dependency on a front door rhiza no longer ships.
 
 variables:
-  RHIZA_TASK: "rhiza-task@0.3.0"
+  RHIZA_TASK: "rhiza-task@0.3.1"
 
 quality:deptry:
   stage: test

--- a/bundles/gitlab/.gitlab/workflows/rhiza_weekly.yml
+++ b/bundles/gitlab/.gitlab/workflows/rhiza_weekly.yml
@@ -19,7 +19,7 @@
 # Calling the CLI directly drops the dependency on a front door rhiza no longer ships.
 
 variables:
-  RHIZA_TASK: "rhiza-task@0.3.0"
+  RHIZA_TASK: "rhiza-task@0.3.1"
 
 weekly:semgrep:
   stage: test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,10 +176,17 @@ pytest-rhiza = "pytest-rhiza @ git+https://github.com/Jebel-Quant/pytest-rhiza@v
 
 # Restores this repo's own book override, which the migration to the shim dropped. The old root
 # Makefile carried `MKDOCS_EXTRA_PACKAGES = --with 'mkdocstrings[python]'` above the include, and
-# replacing that file with the shim lost it silently: `mkdocs_extra_packages` defaults to empty,
+# replacing that file with the shim lost it silently: `mkdocs_extra_packages` defaulted to empty,
 # so `make book` built the site without the plugin that renders the API reference. Nothing fails
 # -- the pages just come out missing their generated content, which is the worst shape for a
 # regression to have.
+#
+# rhiza-task 0.3.1 made `mkdocstrings[python]` the *default*, for the same reason on a wider
+# scale: the `book` bundle ships `docs/mkdocs-base.yml` with the plugin enabled, so every
+# consumer inherited a config zensical refused to build. This line is therefore no longer a
+# fix -- it now states explicitly what the pin already resolves to, which is worth one line
+# here because tests/integration/test_docs_targets.py asserts the generated API pages exist
+# and this is the setting that names why.
 #
 # Bare specs, not flags: the CLI passes these as `withs=`, adding `--with` itself.
 mkdocs-extra-packages = ["mkdocstrings[python]"]

--- a/tests/api/test_makefile_targets.py
+++ b/tests/api/test_makefile_targets.py
@@ -80,10 +80,12 @@ class TestMakefileRootFixture:
     def test_makefile_puts_the_bootstrapped_uv_on_path(self, root: Path) -> None:
         """The shim must export PATH, or every gate fails on a runner without uv.
 
-        The shipped shim deliberately omits this ("no PATH export") and reaches the CLI by
-        absolute path. That is enough to *start* it and not enough to let it work:
+        The shim through 0.3.0 deliberately omitted this ("no PATH export") and reached the
+        CLI by absolute path. That is enough to *start* it and not enough to let it work:
         rhiza-task's task bodies shell out to bare ``uv``/``uvx``, so the first gate dies
-        with ``FileNotFoundError: 'uvx'``.
+        with ``FileNotFoundError: 'uvx'``. 0.3.1 ships the export, so this is no longer a
+        mother-repo addition -- but it is still the line whose loss makes the branch
+        unmergeable, which is what this test exists to catch, whoever owns it.
 
         Pinned because it is load-bearing for a *required* check. The ``pre-commit`` job runs
         ``make fmt`` with no ``astral-sh/setup-uv`` step, and ``Pre-commit hooks`` is required

--- a/tests/utils/test_gate_scope.py
+++ b/tests/utils/test_gate_scope.py
@@ -177,8 +177,8 @@ def test_rhiza_test_carries_the_docstring_scope_to_the_doctest_check() -> None:
     The sharpest guard in this file, because the property it pins broke the moment this repo
     moved to the shim. pytest-rhiza's ``test_docstrings`` reads its scope from that
     environment variable, falling back to ``SOURCE_FOLDER`` in ``.rhiza/.env`` and then to
-    ``src``. ``quality.mk`` exported it from ``DOCSTRING_FOLDERS``; rhiza-task does not, and
-    cannot read ``[tool.rhiza-task] source-folder`` either -- so the check reported
+    ``src``. ``quality.mk`` exported it from ``DOCSTRING_FOLDERS``; rhiza-task 0.3.0 did not
+    -- so the check reported
 
         SKIPPED  No doctest folder found (looked for: src)
 
@@ -186,6 +186,13 @@ def test_rhiza_test_carries_the_docstring_scope_to_the_doctest_check() -> None:
     doctest examples unchecked, silently, behind a green gate. ``.rhiza/.env`` cannot carry
     the value because that file is gitignored, so CI would never see it -- hence the wrapper
     in the root Makefile (Jebel-Quant/rhiza-task#18), and hence this test.
+
+    **rhiza-task 0.3.1 passes the scope through itself**, so the wrapper no longer supplies
+    something absent; it supplies something *observable*. The upstream fix lives inside the
+    pin, where only a real run reveals whether it is still there, and a real run is what the
+    note below rules out. Reading the export out of a dry run keeps a bump that regressed it
+    -- upstream or here -- from landing green. If the wrapper is ever dropped in favour of a
+    bare delegation, this test must be replaced rather than deleted.
 
     **Asserted from a dry run, deliberately.** An earlier version ran the gate for real and
     checked that no rhiza check reported SKIPPED. That was stricter and wrong twice over: it


### PR DESCRIPTION
[rhiza-task 0.3.1](https://github.com/Jebel-Quant/rhiza-task/releases/tag/v0.3.1) fixes three
things this repo had worked around locally, so the bump is mostly a subtraction.

## What 0.3.1 took over

| workaround here | now | this PR |
| --- | --- | --- |
| the `PATH` export the shim dropped (rhiza-task#19) | shipped by the shim | block removed; the root Makefile is the generated shim again in that region |
| `rhiza-test` exporting `RHIZA_DOCTEST_FOLDERS` (rhiza-task#18) | the `rhiza-test` task passes `source_folder` itself | **wrapper kept** — see below |
| `mkdocs-extra-packages = ["mkdocstrings[python]"]` | the CLI's default | setting kept, comment corrected: it restates the default rather than supplying it |

Verified both fixes against the real CLI before touching anything: the 0.3.1 shim
carries `export PATH := $(INSTALL_DIR):$(PATH)`, and a bare `uvx rhiza-task@0.3.1
rhiza-test` runs 34 checks with no `SKIPPED  No doctest folder found (looked for: src)`
— where a bare pytest of the same check still skips, so it is the CLI supplying the scope.

## Why the `rhiza-test` wrapper stays

It no longer *fixes* anything; it is what makes the fix assertable here. The recipe now
exports the value the CLI would export anyway — same folder, same setting — and that
export is the one form of the property `tests/utils/test_gate_scope.py` can read out of a
`make -n`: no network, no lockfile, no tags. (Its docstring records why a real run was
rejected: `install`'s `uv lock --check` legitimately fails the `lowest-direct` job, and
`test_release_tags` skips on a tagless checkout.) A bare delegation moves #1517's failure
mode inside the pin, where only a real run reveals a regression. Dropping the wrapper is a
reasonable follow-up, but it has to *replace* that test rather than delete it.

## The three stale side-pins

`uvx rhiza-task@0.2.0` appeared at three call sites that deliberately pin independently of
`RHIZA_TASK` — the CI OS matrix and both `print marimo_folder` lookups — because a value a
job depends on must not move under a workflow called at a tag (#1546). That reasoning is
about *independence*, not about `0.2.0`; leaving them there made CI resolve two rhiza-task
builds for no benefit. All three move to 0.3.1.

## Verification

`make all` green — fmt, install, deps, test, docs-coverage, security, license, typecheck,
rhiza-test — with 1299 tests passing, plus `make book` (which exercises the changed
mkdocstrings default and still emits the API reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
