### PR TITLE
fix: revive two silently inert guards, and watch the pin that ages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -117,11 +117,47 @@ repos:
     hooks:
       # Migrated from rhiza
       - id: check-rhiza-workflow-names
+      # Mother-repo override (#1581). The hook declares `files: ^Makefile$`, and since #1576
+      # the root Makefile is a dogfood symlink into bundles/core/ -- git tracks it as mode
+      # 120000, and prek classifies a symlink as `symlink` rather than `file`, so a hook
+      # carrying pre-commit's default `types: [file]` is never handed it. The pattern
+      # therefore matched nothing even under `--all-files`, and the hook printed
+      # "(no files to check)Skipped" on every `make fmt` -- another line that reads like a
+      # check, the #1535 complaint reached by a different route.
+      #
+      # The block it maintains had already gone stale: #1580 bumped the pin to rhiza-task
+      # 1.1.0, which added `book-nav`, `complexity` and `docs-examples` and gave `book` a
+      # `paper` prerequisite, and none of it reached README.md.
+      #
+      # `always_run` rather than a `types` override, because the hook takes
+      # `pass_filenames: false` -- it does not want the path, only the trigger. That also
+      # makes it fire when the *task list* changes, which is what actually invalidates the
+      # block: the pin lives in the Makefile, but the tasks live in the CLI it names, so
+      # keying regeneration on a file changing was never quite right.
       - id: update-readme-help
+        always_run: true
       # Additional utility hooks
       - id: check-rhiza-config
-      - id: check-makefile-targets
       - id: check-python-version-consistency
+      # check-makefile-targets asserts a Makefile defines `install`, `test`, `fmt` and
+      # `help`, by extracting explicit rules from it. It was enabled here and inert for the
+      # same symlink reason as update-readme-help above (#1581) -- but unlike that hook it
+      # must stay off, because the shim is incompatible with what it measures:
+      #
+      #   $ check-makefile-targets Makefile
+      #   Makefile:
+      #     - Missing recommended targets: fmt, install, test
+      #
+      # All three work here; they are CLI tasks reached through the `%:` catch-all, which is
+      # the whole design of the shim (ADR 0011). A hook that greps for explicit rules cannot
+      # see them, so enabling it would print a false warning on every commit -- and it exits
+      # 0 without `--strict`, so the warning would never fail anything either.
+      #
+      # `always_run: true` is *not* the fix. The hook takes filenames, so with no match it
+      # loops over an empty list and returns 0: the visible "Skipped" becomes an invisible
+      # "Passed", which is strictly worse. tests/api/test_precommit_hook_reachability.py
+      # holds the line for both halves.
+      # - id: check-makefile-targets
       # check-bumpversion-config asserts that bump-my-version can actually discover this
       # repo's version config (issue #1453) — here, the [tool.bumpversion] table in
       # pyproject.toml. It ships as of v1.1.0 and passes on this repo; it stays off only

--- a/README.md
+++ b/README.md
@@ -384,6 +384,11 @@ Run `make help` for a complete list of 40+ available targets.
  book                Book            test benchmark        build the companion  
                                      stress                book                 
                                      hypothesis-test                            
+                                     paper                                      
+ book-nav            Book                                  check that every     
+                                                           mkdocs nav entry     
+                                                           resolves in the      
+                                                           built book           
  marimo              Book            install               start the Marimo     
                                                            editor               
  marimo-validate     Book            install               check that every     
@@ -456,8 +461,15 @@ Run `make help` for a complete list of 40+ available targets.
  typecheck           Python          install               run ty and/or mypy   
                                                            (typechecker = ty |  
                                                            mypy | both)         
+ docs-examples       Quality         install               check the fenced     
+                                                           examples in the docs 
+                                                           tree                 
  fmt                 Quality                               run the pre-commit   
                                                            hooks over all files 
+ complexity          Quality                               fail on a block      
+                                                           above the            
+                                                           cyclomatic-complexi… 
+                                                           ceiling              
  test-pyproject      Quality         install               run the              
                                                            pyproject.toml       
                                                            structure checks,    

--- a/renovate.json
+++ b/renovate.json
@@ -63,6 +63,20 @@
       ],
       "depNameTemplate": "pytest-rhiza",
       "datasourceTemplate": "pypi"
