### PR TITLE
chore: bump rhiza-task to 1.1.0, and de-fragilise the tests that read it

### DIFF
--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -25,7 +25,7 @@ permissions:
 # from a consumer's `RHIZA_TASK`, which this workflow cannot see: it tracks the tag the
 # workflow is called at.
 env:
-  RHIZA_TASK: rhiza-task@0.3.1
+  RHIZA_TASK: rhiza-task@1.1.0
 
 on:
   push:

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -41,7 +41,7 @@ permissions:
 # from a consumer's `RHIZA_TASK`, which this workflow cannot see: it tracks the tag the
 # workflow is called at.
 env:
-  RHIZA_TASK: rhiza-task@0.3.1
+  RHIZA_TASK: rhiza-task@1.1.0
 
 jobs:
   # Build the book on every commit (any branch). This proves the documentation

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -39,7 +39,7 @@ permissions:
 # see -- and should not: the gates a build runs must not move under it. It tracks the tag
 # this workflow is called at, the same rule the OS-matrix step below states for its pin.
 env:
-  RHIZA_TASK: rhiza-task@0.3.1
+  RHIZA_TASK: rhiza-task@1.1.0
 
 on:
   push:
@@ -130,7 +130,7 @@ jobs:
             ${{ github.repository == 'jebel-quant/rhiza'
                 && '["ubuntu-latest","macos-latest"]' || '' }}
         run: |
-          OS_MATRIX=$(uvx rhiza-task@0.3.1 ci-os-matrix)
+          OS_MATRIX=$(uvx rhiza-task@1.1.0 ci-os-matrix)
           echo "list=$OS_MATRIX" >> "$GITHUB_OUTPUT"
 
       - name: Debug OS matrix

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -82,7 +82,7 @@ jobs:
           #
           # Pinned for the reason the OS matrix is pinned (#1546): the folder a build
           # discovers notebooks in must not move under a workflow called at a tag.
-          NOTEBOOK_DIR=$(uvx rhiza-task@0.3.1 print marimo_folder)
+          NOTEBOOK_DIR=$(uvx rhiza-task@1.1.0 print marimo_folder)
 
           echo "Searching notebooks in: $NOTEBOOK_DIR"
           # Check if directory exists

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -27,7 +27,7 @@ permissions:
 # CLI rather than `core`'s `Makefile` so they do not depend on a front door this workflow
 # neither ships nor can verify.
 env:
-  RHIZA_TASK: rhiza-task@0.3.1
+  RHIZA_TASK: rhiza-task@1.1.0
 
 on:
   #push:

--- a/bundles/core/Makefile
+++ b/bundles/core/Makefile
@@ -18,7 +18,7 @@
 # Repo-specific *tasks* go in a `rhiza_task.tasks` entry point, repo-specific *targets* in
 # `local.mk`, which core deliberately does not ignore. Nothing goes below the shim: this
 # file is synced, so the next `/rhiza:update` overwrites whatever was appended to it.
-RHIZA_TASK ?= rhiza-task@0.3.1
+RHIZA_TASK ?= rhiza-task@1.1.0
 
 # uv cannot be delegated, because uv is what runs the CLI. Prepended so a machine carrying
 # an older uv still resolves the pin, exported because task bodies shell out to bare `uv`.

--- a/bundles/gitlab-marimo/.gitlab/workflows/rhiza_marimo.yml
+++ b/bundles/gitlab-marimo/.gitlab/workflows/rhiza_marimo.yml
@@ -37,7 +37,7 @@ marimo:notebooks:
       #
       # The version is pinned rather than read from RHIZA_TASK: this pipeline cannot see a
       # consumer's Makefile, and a value a job depends on must not move under it.
-      NOTEBOOK_DIR=$(uvx rhiza-task@0.3.1 print marimo_folder 2>/dev/null || echo "marimo")
+      NOTEBOOK_DIR=$(uvx rhiza-task@1.1.0 print marimo_folder 2>/dev/null || echo "marimo")
       echo "Searching notebooks in: $NOTEBOOK_DIR"
 
       if [ ! -d "$NOTEBOOK_DIR" ]; then

--- a/bundles/gitlab-tests/.gitlab/workflows/rhiza_ci.yml
+++ b/bundles/gitlab-tests/.gitlab/workflows/rhiza_ci.yml
@@ -16,7 +16,7 @@
 # on a front door it neither ships nor can verify.
 
 variables:
-  RHIZA_TASK: "rhiza-task@0.3.1"
+  RHIZA_TASK: "rhiza-task@1.1.0"
 
 ci:test:
   # CI budget: ≤20 min (test matrix execution). Last measured: 2026-05-28.

