### PR TITLE
chore: bump pytest-rhiza to 0.3.0, and revive the pin's Renovate manager

### DIFF
--- a/bundles/renovate/renovate.json
+++ b/bundles/renovate/renovate.json
@@ -55,12 +55,12 @@
     },
     {
       "customType": "regex",
-      "description": "The pytest-rhiza pin in core's quality.mk. `make rhiza-test` installs the rhiza repository checks at an exact version so the checks and the template move as one number (#1540); no other manager parses a Makefile, so without this the pin only ages.",
+      "description": "The pytest-rhiza pin in `[tool.rhiza-task]`. `make rhiza-test` installs the rhiza repository checks at an exact version so the checks and the template move as one number (#1540). No built-in manager reads that table -- pep621 sees only the dependency arrays -- so without this the pin only ages. It targeted `RHIZA_CHECKS_VERSION` in `.rhiza/make.d/quality.mk` until #1579, and went silently dead when that file retired -- #1556 for this repo, #1557 for the bundle: a manager whose file pattern matches nothing reports no error, it just stops finding updates.",
       "managerFilePatterns": [
-        "/(^|/)\\.rhiza/make\\.d/quality\\.mk$/"
+        "/(^|/)pyproject\\.toml$/"
       ],
       "matchStrings": [
-        "RHIZA_CHECKS_VERSION\\s*\\?=\\s*(?<currentValue>\\S+)"
+        "pytest-rhiza\\s*=\\s*\"pytest-rhiza==(?<currentValue>[^\"]+)\""
       ],
       "depNameTemplate": "pytest-rhiza",
       "datasourceTemplate": "pypi"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,15 +164,20 @@ layers = ["python"]
 # while broken.
 typechecker = "both"
 
-# Preserves the checks version this repo was already running. `quality.mk` had
-# `RHIZA_CHECKS_VERSION ?= 0.2.1`; rhiza-task's default is v0.2.0, so a bare migration would
-# have *downgraded* the conformance checks — which is exactly the drift the pin exists to
-# prevent, since its whole purpose is that a repo runs the assertions of a known release.
+# Pins the conformance checks, which is the entire purpose of the setting: a repo runs the
+# assertions of a known release, not of whatever the checks repo's HEAD says today. The
+# override outlives the bump — rhiza-task 0.3.1 still defaults to v0.2.0, so deleting this
+# line would *downgrade* the checks by three releases rather than track the newest.
 #
-# Deliberately not v0.2.2, which is newer: bumping the checks is an upgrade decision with its
-# own failure modes, and folding it into a migration PR would confuse "this behaves as before"
-# with "this behaves differently but still passes".
-pytest-rhiza = "pytest-rhiza @ git+https://github.com/Jebel-Quant/pytest-rhiza@v0.2.1"
+# A PyPI version spec, not a git URL. The git form was inherited from rhiza-task's default,
+# and it costs a clone on every `rhiza-test` run for no added precision — a tag is as mutable
+# as a version is not. It also put the pin out of reach of the one thing that would have
+# noticed it ageing: `renovate.json`'s custom manager is a pypi datasource, and a git ref is
+# not a version it can compare.
+#
+# 0.3.0 collects the same five modules and the same 34 checks as 0.2.1 on this repo, so this
+# is a bump of the assertions' *implementation*, not of the check set.
+pytest-rhiza = "pytest-rhiza==0.3.0"
 
 # Restores this repo's own book override, which the migration to the shim dropped. The old root
 # Makefile carried `MKDOCS_EXTRA_PACKAGES = --with 'mkdocstrings[python]'` above the include, and

--- a/renovate.json
+++ b/renovate.json
@@ -54,12 +54,12 @@
     },
     {
       "customType": "regex",
-      "description": "The pytest-rhiza pin in core's quality.mk. `make rhiza-test` installs the rhiza repository checks at an exact version so the checks and the template move as one number (#1540); no other manager parses a Makefile, so without this the pin only ages.",
+      "description": "The pytest-rhiza pin in `[tool.rhiza-task]`. `make rhiza-test` installs the rhiza repository checks at an exact version so the checks and the template move as one number (#1540). No built-in manager reads that table -- pep621 sees only the dependency arrays -- so without this the pin only ages. It targeted `RHIZA_CHECKS_VERSION` in `.rhiza/make.d/quality.mk` until #1579, and went silently dead when that file retired -- #1556 for this repo, #1557 for the bundle: a manager whose file pattern matches nothing reports no error, it just stops finding updates.",
       "managerFilePatterns": [
-        "/(^|/)\\.rhiza/make\\.d/quality\\.mk$/"
+        "/(^|/)pyproject\\.toml$/"
       ],
       "matchStrings": [
-        "RHIZA_CHECKS_VERSION\\s*\\?=\\s*(?<currentValue>\\S+)"
+        "pytest-rhiza\\s*=\\s*\"pytest-rhiza==(?<currentValue>[^\"]+)\""
       ],
       "depNameTemplate": "pytest-rhiza",
       "datasourceTemplate": "pypi"

--- a/tests/bundles/test_bundle_content_validity.py
+++ b/tests/bundles/test_bundle_content_validity.py
@@ -7,7 +7,8 @@ than sweeping the whole tree:
 - every bundle is described in ``template-bundles.yml`` and documented
 - Makefile fragments expose at least one documented target (``## help`` comment)
 - legal files have real content
-- ``renovate.json`` carries the required schema declaration
+- ``renovate.json`` carries the required schema declaration, and its custom manager for
+  the pytest-rhiza pin still matches where that pin lives
 - each language layer's ``.pre-commit-config.yaml`` names the config both prek entry
   points read (see the prek note in CLAUDE.md)
 - the devcontainer definition is valid and self-consistent
@@ -193,6 +194,46 @@ class TestRenovateBundleContent:
         required = {"pep621", "github-actions", "gitlabci"}
         missing = required - set(enabled)
         assert not missing, f"renovate.json 'enabledManagers' is missing required managers: {sorted(missing)}"
+
+    def test_pytest_rhiza_custom_manager_finds_this_repos_pin(self, renovate_json: dict, root: Path) -> None:
+        """The custom manager for the pytest-rhiza pin must actually match where the pin lives.
+
+        A Renovate custom manager whose ``managerFilePatterns`` match no file is not an
+        error -- it finds no dependency and reports nothing, so the pin it exists to bump
+        simply stops being bumped. That is how this one died: it targeted
+        ``RHIZA_CHECKS_VERSION`` in ``.rhiza/make.d/quality.mk``; that file retired with the
+        make layer (#1556 here, #1557 in the bundle) and the pin then sat at 0.2.1 through
+        two releases of pytest-rhiza (#1579).
+
+        So the assertion is liveness against this repo's own tree, which is where dogfooding
+        earns its keep: the pin lives in ``pyproject.toml``'s ``[tool.rhiza-task]`` table, a
+        file every Python consumer has too. Its sibling manager -- the template.yml/ref pair
+        -- gets no such test on purpose: that file exists only in a *consumer*, never here,
+        so there is nothing to match it against.
+        """
+        managers = renovate_json.get("customManagers", [])
+        assert managers, "renovate.json should declare customManagers"
+
+        pin = [m for m in managers if m.get("depNameTemplate") == "pytest-rhiza"]
+        assert len(pin) == 1, "expected exactly one customManager for the pytest-rhiza pin"
+        manager = pin[0]
+
+        assert manager.get("datasourceTemplate") == "pypi", (
+            "the pin is a PyPI version spec, so the datasource must be pypi -- a git ref "
+            "is not a version Renovate can compare"
+        )
+
+        # Renovate wraps a regex file pattern in slashes and uses JS named groups.
+        patterns = [p.strip("/") for p in manager["managerFilePatterns"]]
+        assert any(re.search(p, "pyproject.toml") for p in patterns), (
+            f"no managerFilePattern in {patterns} matches pyproject.toml, where the pin lives"
+        )
+
+        pyproject = (root / "pyproject.toml").read_text(encoding="utf-8")
+        for match_string in manager["matchStrings"]:
+            found = re.search(match_string.replace("(?<", "(?P<"), pyproject)
+            assert found, f"matchString {match_string!r} finds nothing in pyproject.toml"
+            assert found.group("currentValue"), "matchString must capture a currentValue"
 
 
 def _layer_precommit(root: Path, layer: str) -> dict:


### PR DESCRIPTION
## What

Two coupled changes to the conformance-check pin in `[tool.rhiza-task]`.

**The bump.** `pytest-rhiza` was pinned at `v0.2.1` while 0.2.2 and 0.3.0 shipped. The pin is now a PyPI version spec:

```diff
-pytest-rhiza = "pytest-rhiza @ git+https://github.com/Jebel-Quant/pytest-rhiza@v0.2.1"
+pytest-rhiza = "pytest-rhiza==0.3.0"
```

The git URL was inherited from rhiza-task's default, from when the package was unpublished. It cost a clone on every `rhiza-test` run for no added precision — a tag is as mutable as a version is not — and it put the pin out of reach of a `pypi` datasource. The override itself is still load-bearing: rhiza-task 0.3.1 defaults to `v0.2.0`, so deleting the line would *downgrade* by three releases.

**The manager that should have caught it.** `renovate.json`'s custom manager for this pin targeted `RHIZA_CHECKS_VERSION` in `.rhiza/make.d/quality.mk` — a file that retired with the make layer, #1556 for this repo and #1557 for the bundle. A custom manager whose `managerFilePatterns` match nothing is not an error: it finds no dependency, reports nothing, and the pin it exists to bump simply stops being bumped. That is why two releases went by unnoticed. It targets `pyproject.toml` now, in the bundle and in this repo's override, with the `pypi` datasource the version spec makes usable.

## Behaviour

Not a change to the check set. Same five modules, same 34 checks, green either way:

| pin | result |
| --- | --- |
| `v0.2.1` (before) | 34 collected, 34 passed |
| `0.3.0` (after) | 34 collected, 34 passed |

What 0.3.0 moves is the assertions' implementation — `test_pyproject` letting the declared version lead the newest tag, `test_docstrings` resolving the folder under test rather than a same-named installed package. Neither changes an outcome here.

## The guard

`test_pytest_rhiza_custom_manager_finds_this_repos_pin` holds the manager to the pin it exists to bump: the file pattern must match `pyproject.toml`, the datasource must be `pypi`, and the matchString must capture a `currentValue` out of the real file. Reverting the file pattern to `quality.mk` fails it.

Its sibling manager — the `template.yml`/`ref` pair — gets no such test on purpose, and the docstring says so: that file exists only in a *consumer*, never in the mother repo, so there is nothing here to match it against.

## Gates

`make test` (1444 passed, 100% on `utils`), `make rhiza-test` (34 passed), `make fmt` — including the `Validate Renovate Config` hook, which schema-checks the rewritten manager.

## Not in scope

`RHIZA_TASK ?= rhiza-task@0.3.1` in `bundles/core/Makefile` has no Renovate manager at all, so it ages the same way by default. Worth its own change: the file is template-owned, so a manager updating it downstream would fight the sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
