### PR TITLE
refactor: one reader for the task registry, with the control it was missing

### DIFF
--- a/tests/api/test_ci_workflow.py
+++ b/tests/api/test_ci_workflow.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-import json
 import re
-import subprocess  # nosec B404
 import sys
 from pathlib import Path
 
 import pytest
 import yaml
+
+from tests.registry import require as require_registry
 
 MULTI_OS_MATRIX = 'RHIZA_CI_OS_MATRIX=["ubuntu-latest","windows-latest"]'
 WORKFLOW_PATH = Path(".github") / "workflows" / "rhiza_ci.yml"
@@ -93,49 +93,25 @@ def test_ci_jobs_define_timeout_budgets(root):
         assert jobs[job_name]["timeout-minutes"] == timeout
 
 
-def _gates_named_by_all(root: Path) -> list[str]:
+def _gates_named_by_all() -> list[str]:
     """Return the gate names ``all`` depends on, from the rhiza-task registry.
 
-    The registry is keyed ``layer:name`` and populated by the ``@task`` decorator, so the
-    task modules have to be imported before it is read -- via the CLI's own
-    :func:`rhiza_task.cli.load_tasks`, so the set follows the ``rhiza_task.tasks`` entry-point
-    group instead of a module list that ages here. Only this repo's layer is consulted:
-    ``rust:all`` and ``go:all`` name a slightly different set, and asserting a Rust gate runs
-    in a Python repo's CI would be nonsense.
+    Read through :mod:`tests.registry`, the fourth caller of what used to be three copies of
+    the same subprocess (#1583). Only this repo's layer is consulted: ``rust:all`` and
+    ``go:all`` name a slightly different set, and asserting a Rust gate runs in a Python
+    repo's CI would be nonsense.
 
-    Args:
-        root: Repository root, used to locate the Makefile carrying the pin.
+    The ``assert gates`` below is the control this function already had, and it is why the
+    #1580 breakage surfaced here as a red test rather than as a shrinking gate list. It stays
+    even though :func:`tests.registry.load` now anchors on ``python:all`` too: that check says
+    the key exists, this one says it has prerequisites, and an ``all`` that named nothing would
+    make every assertion downstream vacuous.
 
     Returns:
         The prerequisite gate names, in declaration order.
     """
