### PR TITLE
chore: release v1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com),
 and entries are generated from [Conventional Commits](https://www.conventionalcommits.org).
 
+## [1.4.2] - 2026-08-19
+
+### Maintenance
+- Bump rhiza-task to 0.3.1, retiring two mother-repo workarounds (#1564)
+
 ## [1.4.1] - 2026-08-19
 
 ### Bug Fixes

--- a/bundles/github-book/.github/workflows/rhiza_book.yml
+++ b/bundles/github-book/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.4.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.4.2
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml
+++ b/bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   devcontainer:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v1.4.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v1.4.2
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-docker/.github/workflows/rhiza_docker.yml
+++ b/bundles/github-docker/.github/workflows/rhiza_docker.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   docker:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v1.4.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v1.4.2
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-marimo/.github/workflows/rhiza_marimo.yml
+++ b/bundles/github-marimo/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.4.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.4.2
     secrets: inherit

--- a/bundles/github-paper/.github/workflows/rhiza_paper.yml
+++ b/bundles/github-paper/.github/workflows/rhiza_paper.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   paper:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v1.4.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v1.4.2
     secrets: inherit
     permissions:
       contents: write

--- a/bundles/github-quality-review/.github/workflows/rhiza_quality_review.yml
+++ b/bundles/github-quality-review/.github/workflows/rhiza_quality_review.yml
@@ -34,5 +34,5 @@ on:
 
 jobs:
   quality-review:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_quality_review.yml@v1.4.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_quality_review.yml@v1.4.2
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_benchmark.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.4.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.4.2
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_ci.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.4.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.4.2
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_codeql.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.4.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.4.2
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/bundles/github-tests/.github/workflows/rhiza_mutation.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_mutation.yml
@@ -42,7 +42,7 @@ jobs:
     # this repo sets the `MUTATION_ENABLED` variable to 'true'. Gating here in
     # the caller keeps it optional regardless of the pinned reusable workflow.
     if: ${{ vars.MUTATION_ENABLED == 'true' }}
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v1.4.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v1.4.2
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github/.github/workflows/rhiza_fuzzing.yml
+++ b/bundles/github/.github/workflows/rhiza_fuzzing.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   fuzzing:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v1.4.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v1.4.2
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github/.github/workflows/rhiza_scorecard.yml
+++ b/bundles/github/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.4.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.4.2
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/bundles/github/.github/workflows/rhiza_weekly.yml
+++ b/bundles/github/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.4.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.4.2
     secrets: inherit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rhiza"
-version = "1.4.1"
+version = "1.4.2"
 description = "Reusable configuration templates for modern Python projects"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -70,7 +70,7 @@ Issues = "https://github.com/jebel-quant/rhiza/issues"
 # python-core bundle no longer ships a `.rhiza/.cfg.toml` copy of this block; the
 # Rust and Go layers ship a root `.bumpversion.toml` instead, since neither
 # language has a discoverable file of its own.
-current_version = "1.4.1"
+current_version = "1.4.2"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:[-]?(?P<release>[a-z]+)[\\.]?(?P<pre_n>\\d+))?(?:\\+build\\.(?P<build_n>\\d+))?"
 serialize = [
     "{major}.{minor}.{patch}-{release}.{pre_n}+build.{build_n}",

--- a/uv.lock
+++ b/uv.lock
@@ -863,7 +863,7 @@ wheels = [
 
 [[package]]
 name = "rhiza"
-version = "1.4.1"
+version = "1.4.2"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Release **v1.4.1 → v1.4.2**, a patch: the single unreleased commit is `chore: bump
rhiza-task to 0.3.1, retiring two mother-repo workarounds` (#1564).

## What the bump touched

`bump-my-version` rewrote only the locations `[tool.bumpversion]` declares — nothing
was hand-edited:

- `pyproject.toml` — `[project].version` and `current_version` (2 lines)
- **13 bundle CI stubs** under `bundles/**/.github/workflows/*.yml` — the
  self-referencing `jebel-quant/rhiza/.github/workflows/…@vX.Y.Z` pins, which must move
  with the release or a synced consumer would call the *previous* version's reusable
  workflows
- `uv.lock` — the `rhiza` entry's own version, regenerated by the `uv-lock` hook rather
  than edited (only that one line changed)

The live `.github/workflows/*` here are untouched: they run top-level on
`push`/`pull_request` and hold no cross-repo `uses:` at a rhiza tag, so this PR's checks
resolve normally.

## Changelog

One section prepended with `git-cliff --unreleased --tag v1.4.2 --prepend`; the diff is
five added lines and no edit to any earlier section:

```
## [1.4.2] - 2026-08-19

### Maintenance
- Bump rhiza-task to 0.3.1, retiring two mother-repo workarounds (#1564)
```

## Merging this does not publish the release

There is **no tag yet**, deliberately. A squash-merge replaces this branch's commit, so a
tag cut now would name a SHA that never lands on `main`. The tag is created afterwards,
on the merged commit, by a second `/rhiza:release` run — which re-runs the
strictly-increases guard against the merged history before creating anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