--- a/bundles/gitlab/.gitlab/workflows/rhiza_quality.yml
+++ b/bundles/gitlab/.gitlab/workflows/rhiza_quality.yml
@@ -18,7 +18,7 @@
 # on a front door it neither ships nor can verify.
 
 variables:
-  RHIZA_TASK: "rhiza-task@0.3.1"
+  RHIZA_TASK: "rhiza-task@1.1.0"
 
 quality:deptry:
   stage: test

--- a/bundles/gitlab/.gitlab/workflows/rhiza_weekly.yml
+++ b/bundles/gitlab/.gitlab/workflows/rhiza_weekly.yml
@@ -19,7 +19,7 @@
 # on a front door it neither ships nor can verify.
 
 variables:
-  RHIZA_TASK: "rhiza-task@0.3.1"
+  RHIZA_TASK: "rhiza-task@1.1.0"
 
 weekly:semgrep:
   stage: test

--- a/docs/reference/GLOSSARY.md
+++ b/docs/reference/GLOSSARY.md
@@ -133,10 +133,12 @@ The pinned CLI that provides Rhiza's developer tasks — `install`, `test`, `typ
 `.rhiza/rhiza.mk` and the sixteen fragments in `.rhiza/make.d/`, both of which are gone.
 
 ### `Makefile` (the shim)
-A repo-owned file, generated once with `uvx rhiza-task shim > Makefile`. It pins `RHIZA_TASK`,
-bootstraps `uv` on a runner that has none, and forwards every unmatched target to the CLI with a
-`%:` catch-all. Because it is repo-owned rather than synced, anything a project adds to it
-survives a template update.
+A template-owned file, shipped by the `core` bundle. It pins `RHIZA_TASK`, bootstraps `uv` on a
+runner that has none, and forwards every unmatched target to the CLI with a `%:` catch-all.
+Because it is synced, the pin travels with the template — a repo synced at a tag runs that tag's
+gates — and anything appended to the file is overwritten by the next update. Project-specific
+targets go in `local.mk`, which the shim `-include`s. It was repo-owned for one release, printed
+by `uvx rhiza-task shim`; that subcommand was removed in rhiza-task 1.0.0.
 
 ### `.rhiza/template.yml`
 Configuration file defining which files to sync from upstream, include/exclude patterns, and sync behavior.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,7 +166,7 @@ typechecker = "both"
 
 # Pins the conformance checks, which is the entire purpose of the setting: a repo runs the
 # assertions of a known release, not of whatever the checks repo's HEAD says today. The
-# override outlives the bump — rhiza-task 0.3.1 still defaults to v0.2.0, so deleting this
+# override outlives the bump — rhiza-task 1.1.0 still defaults to v0.2.0, so deleting this
 # line would *downgrade* the checks by three releases rather than track the newest.
 #
 # A PyPI version spec, not a git URL. The git form was inherited from rhiza-task's default,