+    },
+    {
+      "customType": "regex",
+      "description": "The `RHIZA_TASK` pin: `bundles/core/Makefile` names the CLI that runs every gate, and the five live `.github/workflows/` plus the four GitLab bundle stubs repeat it because a reusable workflow cannot read a consumer's variable. Eleven literals, one dependency -- Renovate groups by dep+version, so they move in one PR, which is the property that matters: a partial bump leaves the shim and the workflows disagreeing about which CLI runs the gates. Without this manager the pin only ages, exactly as the pytest-rhiza one did (#1579): it sat at 0.3.1 while upstream shipped 1.0.0 and 1.1.0, and #1580 had to move all eleven by hand. This entry lives in the *root* renovate.json only, which is an intentional mother-repo override (utils/link_dogfood.py's exclusion list). Shipping it in `bundles/renovate/` would put it in consumers, where it would bump a template-owned file that the next `/rhiza:update` overwrites -- a PR loop, not an update. The bundle GitLab stubs are in scope here because they are authored in this repo, which is where a consumer's copy gets its value. The root `Makefile` is deliberately NOT matched: it is a dogfood symlink into bundles/core/, and writing through that path would replace the link with a regular file. tests/api/test_renovate_managers.py holds every one of these claims.",
+      "managerFilePatterns": [
+        "/^bundles/core/Makefile$/",
+        "/^\\.github/workflows/[^/]+\\.ya?ml$/",
+        "/^bundles/[^/]+/\\.gitlab/.*\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "rhiza-task@(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "rhiza-task",
+      "datasourceTemplate": "pypi"
     }
   ]
 }