-    pin = re.search(r"^RHIZA_TASK \?= (\S+)", (root / "Makefile").read_text(encoding="utf-8"), re.MULTILINE)
-    assert pin, "the root Makefile no longer pins RHIZA_TASK"
-    name, _, version = pin.group(1).partition("@")
-    script = (
-        "import json;"
-        "from rhiza_task.cli import load_tasks; load_tasks();"
-        "from rhiza_task.spec import REGISTRY;"
-        "print(json.dumps(list(REGISTRY['python:all'].needs)))"
-    )
-    proc = subprocess.run(  # nosec B603
-        [
-            "uv",
-            "run",
-            "--quiet",
-            "--no-project",
-            "--with",
-            f"{name}=={version}" if version else name,
-            "python",
-            "-c",
-            script,
-        ],
-        cwd=root,
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    gates = json.loads(proc.stdout)
+    registry = require_registry()
+    gates = registry["python:all"]
     assert gates, "the registry reports no prerequisites for `all`, so this guard would be inert"
     return gates
 
@@ -154,7 +130,7 @@ def test_every_gate_named_by_make_all_runs_in_ci(root):
     shim it comes from the CLI's task registry instead, which is the same derivation against
     the new source of truth.
     """
-    gates = _gates_named_by_all(root)
+    gates = _gates_named_by_all()
 
     workflows = (root / ".github" / "workflows").glob("*.yml")
     invoked = "\n".join(wf.read_text(encoding="utf-8") for wf in workflows)

--- a/tests/bundles/test_bundle_combinations.py
+++ b/tests/bundles/test_bundle_combinations.py
@@ -19,6 +19,8 @@ from pathlib import Path
 import pytest
 import yaml
 
+from tests.registry import require as require_registry
+from tests.registry import resolves
 from tests.util import sync_bundles
 
 
@@ -248,12 +250,8 @@ class TestBenchmarksBundleSync:
         test infrastructure. The fragment retired to rhiza-task, so what matters is that the task
         exists — the dependency is expressed in its registry entry rather than by a file arriving.
         """
-        from tests.bundles.test_layer_contract import _registry, _resolves
-
-        registry = _registry()
-        if not registry:
-            pytest.skip("could not read the rhiza-task registry")
-        assert _resolves(registry, "python", "benchmark"), (
+        registry = require_registry()
+        assert resolves(registry, "python", "benchmark"), (
             "`benchmark` resolves to no registered task, so this bundle's config has no gate to feed"
         )
 

--- a/tests/bundles/test_layer_contract.py
+++ b/tests/bundles/test_layer_contract.py
@@ -16,15 +16,12 @@ Each is a guard against a divergence that already happened once:
 
 from __future__ import annotations
 
-import functools
-import json
-import re
-import subprocess  # nosec B404
 import tomllib
-from pathlib import Path
 
 import pytest
 
+from tests.registry import require as require_registry
+from tests.registry import resolves
 from tests.util import sync_bundles
 
 
@@ -84,69 +81,12 @@ class TestNonPythonLayersShipADiscoverableBumpversionConfig:
         )
 
 
-@pytest.mark.parametrize("layer", ["python-core", "rust-core", "go-core"])
-@functools.lru_cache(maxsize=1)
-def _registry() -> dict[str, list[str]]:
-    """Return the pinned CLI's task registry as ``{key: [prerequisite, ...]}``.
-
-    Keys are ``layer:name`` for a layer-scoped task and bare ``name`` for a neutral one, which
-    is how :mod:`rhiza_task.spec` stores them -- three layers may each define ``test``, and
-    which one answers is decided per repository.
-
-    The task modules must be imported before the registry is read: the ``@task`` decorator
-    populates it at import time, and ``rhiza_task.tasks`` does not pull in its submodules.
-    Loaded through the CLI's own :func:`rhiza_task.cli.load_tasks`, which walks the
-    ``rhiza_task.tasks`` entry-point group, rather than a module list written out here -- such
-    a list silently omits whatever the next release adds, and that is not a hypothetical: it
-    is how ``book``'s ``paper`` prerequisite went unseen when rhiza-task 1.1.0 added it.
-
-    Returns:
-        The registry, or an empty dict when the CLI cannot be reached.
-    """
-    root = Path(__file__).resolve().parents[2]
-    match = re.search(r"^RHIZA_TASK \?= (\S+)", (root / "Makefile").read_text(encoding="utf-8"), re.MULTILINE)
-    if not match:
-        return {}
-    name, _, version = match.group(1).partition("@")
-    script = (
-        "import json;"
-        "from rhiza_task.cli import load_tasks; load_tasks();"
-        "from rhiza_task.spec import REGISTRY;"
-        "print(json.dumps({k: list(v.needs) for k, v in REGISTRY.items()}))"
-    )
-    proc = subprocess.run(  # nosec B603
-        [
-            "uv",
-            "run",
-            "--quiet",
-            "--no-project",
-            "--with",
-            f"{name}=={version}" if version else name,
-            "python",
-            "-c",
-            script,
-        ],
-        cwd=root,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    return json.loads(proc.stdout) if proc.returncode == 0 else {}
-
-
-def _resolves(registry: dict[str, list[str]], layer: str, task: str) -> bool:
-    """Report whether ``task`` resolves for ``layer``: layer-scoped first, then neutral.
-
-    Args:
-        registry: The task registry.
-        layer: ``python``, ``rust`` or ``go``.
-        task: A task name.
-
-    Returns:
-        True when some registered task answers that name for that layer.
-    """
-    return f"{layer}:{task}" in registry or task in registry
-
+# `_registry` and `_resolves` used to live here, and `test_bundle_combinations` imported them
+# from this module by their private names (#1583). They are :mod:`tests.registry` now -- one
+# reader for the four modules that need the same answer, with the anchor check that makes a
+# narrowed derivation fail instead of skip (#1584). The stray
+# `@pytest.mark.parametrize("layer", ...)` that sat on `_registry` went with them: a mark on a
+# module-level helper is never read, so it had been inert since whatever refactor stranded it.
 
 # The CLI's layer names, against the bundle names the rest of this module uses.
 _LAYERS = {"python-core": "python", "rust-core": "rust", "go-core": "go"}
@@ -169,14 +109,12 @@ class TestALayersAllIsSatisfiableOnItsOwn:
     @pytest.mark.parametrize("layer", sorted(_LAYERS))
     def test_every_prerequisite_of_all_resolves(self, layer):
         """Each name in this layer's `all` must resolve to a registered task."""
-        registry = _registry()
-        if not registry:
-            pytest.skip("could not read the rhiza-task registry")
+        registry = require_registry()
         cli_layer = _LAYERS[layer]
         key = f"{cli_layer}:all"
         assert key in registry, f"{layer} defines no `all` task"
 
-        missing = [name for name in registry[key] if not _resolves(registry, cli_layer, name)]
+        missing = [name for name in registry[key] if not resolves(registry, cli_layer, name)]
         assert not missing, (
             f"`all` on {layer} names {missing}, which resolve to no registered task. A gate that "
             f"only resolves once something else happens to be present is not part of the contract."
@@ -204,10 +142,8 @@ class TestEveryLayerDefinesTheSameGateNames:
     @pytest.mark.parametrize("gate", GATES)
     def test_all_three_layers_define_the_gate(self, gate):
         """Each gate name must resolve for every language layer."""
-        registry = _registry()
-        if not registry:
-            pytest.skip("could not read the rhiza-task registry")
-        missing = [b for b, cli in sorted(_LAYERS.items()) if not _resolves(registry, cli, gate)]
+        registry = require_registry()
+        missing = [b for b, cli in sorted(_LAYERS.items()) if not resolves(registry, cli, gate)]
         assert not missing, (
             f"`{gate}` does not resolve for {missing}. A gate the other layers provide under this "
             f"name makes the contract language-specific: a caller has to know what the project is "

--- a/tests/docs/test_doc_consistency.py
+++ b/tests/docs/test_doc_consistency.py
@@ -397,6 +397,26 @@ class TestProseDrift:
         """Guard against the make-mention scanner silently collecting nothing."""
         assert len(_make_mention_cases()) > 10, "expected CLAUDE.md/README.md to mention make targets"
 
+    def test_the_cli_half_of_the_target_set_was_collected(self) -> None:
+        """The other side of the comparison needs a control too (#1584).
+
+        ``_defined_make_targets`` is CLI tasks plus explicit rules, and this repo's Makefile
+        holds seven rules. So an unreachable CLI does not make the mention gate vacuous -- it
+        makes it fail, on every document that says ``make test``, with a message about the
+        *documentation* being wrong. The gate is safe either way; what this adds is a failure
+        that names the real cause instead of sending the reader to edit correct prose.
+
+        ``fmt`` and ``test`` rather than a count: both are gates every layer defines, so
+        neither disappears without a breaking change upstream.
+        """
+        names = _cli_task_names()
+        if not names:
+            pytest.skip("could not reach the pinned CLI to enumerate its tasks")
+        assert {"fmt", "test"} <= names, (
+            f"the CLI reported {len(names)} task(s) but not the gates every layer defines; "
+            f"the task-name parse is probably reading the wrong column of `rhiza-task list`"
+        )
+
 
 # Tools whose presence in the toolchain is worth keeping the docs honest about. Each is
 # either invoked somewhere in _INVOCATION_SOURCES or it is not; the test below derives

--- a/tests/integration/test_book_targets.py
+++ b/tests/integration/test_book_targets.py
@@ -17,26 +17,15 @@ was absent, so retiring the fragment turned four tests into four silent skips. T
 
 from __future__ import annotations
 
-import json
-import re
 import subprocess  # nosec B404
 from pathlib import Path
 
 import pytest
 
+from tests.registry import require as require_registry
+from tests.registry import resolves
+
 _ROOT = Path(__file__).resolve().parents[2]
-
-
-def _pin() -> str:
-    """Return the pinned rhiza-task spec from the root Makefile.
-
-    Returns:
-        The ``rhiza-task@X.Y.Z`` spec.
-    """
-    match = re.search(r"^RHIZA_TASK \?= (\S+)", (_ROOT / "Makefile").read_text(encoding="utf-8"), re.MULTILINE)
-    if not match:
-        pytest.skip("the root Makefile no longer pins RHIZA_TASK")
-    return match.group(1)
 
 
 @pytest.mark.parametrize("target", ["book", "serve"])
@@ -62,42 +51,18 @@ def test_every_prerequisite_of_book_resolves() -> None:
     property is the same one and its failure mode is identical — `book` dying on a name nothing
     provides.
 
-    Every task module is loaded, through the CLI's own `load_tasks`. Naming them by hand made
-    this test's own coverage depend on a list nobody re-derives: rhiza-task 1.1.0 gave `book` a
-    `paper` prerequisite, `paper` lives in a module the list did not mention, and the assertion
-    reported a missing task where the real gap was the fixture.
+    Read through :mod:`tests.registry`, which was the third copy of this subprocess until
+    #1583. Naming the task modules by hand made this test's own coverage depend on a list
+    nobody re-derives: rhiza-task 1.1.0 gave `book` a `paper` prerequisite, `paper` lives in a
+    module the list did not mention, and the assertion reported a missing task where the real
+    gap was the fixture. The shared reader walks the entry-point group the CLI itself walks,
+    and asserts the registry is plausible before any caller reads it (#1584).
     """
-    name, _, version = _pin().partition("@")
-    script = (
-        "import json;"
-        "from rhiza_task.cli import load_tasks; load_tasks();"
-        "from rhiza_task.spec import REGISTRY;"
-        "print(json.dumps({k: list(v.needs) for k, v in REGISTRY.items()}))"
-    )
-    proc = subprocess.run(  # nosec B603
-        [
-            "uv",
-            "run",
-            "--quiet",
-            "--no-project",
-            "--with",
-            f"{name}=={version}" if version else name,
-            "python",
-            "-c",
-            script,
-        ],
-        cwd=_ROOT,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if proc.returncode != 0:
-        pytest.skip("could not read the rhiza-task registry")
-    registry = json.loads(proc.stdout)
+    registry = require_registry()
 
     book = next((v for k, v in registry.items() if k.endswith("book")), None)
     assert book is not None, "`book` is not a registered task"
-    missing = [n for n in book if f"python:{n}" not in registry and n not in registry]
+    missing = [n for n in book if not resolves(registry, "python", n)]
     assert not missing, (
         f"`book` names {missing}, which resolve to no registered task — the failure the no-op `::` "
         f"anchors in book.mk existed to prevent"

--- a/tests/registry.py
+++ b/tests/registry.py
@@ -1,0 +1,150 @@
+"""One reader for the pinned CLI's task registry, with the control that keeps it honest.
+
+Four modules across three test packages need the same answer -- does this task name resolve,
+and what does it depend on -- and until #1583 each had its own copy of the subprocess that
+asks. Three copies drifted independently, and one of them reached into another test module
+for the helpers it was missing:
+
+    from tests.bundles.test_layer_contract import _registry, _resolves
+
+That import is what #1583 is about. Two ``test_*`` modules coupled through private names
+neither declared, sharing an ``lru_cache`` across a boundary that does not exist as far as
+either file's reader is concerned.
+
+**The deeper problem was #1584, and it is why this module raises rather than returns.** The
+old helper answered an unreachable CLI and an empty registry the *same* way -- with ``{}`` --
+so every caller wrote ``if not registry: pytest.skip(...)`` and a registry that loaded fine
+but came back empty was reported as an environment problem. That is a derived expectation
+narrowing to nothing while the suite stays green, which is the exact failure #1580 hit twice.
+So the two outcomes are separated here:
+
+- **Unavailable** -- no pin, no ``uv``, no network -- is an outage. :func:`require` skips,
+  and says which.
+- **Reachable but implausible** -- the registry loaded and does not contain the tasks this
+  repo is built on -- is a **failure**, raised from :func:`load` where no caller can mistake
+  it for a skip.
+
+The anchors in :data:`_ANCHORS` are that second check. They are deliberately tasks whose
+disappearance would be a breaking change upstream rather than a routine rename, so this stays
+a smoke test of the derivation and not a second copy of the layer contract.
+"""
+
+from __future__ import annotations
+
+import functools
+import json
+import re
+import subprocess  # nosec B404 - fixed argument vectors
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+
+# Read from the shim rather than hardcoded, so this follows the pin instead of drifting from
+# it -- the same reason every other module here reads it out of the Makefile.
+_PIN = re.compile(r"^RHIZA_TASK \?= (\S+)", re.MULTILINE)
+
+# `load_tasks` is the CLI's own entry-point walk. Naming task modules by hand instead is how
+# `book`'s `paper` prerequisite went unseen when rhiza-task 1.1.0 added it (#1580).
+_SCRIPT = (
+    "import json;"
+    "from rhiza_task.cli import load_tasks; load_tasks();"
+    "from rhiza_task.spec import REGISTRY;"
+    "print(json.dumps({k: list(v.needs) for k, v in REGISTRY.items()}))"
+)
+
+# Tasks whose absence means the registry did not load properly, rather than that rhiza-task
+# reorganised itself: the Python layer's aggregate, a neutral task, and a layer-scoped gate.
+# One of each kind, because a derivation can narrow to *part* of the registry -- which is
+# precisely what a hand-written module list did.
+_ANCHORS = ("python:all", "fmt", "python:test")
+
+
+def pin() -> str | None:
+    """Return the ``rhiza-task@X.Y.Z`` spec the root Makefile pins.
+
+    Returns:
+        The spec, or None when the Makefile no longer pins one.
+    """
+    match = _PIN.search((_ROOT / "Makefile").read_text(encoding="utf-8"))
+    return match.group(1) if match else None
+
+
+@functools.lru_cache(maxsize=1)
+def load() -> dict[str, list[str]] | None:
+    """Return the registry as ``{key: [prerequisite, ...]}``, or None when unreachable.
+
+    Keys are ``layer:name`` for a layer-scoped task and a bare ``name`` for a neutral one,
+    which is how :mod:`rhiza_task.spec` stores them: three layers may each define ``test``,
+    and which one answers is decided per repository.
+
+    The failure *outcome* is cached along with the success, so a run without a network pays
+    for one ``uv`` invocation rather than one per caller.
+
+    Returns:
+        The registry, or None when there is no pin or the CLI could not be run.
+
+    Raises:
+        AssertionError: When the CLI ran but the registry does not contain :data:`_ANCHORS`.
+            Deliberately not a skip -- see this module's docstring.
+    """
+    spec = pin()
+    if spec is None:
+        return None
+    name, _, version = spec.partition("@")
+    proc = subprocess.run(  # nosec B603
+        [
+            "uv",
+            "run",
+            "--quiet",
+            "--no-project",
+            "--with",
+            f"{name}=={version}" if version else name,
+            "python",
+            "-c",
+            _SCRIPT,
+        ],
+        cwd=_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return None
+    registry: dict[str, list[str]] = json.loads(proc.stdout)
+
+    missing = [anchor for anchor in _ANCHORS if anchor not in registry]
+    assert not missing, (
+        f"{spec}'s task registry loaded but is missing {missing}, so every test deriving "
+        f"expectations from it is measuring less than it reads. Either the pin is broken or "
+        f"`load_tasks` stopped importing what it used to -- both are regressions, not "
+        f"reasons to skip (#1584)."
+    )
+    return registry
+
+
+def require() -> dict[str, list[str]]:
+    """Return the registry, skipping the calling test when the CLI cannot be reached.
+
+    Returns:
+        The registry, guaranteed non-empty and carrying every anchor.
+    """
+    registry = load()
+    if registry is None:
+        pytest.skip(f"could not read the task registry from {pin() or 'an unpinned CLI'}")
+    return registry
+
+
+def resolves(registry: dict[str, list[str]], layer: str, task: str) -> bool:
+    """Report whether ``task`` resolves for ``layer``: layer-scoped first, then neutral.
+
+    Args:
+        registry: The task registry.
+        layer: ``python``, ``rust`` or ``go``.
+        task: A task name.
+
+    Returns:
+        True when some registered task answers that name for that layer.
+    """
+    return f"{layer}:{task}" in registry or task in registry

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,99 @@
+"""The positive control for every test that derives an expectation from the pinned CLI.
+
+#1580 bumped rhiza-task across two majors and broke three tests. Neither break was the bump's
+fault: both were derivations that **narrowed** instead of failing.
+
+- Three modules read the task registry after importing a hand-written list of task modules.
+  1.1.0 gave ``book`` a ``paper`` prerequisite, ``paper`` lived in a module no list named, and
+  the assertion reported a missing task where the gap was its own fixture.
+- ``TestToolClaims`` decided which tools "run" by text-scanning the CLI's source, so a new
+  docstring *explaining* that pip-audit is not wired up registered as an invocation.
+
+The second surfaced as a red test only because it already had a control --
+``test_the_invocation_scan_found_something``. Without that, the scan could have returned an
+empty set and every doc-claim assertion would have passed vacuously. The registry derivations
+had no equivalent, and failed loudly this time only by luck: the narrowed registry happened to
+be missing a name that another assertion looked at. A narrowing in a direction nothing checked
+would have been silent.
+
+This module is that missing control, and it is deliberately in ``tests/`` root rather than
+beside one of the callers: the property belongs to :mod:`tests.registry`, which all of them
+now share, not to any one of them.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests import registry as reg
+
+
+def test_the_pin_is_readable() -> None:
+    """Everything here rests on finding the pin in the shim; assert that first."""
+    assert reg.pin(), (
+        "the root Makefile no longer pins RHIZA_TASK, so every registry-derived test in this "
+        "suite silently degrades to a skip"
+    )
+
+
+def test_the_registry_loads_and_carries_its_anchors() -> None:
+    """The registry must be reachable and plausible -- the control the derivations lacked.
+
+    :func:`tests.registry.load` asserts the anchors itself, so reaching this line at all is
+    most of the property. Restated here as a named test so a failure says *this* rather than
+    surfacing inside whichever unrelated assertion happened to touch the registry first.
+    """
+    loaded = reg.load()
+    if loaded is None:
+        pytest.skip(f"could not read the task registry from {reg.pin()}")
+    assert len(loaded) > 20, (
+        f"the registry holds only {len(loaded)} task(s), which is fewer than any released "
+        f"rhiza-task has carried. A derivation this thin measures almost nothing (#1584)."
+    )
+
+
+def test_both_kinds_of_key_are_present() -> None:
+    """Layer-scoped and neutral keys must both appear, because a narrowing can drop one.
+
+    This is the shape of the #1580 failure rather than a restatement of the anchor list: a
+    partial set of task modules yields a registry that looks populated while missing a whole
+    category. ``fmt`` is neutral (it answers to its bare name, which is what ``core`` was) and
+    ``python:test`` is layer-scoped, so requiring one of each catches a derivation that
+    resolved only half the registry.
+    """
+    loaded = reg.require()
+    assert any(":" in key for key in loaded), "no layer-scoped keys at all, so no layer's tasks loaded"
+    assert any(":" not in key for key in loaded), "no neutral keys at all, so the language-neutral tasks did not load"
+
+
+def test_resolves_prefers_the_layer_then_falls_back_to_neutral() -> None:
+    """``resolves`` must answer for both key shapes, or half the callers are wrong.
+
+    ``test`` exists per layer, ``fmt`` only neutrally, and a caller asking about either must
+    get True. A ``resolves`` that only checked the layer-scoped form would silently report
+    every neutral task as missing.
+    """
+    loaded = reg.require()
+    assert reg.resolves(loaded, "python", "test"), "a layer-scoped gate must resolve for its own layer"
+    assert reg.resolves(loaded, "python", "fmt"), "a neutral task must resolve for any layer"
+    assert not reg.resolves(loaded, "python", "definitely-not-a-task"), (
+        "resolves() answers True for a name nothing registers, so every assertion built on it is vacuous"
+    )
+
+
+def test_an_unavailable_cli_is_a_skip_and_not_an_empty_answer(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``require`` must skip when the CLI is unreachable, never hand back an empty registry.
+
+    The old helper returned ``{}`` for both "could not run the CLI" and "the CLI said
+    nothing", which is what let a narrowed derivation read as an outage. Asserted by
+    monkeypatching the loader, because the real unavailable case cannot be produced on a
+    machine that has ``uv`` -- and ``env -i`` breaks the network in this sandbox rather than
+    only the PATH.
+    """
+    monkeypatch.setattr(reg, "load", lambda: None)
+    with pytest.raises(BaseException, match="could not read the task registry") as excinfo:
+        reg.require()
+    assert excinfo.type is pytest.skip.Exception, (
+        f"require() raised {excinfo.type.__name__} rather than skipping, so an offline run "
+        f"fails the suite instead of reporting the gate as unmeasured"
+    )


### PR DESCRIPTION
Closes #1583. Closes #1584.

Two issues, one cause: **four** modules needed the same answer from the pinned CLI, three of them had their own copy of the subprocess that asks, and none of the copies could tell *"the CLI is unreachable"* from *"the registry came back empty"*.

## The shared reader (#1583)

`tests/bundles/test_bundle_combinations.py` reached into another test module for the helpers it didn't have:

```python
from tests.bundles.test_layer_contract import _registry, _resolves
```

Two `test_*` modules coupled through private names neither declared, sharing an `lru_cache` across a boundary that does not exist as far as either file's reader is concerned.

`tests/registry.py` is the home for both now — and **three** copies of the subprocess collapse into it. `test_layer_contract`, `test_book_targets` and `test_ci_workflow` each had one, and they had already begun to drift: two skipped on a CLI failure, the third raised, and only one carried a control. **167 lines out, 62 in.** Five imports in `test_layer_contract` and two in `test_ci_workflow` became unused on the way — the duplication showing itself as it left — and `test_book_targets`'s `_pin` helper went too, dead once the subprocess it fed was gone.

Two things found while moving it. Neither is the point, both are worth the diff:

- **A stray `@pytest.mark.parametrize("layer", [...])` sat on `_registry`**, a module-level private helper. pytest only reads marks on collected items, so it had been inert since whatever refactor stranded it there.
- **`test_book_targets` open-coded `resolves()`** as `f"python:{n}" not in registry and n not in registry`. It calls the shared helper now, so the layer-then-neutral fallback has one definition rather than two.

## The control (#1584)

#1580 broke three tests, and neither break was the bump's fault: both were derivations that **narrowed** instead of failing. The pip-audit one surfaced as a red test only because `TestToolClaims` already had `test_the_invocation_scan_found_something` — without it, the scan could have returned an empty set and every doc-claim assertion would have passed vacuously. The registry derivations had no equivalent, and failed loudly that time **only by luck**: the narrowed registry happened to be missing a name another assertion looked at. A narrowing in a direction nothing checked would have been silent.

So the reader separates the two outcomes the old helper conflated:

| outcome | old | new |
|---|---|---|
| no pin, no `uv`, no network | `{}` → caller skips | `require()` skips, naming the pin |
| CLI ran, registry implausible | `{}` → caller **skips** | **fails**, raised from `load()` |

`_ANCHORS` is that second check — `python:all`, `fmt`, `python:test`: one aggregate, one neutral task, one layer-scoped gate. Three kinds, because a derivation can narrow to *part* of the registry, which is exactly what a hand-written module list did.

`tests/test_registry.py` holds the property, deliberately at `tests/` root rather than beside any one caller — it belongs to the reader they now share. It also pins that `require()` **skips** rather than returning an empty dict, monkeypatched because the real unavailable case can't be produced on a machine that has `uv`: `env -i` breaks the network in this sandbox rather than only the PATH.

### One more derivation got a control

`_cli_task_names` in `test_doc_consistency`. Worth being precise about what it fixes, since the gate was never actually vacuous: `_defined_make_targets` is CLI tasks *plus* explicit rules, so an unreachable CLI makes the mention gate **fail** — on every document that says `make test`, with a message about the *documentation* being wrong. The control doesn't add safety; it adds a failure that names the real cause instead of sending the reader off to edit correct prose.

I checked the other CLI-derived collections rather than assuming: `_cli_task_sources`/`_invoked_tools` and the `test_gate_scope` folder settings already have controls, and `test_bundle_cli_targets`'s `cli_tasks` fixture fails safe (a narrowed task set makes every `missing` assertion go red).

## Verification

`make all` green — **1478 passed** (up 6 net; 28 assertions added, the removed duplicates were parametrised over the same registry), every gate `ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