--- a/tests/api/test_ci_workflow.py
+++ b/tests/api/test_ci_workflow.py
@@ -97,7 +97,9 @@ def _gates_named_by_all(root: Path) -> list[str]:
     """Return the gate names ``all`` depends on, from the rhiza-task registry.
 
     The registry is keyed ``layer:name`` and populated by the ``@task`` decorator, so the
-    task modules have to be imported before it is read. Only this repo's layer is consulted:
+    task modules have to be imported before it is read -- via the CLI's own
+    :func:`rhiza_task.cli.load_tasks`, so the set follows the ``rhiza_task.tasks`` entry-point
+    group instead of a module list that ages here. Only this repo's layer is consulted:
     ``rust:all`` and ``go:all`` name a slightly different set, and asserting a Rust gate runs
     in a Python repo's CI would be nonsense.
 
@@ -111,8 +113,8 @@ def _gates_named_by_all(root: Path) -> list[str]:
     assert pin, "the root Makefile no longer pins RHIZA_TASK"
     name, _, version = pin.group(1).partition("@")
     script = (
-        "import importlib, json;"
-        "[importlib.import_module('rhiza_task.tasks.' + m) for m in ('python', 'quality', 'book', 'extras', 'doctor')];"
+        "import json;"
+        "from rhiza_task.cli import load_tasks; load_tasks();"
         "from rhiza_task.spec import REGISTRY;"
         "print(json.dumps(list(REGISTRY['python:all'].needs)))"
     )

--- a/tests/bundles/test_layer_contract.py
+++ b/tests/bundles/test_layer_contract.py
@@ -95,6 +95,10 @@ def _registry() -> dict[str, list[str]]:
 
     The task modules must be imported before the registry is read: the ``@task`` decorator
     populates it at import time, and ``rhiza_task.tasks`` does not pull in its submodules.
+    Loaded through the CLI's own :func:`rhiza_task.cli.load_tasks`, which walks the
+    ``rhiza_task.tasks`` entry-point group, rather than a module list written out here -- such
+    a list silently omits whatever the next release adds, and that is not a hypothetical: it
+    is how ``book``'s ``paper`` prerequisite went unseen when rhiza-task 1.1.0 added it.
 
     Returns:
         The registry, or an empty dict when the CLI cannot be reached.
@@ -105,9 +109,8 @@ def _registry() -> dict[str, list[str]]:
         return {}
     name, _, version = match.group(1).partition("@")
     script = (
-        "import importlib, json;"
-        "[importlib.import_module('rhiza_task.tasks.' + m)"
-        " for m in ('python', 'rust', 'go', 'quality', 'book', 'extras', 'doctor')];"
+        "import json;"
+        "from rhiza_task.cli import load_tasks; load_tasks();"
         "from rhiza_task.spec import REGISTRY;"
         "print(json.dumps({k: list(v.needs) for k, v in REGISTRY.items()}))"
     )

--- a/tests/docs/test_doc_consistency.py
+++ b/tests/docs/test_doc_consistency.py
@@ -428,6 +428,32 @@ _INVOCATION_SOURCES = (
 _CLAIM_GATE_EXEMPT = {"CHANGELOG.md"}
 
 
+# Dumps the pinned CLI's task modules as code with every docstring replaced by ``pass``, so the
+# scan below sees what the tasks *do* and not what their prose says about it. ``ast.unparse``
+# drops comments for free.
+_CLI_CODE_WITHOUT_PROSE = """
+import ast, pathlib, rhiza_task
+
+HOLDS_DOCSTRING = (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+
+
+def strip(tree):
+    for node in ast.walk(tree):
+        if not isinstance(node, HOLDS_DOCSTRING) or not node.body:
+            continue
+        first = node.body[0]
+        if isinstance(first, ast.Expr) and isinstance(first.value, ast.Constant) and isinstance(first.value.value, str):
+            node.body[0] = ast.Pass()
+    return ast.fix_missing_locations(tree)
+
+
+print("\\n".join(
+    ast.unparse(strip(ast.parse(p.read_text())))
+    for p in sorted(pathlib.Path(rhiza_task.__file__).parent.rglob("*.py"))
+))
+"""
+
+
 @functools.lru_cache(maxsize=1)
 def _cli_task_sources() -> str:
     """Return the concatenated source of the pinned CLI's task modules.
@@ -442,6 +468,14 @@ def _cli_task_sources() -> str:
     Read from the installed package rather than listed here, because this class's whole design is
     that the invoked set is derived: adding a tool to a task must re-permit its mentions in the
     same commit, with no list to update.
+
+    **Code only -- docstrings and comments are stripped**, because upstream prose is not an
+    invocation. rhiza-task 1.1.0 documents in ``tasks/python.py`` why pip-audit is deliberately
+    *not* wired up, citing this very module; a raw text scan read that explanation as evidence
+    that the tool runs. The damage was not the one red test: it also silently re-permitted every
+    document here to claim pip-audit runs, which is the #1506 regression this gate exists to
+    catch. A tool named in an argument list survives ``ast.unparse``; a tool named in a sentence
+    about it does not.
 
     Returns:
         The concatenated text, or an empty string if the CLI cannot be located.
@@ -461,8 +495,7 @@ def _cli_task_sources() -> str:
             requirement,
             "python",
             "-c",
-            "import pathlib, rhiza_task;"
-            "print('\\n'.join(p.read_text() for p in pathlib.Path(rhiza_task.__file__).parent.rglob('*.py')))",
+            _CLI_CODE_WITHOUT_PROSE,
         ],
         cwd=_ROOT,
         capture_output=True,

--- a/tests/integration/test_book_targets.py
+++ b/tests/integration/test_book_targets.py
@@ -61,12 +61,16 @@ def test_every_prerequisite_of_book_resolves() -> None:
     tasks are registered rather than because a fragment stubbed them. Asserted here because the
     property is the same one and its failure mode is identical — `book` dying on a name nothing
     provides.