--- a/tests/api/test_precommit_hook_reachability.py
+++ b/tests/api/test_precommit_hook_reachability.py
@@ -1,0 +1,303 @@
+r"""Every configured pre-commit hook must be able to see a file in this repository.
+
+A hook whose ``files:`` pattern matches nothing is not an error to prek: it prints
+``(no files to check)Skipped`` and the run stays green. That line reads like a check, in the
+output of the gate this repo runs most, and the repo has now been bitten by it three times
+through three different routes:
+
+- **A pattern for a layout this repo does not have.** The bundle ships interrogate with
+  ``files: ^src/``, right for a downstream project and inert here, so the hook skipped on
+  every ``make fmt`` while ``make docs-coverage`` enforced a stricter bar (#1535).
+- **A pattern for a path the template retired.** ``check-makefile-targets`` also matches
+  ``^\\.rhiza/.*\\.mk$``, and the make fragments went in #1556.
+- **A pattern for a path that became a symlink.** ``update-readme-help`` matches
+  ``^Makefile$``; #1576 made the root Makefile a dogfood symlink into ``bundles/core/``, git
+  tracks it as mode 120000, and prek classifies a symlink as ``symlink`` rather than
+  ``file`` -- so a hook carrying pre-commit's default ``types: [file]`` is never handed it,
+  even under ``--all-files``. The README's generated help block was stale for a release
+  before anyone noticed (#1581).
+
+The third route is why the candidate set below **excludes symlinks** unless a hook opts in.
+Modelling prek's file typing any further than that would mean reimplementing ``identify``;
+what matters is that the one rule this repo keeps tripping over is enforced, and
+:func:`test_the_symlink_rule_is_what_makes_this_test_bite` is the positive control proving
+it still is.
+
+**A ``language: fail`` hook is exempt, and not as a special case.** Such a hook exists to
+match nothing -- ``no-python-cache-files`` fails the commit precisely *when* its pattern
+selects a file -- so an empty match set is its passing state rather than a silent skip. The
+distinction this test draws is therefore not "does the pattern match" but "is a pattern that
+matches nothing what this hook wanted".
+
+**Scope: two halves, and neither needs the other.** The offline half checks every pattern
+written in *this* config -- the overrides, which are where a mother-repo assumption gets
+encoded. The network half checks the hooks from ``Jebel-Quant/rhiza-hooks``, whose patterns
+name rhiza's own layout (``^Makefile$``, ``^\\.rhiza/template\\.yml$``) and therefore drift
+when rhiza moves a file. Third-party hooks are deliberately out of scope: ruff and
+markdownlint key on file extensions, which do not move.
+"""
+
+from __future__ import annotations
+
+import functools
+import re
+import subprocess  # nosec B404 - fixed argument vectors
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+import yaml
+
+_ROOT = Path(__file__).resolve().parents[2]
+_CONFIG = _ROOT / ".pre-commit-config.yaml"
+
+_RHIZA_HOOKS_REPO = "https://github.com/Jebel-Quant/rhiza-hooks"
+_HOOKS_MANIFEST = "https://raw.githubusercontent.com/Jebel-Quant/rhiza-hooks/{rev}/.pre-commit-hooks.yaml"
+
+# Hooks that legitimately match nothing *in this repository*, each with the reason. An entry
+# here is a claim that the hook is inert by design rather than by accident -- so it is the
+# review surface this test exists to create, and the list must stay short.
+_INERT_BY_DESIGN = {
+    # The mother repo has no `.rhiza/template.yml`: it *is* the template, so there is no
+    # consumer config for the hook to validate. Enabled deliberately, so that a future
+    # `template.yml` here (or a copy of this config in a consumer) starts being checked
+    # without an edit.
+    "check-rhiza-config": "the mother repo has no .rhiza/template.yml -- it is the template",
+}
+
+# Git's mode for a symlink. prek tags these `symlink`, not `file`, so a hook with
+# pre-commit's default `types: [file]` never receives one.
+_SYMLINK_MODE = "120000"
+
+
+@functools.lru_cache(maxsize=1)
+def _tracked() -> tuple[tuple[str, str], ...]:
+    """Return every tracked path with its git mode, as ``(mode, path)`` pairs.
+
+    Returns:
+        One pair per tracked path, modes as the six-digit strings ``git ls-files -s`` prints.
+    """
+    proc = subprocess.run(  # nosec B603
+        ["git", "ls-files", "-s"],
+        cwd=_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    pairs = []
+    for line in proc.stdout.splitlines():
+        meta, _, path = line.partition("\t")
+        pairs.append((meta.split()[0], path))
+    return tuple(pairs)
+
+
+def _candidates(hook: dict) -> list[str]:
+    """Return the tracked paths prek could hand this hook.
+
+    Symlinks are excluded unless the hook's ``types``/``types_or`` names ``symlink``: that is
+    the rule the root Makefile broke, and the only part of prek's file typing modelled here.
+
+    Args:
+        hook: The effective hook config -- upstream definition with this repo's keys applied.
+
+    Returns:
+        The candidate paths, before the ``files``/``exclude`` patterns are applied.
+    """
+    declared = set(hook.get("types", []) or []) | set(hook.get("types_or", []) or [])
+    wants_symlinks = "symlink" in declared
+    return [path for mode, path in _tracked() if wants_symlinks or mode != _SYMLINK_MODE]
+
+
+def _matches(hook: dict) -> list[str]:
+    """Return the candidate paths this hook's patterns actually select.
+
+    Args:
+        hook: The effective hook config.
+
+    Returns:
+        Every candidate path matching ``files`` and not matching ``exclude``.
+    """
+    files = re.compile(hook["files"]) if hook.get("files") else None
+    exclude = re.compile(hook["exclude"]) if hook.get("exclude") else None
+    selected = []
+    for path in _candidates(hook):
+        if files is not None and not files.search(path):
+            continue
+        if exclude is not None and exclude.search(path):
+            continue
+        selected.append(path)
+    return selected
+
+
+@functools.lru_cache(maxsize=1)
+def _config() -> dict:
+    """Return the parsed root pre-commit config.
+
+    Returns:
+        The config mapping, with its ``repos`` list.
+    """
+    return yaml.safe_load(_CONFIG.read_text(encoding="utf-8"))
+
+
+def _configured_hooks(repo_url: str | None = None) -> list[dict]:
+    """Return the hook entries this config declares, optionally for one repo.
+
+    Args:
+        repo_url: When given, only hooks from that ``repo:`` are returned.
+
+    Returns:
+        The hook mappings as written in this config, each carrying its own overrides only.
+    """
+    hooks = []
+    for repo in _config()["repos"]:
+        if repo_url is not None and repo.get("repo") != repo_url:
+            continue
+        hooks.extend(repo.get("hooks", []))
+    return hooks
+
+
+@functools.lru_cache(maxsize=1)
+def _upstream_rhiza_hooks() -> dict[str, dict] | None:
+    """Return rhiza-hooks' own hook definitions at the pinned rev.
+
+    Fetched rather than listed here, because the whole failure mode is a pattern written
+    upstream that this repo's layout has moved out from under -- a copy here would be one
+    more thing to drift.
+
+    Returns:
+        ``{hook id: definition}``, or None when the network or the rev is unavailable.
+    """
+    rev = next(
+        (r.get("rev") for r in _config()["repos"] if r.get("repo") == _RHIZA_HOOKS_REPO),
+        None,
+    )
+    if not rev:
+        return None
+    try:
+        # Suppressed below: the URL is this module's own https constant with a pinned rev
+        # interpolated, the same shape as tests/bundles/test_gitlab_ci.py's fetches.
+        with urllib.request.urlopen(_HOOKS_MANIFEST.format(rev=rev), timeout=20) as response:  # noqa: S310  # nosec B310
+            manifest = yaml.safe_load(response.read().decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, OSError, yaml.YAMLError):
+        return None
+    return {entry["id"]: entry for entry in manifest}
+
+
+def _effective(hook: dict, upstream: dict) -> dict:
+    """Merge this repo's hook entry over the upstream definition.
+
+    Args:
+        hook: The entry as written in this config.
+        upstream: The hook's upstream definition.
+
+    Returns:
+        The upstream definition with every key this config restates replaced.
+    """
+    return {**upstream, **hook}
+
+
+def _reachable(hook: dict) -> bool:
+    """Report whether prek can hand this hook at least one file.
+
+    ``always_run`` is the documented way to say a hook needs no file at all -- it is what
+    ``update-readme-help`` uses here, and what upstream's
+    ``check-python-version-consistency`` ships with.
+
+    Args:
+        hook: The effective hook config.
+
+    Returns:
+        True when the hook always runs, or when its patterns select a candidate.
+    """
+    return bool(hook.get("always_run")) or bool(_matches(hook))
+
+
+def _is_tripwire(hook: dict) -> bool:
+    """Report whether this hook exists in order to match nothing.
+
+    pre-commit's ``language: fail`` means "if you are handed a file, fail" -- so a tripwire's
+    passing state is an empty match set, and reachability is not a property it should have.
+    ``no-python-cache-files`` is the one here. Keyed on the language rather than on the id, so
+    the next tripwire added is classified correctly without an edit.
+
+    Args:
+        hook: The effective hook config.
+
+    Returns:
+        True when the hook is a guard against files existing at all.
+    """
+    return hook.get("language") == "fail"
+
+
+_LOCALLY_SCOPED = [h for h in _configured_hooks() if h.get("files") and not _is_tripwire(h)]
+
+
+@pytest.mark.parametrize("hook", _LOCALLY_SCOPED, ids=lambda h: str(h["id"]))
+def test_a_pattern_written_here_selects_a_real_file(hook: dict) -> None:
+    """Every ``files:`` pattern in this config must match a tracked file.
+
+    The offline half. A pattern restated here is a mother-repo decision -- interrogate's
+    ``^(utils|tests)/`` exists because the bundle's ``^src/`` matched nothing (#1535) -- so
+    it is exactly the kind that goes stale when this repo's layout changes.
+    """
+    assert _matches(hook), (
+        f"hook {hook['id']!r} declares files={hook['files']!r}, which matches no tracked "
+        f"file. prek reports that as '(no files to check)Skipped' and the gate stays green, "
+        f"so the hook is not checking anything (#1535, #1581)."
+    )
+
+
+def test_every_rhiza_hook_can_see_something() -> None:
+    """rhiza-hooks' patterns name rhiza's own layout, so they drift when rhiza moves a file.
+
+    The network half. Skips without the manifest, so ``make test`` stays green offline while
+    CI does the real check -- the same bargain as ``test_bundle_cli_targets`` and
+    ``test_gitlab_ci``.
+    """
+    upstream = _upstream_rhiza_hooks()
+    if upstream is None:
+        pytest.skip("could not fetch rhiza-hooks' .pre-commit-hooks.yaml")
+
+    unreachable = []
+    for entry in _configured_hooks(_RHIZA_HOOKS_REPO):
+        hook_id = entry["id"]
+        if hook_id in _INERT_BY_DESIGN or hook_id not in upstream:
+            continue
+        effective = _effective(entry, upstream[hook_id])
+        if _is_tripwire(effective):
+            continue
+        if not _reachable(effective):
+            unreachable.append(f"{hook_id} (files={upstream[hook_id].get('files')!r})")
+
+    assert not unreachable, (
+        f"these rhiza-hooks match no tracked file and are silently inert: {unreachable}. "
+        f"Either set `always_run: true` (if the hook takes `pass_filenames: false`), narrow "
+        f"the config to a path that exists, disable the hook with the reason recorded, or "
+        f"add it to _INERT_BY_DESIGN with a reason. Do not set `always_run` on a hook that "
+        f"takes filenames: it then loops over an empty list and reports Passed (#1581)."
+    )
+
+
+def test_the_symlink_rule_is_what_makes_this_test_bite() -> None:
+    """Positive control: ``^Makefile$`` with default types must resolve to nothing.
+
+    Without this, a change that stopped excluding symlinks would make every assertion above
+    pass vacuously -- and the #1581 route would reopen with the guard still green. Asserted
+    against the real root Makefile, which is a tracked symlink, so it also fails if the
+    dogfood link is ever replaced by a real file (at which point the override in
+    ``.pre-commit-config.yaml`` is no longer needed and its comment is wrong).
+    """
+    modes = {path: mode for mode, path in _tracked()}
+    assert modes.get("Makefile") == _SYMLINK_MODE, (
+        "the root Makefile is no longer a tracked symlink, so update-readme-help's "
+        "`always_run: true` override and its comment in .pre-commit-config.yaml are stale"
+    )
+    assert not _matches({"id": "probe", "files": r"^Makefile$"}), (
+        "a hook matching ^Makefile$ with pre-commit's default types now resolves to a file, "
+        "so this suite would no longer catch #1581's symlink route"
+    )
+    assert _matches({"id": "probe", "files": r"^Makefile$", "types": ["symlink"]}), (
+        "opting into symlinks no longer selects the root Makefile, so _candidates() is "
+        "excluding more than it should and every assertion above is weaker than it reads"
+    )

--- a/tests/api/test_renovate_managers.py
+++ b/tests/api/test_renovate_managers.py
@@ -1,0 +1,231 @@
+"""Renovate's custom managers must still match the pins they were written for.
+
+A custom manager whose file pattern matches nothing is **not an error to Renovate**. It
+reports no failure and opens no PR; the pin it was watching simply stops being updated. That
+is how the pytest-rhiza manager died: it targeted ``RHIZA_CHECKS_VERSION`` in
+``.rhiza/make.d/quality.mk``, the make layer retired (#1556 here, #1557 for the bundle), and
+the pin aged through two releases before anyone looked (#1579).
+
+``RHIZA_TASK`` then repeated the lesson with no manager at all. It sat at 0.3.1 while
+upstream shipped 1.0.0 and 1.1.0, and #1580 moved all eleven literals by hand. #1582 added
+the manager; this module is the half that keeps it honest, because adding a manager without a
+test only moves the silent-failure mode one level up.
+
+**Three claims are asserted, and the third is the counter-intuitive one:**
+
+1. Every ``rhiza-task@X.Y.Z`` literal in the tree lies in a file the manager matches.
+2. Every such line matches the manager's ``matchStrings``, capturing ``currentValue``.
+3. The **root** ``Makefile`` is deliberately *not* matched. It is a dogfood symlink into
+   ``bundles/core/``, and a writer following that path would replace the link with a regular
+   file -- silently undoing #1576 and leaving two copies of the shim to drift. The bundle
+   file is the one that carries the pin; the root one only reflects it.
+
+A fourth invariant comes along for free and is worth as much as the others: all eleven
+literals must name the **same** version. Renovate groups by dep+version and so keeps them in
+step, but a hand bump does not, and a repo whose shim and workflows name different CLIs runs
+its gates on two versions without saying so.
+"""
+
+from __future__ import annotations
+
+import functools
+import json
+import re
+import subprocess  # nosec B404 - fixed argument vectors
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+_RENOVATE = _ROOT / "renovate.json"
+
+# The pin as it appears in every shape: `RHIZA_TASK ?= rhiza-task@1.1.0`, the quoted
+# `RHIZA_TASK: "rhiza-task@1.1.0"`, and the inline `uvx rhiza-task@1.1.0 print ...`.
+_PIN = re.compile(r"rhiza-task@(\d+\.\d+\.\d+)")
+
+# Where a literal may live without the manager being expected to update it.
+#
+# CHANGELOG.md records what *was* pinned, so rewriting it would falsify history. The root
+# Makefile is the dogfood symlink -- see the module docstring's third claim. Nothing else is
+# exempt: a new home for the pin should fail this suite until the manager learns about it.
+_NOT_THE_MANAGER_S_JOB = {"CHANGELOG.md", "Makefile"}
+
+# Documentation and tests reference the pin as prose or as a pattern, not as a pin to bump.
+_PROSE_PREFIXES = ("docs/", "tests/", "README.md", "CLAUDE.md")
+
+
+@functools.lru_cache(maxsize=1)
+def _tracked_files() -> tuple[str, ...]:
+    """Return every tracked path that is a regular file, symlinks excluded.
+
+    Returns:
+        Repo-relative paths, with mode-120000 entries dropped.
+    """
+    proc = subprocess.run(  # nosec B603
+        ["git", "ls-files", "-s"],
+        cwd=_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    out = []
+    for line in proc.stdout.splitlines():
+        meta, _, path = line.partition("\t")
+        if meta.split()[0] != "120000":
+            out.append(path)
+    return tuple(out)
+
+
+@functools.lru_cache(maxsize=1)
+def _manager() -> dict:
+    """Return the custom manager that watches the rhiza-task pin.
+
+    Returns:
+        The manager mapping from ``renovate.json``.
+    """
+    config = json.loads(_RENOVATE.read_text(encoding="utf-8"))
+    managers = [m for m in config.get("customManagers", []) if m.get("depNameTemplate") == "rhiza-task"]
+    assert len(managers) == 1, (
+        f"expected exactly one custom manager for rhiza-task in renovate.json, found {len(managers)}. "
+        f"Two managers for one dependency race each other; none means the pin only ages (#1579, #1582)."
+    )
+    return managers[0]
+
+
+def _as_regex(pattern: str) -> re.Pattern[str]:
+    """Convert one Renovate ``managerFilePatterns`` entry to a Python regex.
+
+    Renovate accepts either a glob or a ``/regex/`` literal; this repo's managers use the
+    regex form throughout, so only the delimiters have to come off.
+
+    Args:
+        pattern: The entry as written in ``renovate.json``.
+
+    Returns:
+        The compiled pattern.
+    """
+    delimited = (
+        f"managerFilePatterns entry {pattern!r} is not in the /regex/ form the other "
+        f"managers here use; a glob would need different handling in this test"
+    )
+    assert pattern.startswith("/"), delimited
+    assert pattern.endswith("/"), delimited
+    return re.compile(pattern[1:-1])
+
+
+def _match_string(pattern: str) -> re.Pattern[str]:
+    """Compile one Renovate ``matchStrings`` entry as a Python regex.
+
+    Renovate's regexes are **JavaScript**, where a named group is ``(?<name>...)``; Python
+    spells it ``(?P<name>...)`` and raises ``re.error: unknown extension ?<c`` on the other
+    form. So the config is correct as written and this test has to translate, not the other
+    way round -- "fixing" renovate.json to satisfy Python would break the manager.
+
+    Args:
+        pattern: The entry as written in ``renovate.json``.
+
+    Returns:
+        The compiled pattern, with named groups in Python syntax.
+    """
+    return re.compile(re.sub(r"\(\?<(?![=!])", "(?P<", pattern))
+
+
+def _pinned_files() -> list[str]:
+    """Return the tracked files carrying a rhiza-task pin the manager should own.
+
+    Returns:
+        Repo-relative paths, prose and history excluded.
+    """
+    out = []
+    for path in _tracked_files():
+        if path in _NOT_THE_MANAGER_S_JOB or path.startswith(_PROSE_PREFIXES):
+            continue
+        if _PIN.search((_ROOT / path).read_text(encoding="utf-8", errors="replace")):
+            out.append(path)
+    return sorted(out)
+
+
+def test_the_scan_finds_the_pins_at_all() -> None:
+    """Positive control: an empty file list would make every assertion below vacuous.
+
+    Named first because it is the one that fails if the pin is renamed, moved wholesale, or
+    if ``_PROSE_PREFIXES`` grows until it swallows the real thing.
+    """
+    found = _pinned_files()
+    assert len(found) >= 9, (
+        f"found only {len(found)} file(s) carrying a rhiza-task pin: {found}. The shim and the "
+        f"live workflows alone are more than that, so the scan is looking in the wrong place "
+        f"and the coverage assertions below prove nothing."
+    )
+    assert "bundles/core/Makefile" in found, "the shim is where the pin lives; the scan must see it"
+
+
+@pytest.mark.parametrize("path", _pinned_files())
+def test_every_pinned_file_is_matched_by_the_manager(path: str) -> None:
+    """A file carrying the pin that no ``managerFilePatterns`` entry matches is unwatched.
+
+    This is the assertion that would have caught #1579 before the pin aged: the manager
+    still parses, still validates, and matches nothing.
+    """
+    patterns = [_as_regex(p) for p in _manager()["managerFilePatterns"]]
+    assert any(p.search(path) for p in patterns), (
+        f"{path} carries a rhiza-task pin that no managerFilePatterns entry matches, so "
+        f"Renovate will never bump it. A partial bump leaves the shim and the workflows "
+        f"naming different CLIs (#1582)."
+    )
+
+
+@pytest.mark.parametrize("path", _pinned_files())
+def test_the_match_string_captures_every_occurrence(path: str) -> None:
+    """Matching the file is not enough: the regex must also capture each pin's version.
+
+    A ``matchStrings`` that finds the file but not the literal is the same silent no-op one
+    level down -- Renovate reports the manager as having found no dependency, which is not an
+    error either.
+    """
+    match_strings = [_match_string(s) for s in _manager()["matchStrings"]]
+    text = (_ROOT / path).read_text(encoding="utf-8")
+    occurrences = _PIN.findall(text)
+    for regex in match_strings:
+        captured = [m.group("currentValue") for m in regex.finditer(text)]
+        if len(captured) == len(occurrences):
+            assert captured == occurrences, f"{path}: captured {captured}, expected {occurrences}"
+            return
+    pytest.fail(
+        f"{path} carries {len(occurrences)} rhiza-task pin(s) but no matchStrings entry "
+        f"captures all of them. rhiza_ci.yml carries two — an env var and an inline `uvx` "
+        f"call — so a regex anchored on `RHIZA_TASK:` alone silently misses one."
+    )
+
+
+def test_the_root_makefile_is_not_matched() -> None:
+    """The dogfood symlink must stay out of the manager's reach.
+
+    Renovate writing through ``Makefile`` would replace the symlink with a regular file,
+    quietly undoing #1576 and leaving two copies of the shim free to drift. The bundle file
+    is the pin's home; the root path only reflects it.
+    """
+    patterns = [_as_regex(p) for p in _manager()["managerFilePatterns"]]
+    assert not any(p.search("Makefile") for p in patterns), (
+        "a managerFilePatterns entry matches the root `Makefile`, which is a dogfood symlink "
+        "into bundles/core/. Renovate would turn it into a real file on the first bump. "
+        "Match `bundles/core/Makefile` instead."
+    )
+
+
+def test_every_pin_names_the_same_version() -> None:
+    """A split pin runs the gates on two CLIs without saying so.
+
+    Renovate keeps the literals in step by grouping on dep+version; a hand bump does not,
+    which is the failure this asserts against. #1580 moved eleven literals at once and this
+    is what proves it moved all of them.
+    """
+    versions: dict[str, set[str]] = {}
+    for path in _pinned_files():
+        for version in _PIN.findall((_ROOT / path).read_text(encoding="utf-8")):
+            versions.setdefault(version, set()).add(path)
+    assert len(versions) == 1, (
+        f"the rhiza-task pin disagrees with itself across files: "
+        f"{ {v: sorted(p) for v, p in versions.items()} }. Every literal must name one "
+        f"version, or the shim and CI run different gates."
+    )


### PR DESCRIPTION
Closes #1581. Closes #1582.

Both halves are the same failure: **a pattern that matches nothing is not an error to the tool that reads it**, so the guard stops guarding and the run stays green.

## The hooks (#1581)

`update-readme-help` declares `files: ^Makefile$`. Since #1576 the root Makefile is a dogfood symlink into `bundles/core/` — git tracks it as mode `120000`, and prek classifies a symlink as `symlink` rather than `file`, so a hook carrying pre-commit's default `types: [file]` is never handed it. The pattern matched nothing **even under `--all-files`**, and the hook printed `(no files to check)Skipped` on every `make fmt`: another line that reads like a check, which is the #1535 complaint reached by a different route.

The block it maintains had already gone stale. #1580 bumped the pin to rhiza-task 1.1.0, which added `book-nav`, `complexity` and `docs-examples` and gave `book` a `paper` prerequisite — none of it reached `README.md`, and nothing asserted otherwise: `test_doc_consistency` checks that no document names a target which *doesn't exist*, the opposite direction, which cannot fail on a missing one.

Fixed with `always_run: true`, which suits a hook taking `pass_filenames: false` — and which also fires it when the **task list** changes rather than only when a file does. That is the real trigger: the pin lives in the Makefile, but the tasks live in the CLI it names.

### `check-makefile-targets` gets the opposite fix, and this corrects #1581 as filed

The issue proposed `always_run: true` for both. That is wrong for the second hook, and the evidence is what changed my mind — handed the shim, it reports:

```
$ check-makefile-targets Makefile
Makefile:
  - Missing recommended targets: fmt, install, test
```

All three work here. They are CLI tasks reached through the `%:` catch-all, which is the entire design of ADR 0011; a hook that greps for explicit rules cannot see them. So enabling it would print a **false** warning on every commit — and it exits 0 without `--strict`, so the warning would never fail anything either.

`always_run: true` would be strictly worse than leaving it broken: the hook takes filenames, so with no match it loops over an empty list and returns 0 — the visible `Skipped` becomes an invisible `Passed`. It is disabled with the reason recorded, in the house style of the `check-bumpversion-config` block above it.

### The guard is for the class, not the two instances

`tests/api/test_precommit_hook_reachability.py`: every configured hook must be able to see a tracked file, symlinks excluded unless it opts in. Two carve-outs, both principled rather than convenient:

- a **`language: fail` tripwire** *wants* an empty match set — `no-python-cache-files` fails the commit precisely *when* its pattern selects a file, so reachability is not a property it should have. Keyed on the language, so the next tripwire is classified correctly with no edit.
- **`check-rhiza-config`** has no `.rhiza/template.yml` to validate, because this repo *is* the template. Recorded in `_INERT_BY_DESIGN` with that reason, and left enabled so a future `template.yml` starts being checked without an edit.

`test_the_symlink_rule_is_what_makes_this_test_bite` is the positive control. Without it, a change that stopped excluding symlinks would leave every other assertion passing vacuously and reopen #1581 with the guard still green.

## The manager (#1582)

One custom regex manager covers all three shapes — the shim, the five live workflows, the four GitLab bundle stubs — so Renovate groups them by dep+version and they move in **one** PR. A partial bump is the failure that matters: it leaves the shim and CI naming different CLIs.

It lives in the **root** `renovate.json` only, which is already an intentional mother-repo override (`utils/link_dogfood.py`'s exclusion list). That is what dissolves the objection I recorded in #1580 against doing this at all: shipping it in `bundles/renovate/` would put it in consumers, where it would bump a template-owned file that the next `/rhiza:update` overwrites — a PR loop, not an update.

The root `Makefile` is deliberately **not** matched. Writing through the symlink would replace it with a regular file, quietly undoing #1576 and leaving two copies of the shim free to drift.

`tests/api/test_renovate_managers.py` asserts four things: the manager matches every pinned file; its `matchStrings` captures every occurrence (`rhiza_ci.yml` carries two, so a regex anchored on `RHIZA_TASK:` alone would silently miss one); the symlink stays out of reach; and all eleven literals name the same version. It translates Renovate's JavaScript `(?<name>)` to Python's `(?P<name>)` — the config is correct as written, and "fixing" it to satisfy `re` would break the manager.

## Verification

`make all` green — **1472 passed** (up 28), every gate `ok`. `make fmt` now shows `Update README with Makefile help output.....Passed` where it showed `Skipped`, and the only two remaining `(no files to check)` lines are the tripwire and the documented carve-out.

One incidental finding worth knowing: these two test files passed `make fmt`'s ruff hook while **untracked**, then failed it on `git add`. prek's `--all-files` means all *tracked* files — so a new file is unlinted until it is staged. Normal pre-commit semantics, but the same shape as everything else in this PR: a gate that looks broader than it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