+
+    Every task module is loaded, through the CLI's own `load_tasks`. Naming them by hand made
+    this test's own coverage depend on a list nobody re-derives: rhiza-task 1.1.0 gave `book` a
+    `paper` prerequisite, `paper` lives in a module the list did not mention, and the assertion
+    reported a missing task where the real gap was the fixture.
     """
     name, _, version = _pin().partition("@")
     script = (
-        "import importlib, json;"
-        "[importlib.import_module('rhiza_task.tasks.' + m)"
-        " for m in ('python', 'quality', 'book', 'extras', 'doctor')];"
+        "import json;"
+        "from rhiza_task.cli import load_tasks; load_tasks();"
         "from rhiza_task.spec import REGISTRY;"
         "print(json.dumps({k: list(v.needs) for k, v in REGISTRY.items()}))"
     )

--- a/tests/utils/test_gate_scope.py
+++ b/tests/utils/test_gate_scope.py
@@ -45,12 +45,20 @@ _BUNDLES = _ROOT / "bundles"
 # `paper` for a root `.tex`. Neither is named by `all` and neither reports success on an empty
 # folder: both skip with the folder in the reason, so a wrong value is visible rather than
 # silent. They are listed to acknowledge them, which is what this set is for.
+#
+# ``docs_folder`` arrived with rhiza-task 1.1.0 and scopes the new ``docs-examples`` gate,
+# which executes the fenced examples in the docs tree. This repo does not run it: `all` does
+# not name it, and the fences here are checked by tests/docs/test_doc_consistency.py instead.
+# Acknowledged rather than asserted for that reason -- if `docs-examples` is ever wired in,
+# the folder needs the same existence guard `source_folder` has above, because the gate skips
+# a missing tree rather than failing.
 _KNOWN_FOLDER_SETTINGS = {
     "source_folder",
     "tests_folder",
     "marimo_folder",
     "docker_folder",
     "paper_folder",
+    "docs_folder",
 }
 
 


### PR DESCRIPTION
The pin sat at `0.3.1` while upstream shipped `1.0.0` and `1.1.0` — because nothing watches it. `renovate.json` has a custom manager for the pytest-rhiza pin and none for this one, so `RHIZA_TASK` only ages. Eleven literals moved:

- `bundles/core/Makefile` — the pin itself, with the root copy following via its dogfood symlink
- five live `.github/workflows/` — `rhiza_ci.yml` (×2), `rhiza_book.yml`, `rhiza_weekly.yml`, `rhiza_benchmark.yml`, `rhiza_marimo.yml`, none of which can read a consumer's `RHIZA_TASK`
- four GitLab bundle stubs — `gitlab/rhiza_weekly.yml`, `gitlab/rhiza_quality.yml`, `gitlab-tests/rhiza_ci.yml`, `gitlab-marimo/rhiza_marimo.yml`

**No consumer loses a target.** No task retired across the two majors: `tests/api/test_bundle_cli_targets.py` asks the new pin for all eighteen and gets them. `1.0.0`'s breaking change was removing the `shim` command, which nothing here invokes — the front door has been template-owned since #1576. Three tasks arrived (`docs-examples`, `complexity`, `book-nav`); none is named by `all` and none is wired up here.

## Three tests failed, and the bump was not the fault in any of them

Each was a fragile derivation the bump merely exposed.

**A hand-written module list cannot see the next release.** `test_book_targets`, `test_layer_contract` and `test_ci_workflow` each imported `rhiza_task.tasks.<m>` from a list spelled out in the test. `1.1.0` gave `book` a `paper` prerequisite, `paper` lives in a module no list mentioned, and the assertion reported a missing task where the real gap was its own fixture. All three now call `rhiza_task.cli.load_tasks()`, which walks the `rhiza_task.tasks` entry-point group the way the CLI does — so the next release's modules arrive without an edit here.

**A docstring is not an invocation.** `TestToolClaims` derives which tools run by text-scanning the pinned CLI's source, docstrings included. `1.1.0` added a docstring in `tasks/python.py` explaining why pip-audit is deliberately *not* wired up — citing this very test — and the scan read that explanation as evidence the tool runs. The red test was the smaller half: it also silently re-permitted every document in this repo to claim pip-audit runs, which is the #1506 regression the gate exists to catch. The scan strips docstrings and comments through `ast.unparse` now, so a tool named in an argument list survives and a tool named in a sentence about it does not.

**`docs_folder` is new**, and scopes the `docs-examples` gate. Acknowledged in `_KNOWN_FOLDER_SETTINGS` rather than asserted, because nothing here runs that gate — with a note that wiring it in would need the existence guard `source_folder` has, since the gate skips a missing tree rather than failing.

## Two prose corrections the bump exposed

- `docs/reference/GLOSSARY.md` still called the `Makefile` repo-owned and told readers to generate it with `uvx rhiza-task shim > Makefile` — a command `1.0.0` deleted.
- `pyproject.toml`'s pytest-rhiza rationale named `0.3.1` as the version whose default is still `v0.2.0`. Verified: that is still true of `1.1.0`, so the claim is retargeted rather than dropped.

## Verification

`make all` is green — 1444 passed, 45 skipped (the opt-in e2e suite), and every gate reports `ok`, `rhiza-test` included with all 34 checks and `test_docstrings` running rather than skipping.

## Not in this PR

**The pin still has no Renovate manager**, which is why it aged three releases. It needs thought rather than a copy of the pytest-rhiza manager: `bundles/core/Makefile` is template-owned, so a manager that bumps it in a *consumer* would fight the next sync — the manager wants scoping to this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
