### PR TITLE
test: enforce the two suite invariants that were holding by convention

### DIFF
--- a/tests/integration/test_docs_targets.py
+++ b/tests/integration/test_docs_targets.py
@@ -47,7 +47,18 @@ def _cli_setting(name: str) -> str:
     )
     if proc.returncode != 0:
         pytest.skip(f"could not read {name} from the CLI: {proc.stderr.strip()[:160]}")
-    return " ".join(proc.stdout.split())
+    value = " ".join(proc.stdout.split())
+    # The control, and it belongs here rather than in each caller (#1588). A setting that
+    # resolves to nothing is not a skip -- the CLI answered -- but it makes a *negative*
+    # assertion on the value pass for the wrong reason: `test_extra_packages_are_bare_specs`
+    # asserts `"--with" not in value`, which an empty string satisfies. Its sibling asserting
+    # `"mkdocstrings" in value` fails safe, so before this the same helper fed one assertion
+    # that could not be fooled and one that could.
+    assert value, (
+        f"the CLI resolved {name!r} to an empty value. Every assertion below is about what "
+        f"that setting *contains*, so an empty answer makes the negative ones vacuous."
+    )
+    return value
 
 
 def test_book_build_still_gets_mkdocstrings() -> None:

--- a/tests/registry.py
+++ b/tests/registry.py
@@ -3,13 +3,19 @@
 Four modules across three test packages need the same answer -- does this task name resolve,
 and what does it depend on -- and until #1583 each had its own copy of the subprocess that
 asks. Three copies drifted independently, and one of them reached into another test module
-for the helpers it was missing:
+for the helpers it was missing: ``test_bundle_combinations`` imported ``_registry`` and
+``_resolves`` from ``tests.bundles.test_layer_contract``, by their private names.
 
-    from tests.bundles.test_layer_contract import _registry, _resolves
+That is what #1583 is about. Two ``test_*`` modules coupled through private names neither
+declared, sharing an ``lru_cache`` across a boundary that does not exist as far as either
+file's reader is concerned.
 
-That import is what #1583 is about. Two ``test_*`` modules coupled through private names
-neither declared, sharing an ``lru_cache`` across a boundary that does not exist as far as
-either file's reader is concerned.
+The import is described here rather than quoted, deliberately (#1587). Quoted as a code
+block it was the only occurrence of that pattern left in the tree, and textually identical
+to the thing it replaced -- so the guard in
+``tests/test_suite_structure.py`` would have needed a carve-out for the very module that
+documents the rule, keyed on a filename, exempting exactly the file where a regression
+would be least visible.
 
 **The deeper problem was #1584, and it is why this module raises rather than returns.** The
 old helper answered an unreachable CLI and an empty registry the *same* way -- with ``{}`` --

--- a/tests/test_suite_structure.py
+++ b/tests/test_suite_structure.py
@@ -1,0 +1,261 @@
+"""Properties of the test suite itself, enforced rather than left to review.
+
+Two invariants live here, both established by hand and both previously unguarded — which is
+the whole reason this module exists. An invariant that holds because four people remembered
+is one edit away from not holding.
+
+**No test module may import another** (#1583, guarded by #1587). ``test_bundle_combinations``
+used to reach into ``test_layer_contract`` for two private helpers, coupling the files through
+names neither declared and sharing an ``lru_cache`` across a boundary invisible to either
+file's reader. #1586 moved the helpers to :mod:`tests.registry`; this guards the result.
+
+**Every module that derives an expectation from the pinned CLI must declare its control**
+(#1584, guarded by #1588). This is the harder one, and the design is worth reading before
+editing.
+
+The failure mode is a derivation that **narrows** instead of erroring: the CLI answers with
+less than it used to, the expectation set shrinks to match, and the assertion built on it
+passes while measuring nothing. #1580 hit that twice in one version bump. The tell is that
+both instances were *found by accident* — one because the narrowed registry happened to be
+missing a name another assertion looked at, the other because its module already had a
+control. Nothing was watching for the class.
+
+So each detected module names the control that protects it, and this module checks the name
+resolves to something real. Two dicts rather than one, because the detector is deliberately
+**over-inclusive**: it flags anything that runs a subprocess while mentioning the pin, which
+catches modules that merely run ``uvx`` for an unrelated tool. A detector that could miss a
+new deriver would be worse than one with written-down exceptions, so the false positives go
+in :data:`_NOT_DERIVERS` with a reason each.
+
+What this does *not* do is check that a control is correct — only that the author was made to
+name one. That is the honest limit of a structural check, and it is still the difference
+between a convention and a rule.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+_TESTS = _ROOT / "tests"
+
+# A test module importing another test module, which #1583 removed and #1587 made checkable.
+_CROSS_TEST_IMPORT = re.compile(r"^\s*(?:from|import)\s+tests\.[a-z_]+\.test_", re.MULTILINE)
+
+# How a module reaches the pinned CLI: reading the pin out of the shim, borrowing a helper
+# that does, or importing the shared reader.
+_TOUCHES_THE_PIN = re.compile(
+    r"RHIZA_TASK \\\?=|pinned_cli|_rhiza_task_requirement|from tests import registry|from tests\.registry import"
+)
+
+# An argv element that names uv as the runner. `--with` is the `uv run` form, `uvx`/`_UVX`
+# the direct one.
+_NAMES_UV = re.compile(r'"uvx"|_UVX|"--with"')
+
+# Every module the detector flags, mapped to the control that protects its derivation. The
+# value is a function name that must exist in that module -- so this cannot rot into a list of
+# names that no longer mean anything, which is the failure mode of every allowlist.
+_CONTROLS = {
+    # The anchors are checked inside `load` itself, so every importer inherits them.
+    "tests/registry.py": "load",
+    "tests/api/test_ci_workflow.py": "_gates_named_by_all",
+    "tests/bundles/test_bundle_combinations.py": "test_the_benchmark_task_is_registered",
+    "tests/bundles/test_layer_contract.py": "test_every_prerequisite_of_all_resolves",
+    "tests/integration/test_book_targets.py": "test_every_prerequisite_of_book_resolves",
+    # Not the registry: these read the CLI's own source text and assert a lower bound on what
+    # they find, which fails rather than passes when the derivation returns less.
+    "tests/bundles/test_go_layer_sync.py": "_cli_task_sources",
+    "tests/bundles/test_rust_layer_sync.py": "_cli_task_sources",
+    # Resolved settings. Each asserts the value is non-empty before asserting anything about
+    # its content -- see test_docs_targets's `_cli_setting`, where the ordering matters.
+    "tests/integration/test_docs_targets.py": "_cli_setting",
+    "tests/integration/test_marimo_targets.py": "test_the_notebook_folder_is_configurable_and_resolves",
+    "tests/utils/test_gate_scope.py": "test_source_folder_resolves_to_something",
+    "tests/docs/test_doc_consistency.py": "_invoked_tools",
+    # The fixture narrowing makes every `missing` assertion fail rather than pass, so the
+    # control is structural: there is no direction in which a thinner task list reads as green.
+    "tests/api/test_bundle_cli_targets.py": "cli_tasks",
+    # The control module for the shared reader. It is a deriver like any other -- it calls
+    # `load()` -- so it declares itself rather than being exempted for being the control.
+    "tests/test_registry.py": "test_the_registry_loads_and_carries_its_anchors",
+}
+
+# Modules the detector flags that do not derive anything from the pin. Each names the tool it
+# actually runs, because "it runs uvx" is the whole reason it was flagged.
+_NOT_DERIVERS = {
+    "tests/integration/test_sbom.py": "runs `uvx cyclonedx-bom`; the pin is not involved",
+    "tests/security/test_security_patterns.py": "runs `uvx bandit` out-of-tree; the pin is not involved",
+    # This module matches its own detector: `_NAMES_UV` and `_TOUCHES_THE_PIN` are literals in
+    # the source above. It reads files and never runs anything.
+    "tests/test_suite_structure.py": "holds the detector's own patterns as string literals",
+}
+
+
+def _modules() -> list[Path]:
+    """Return every Python file under ``tests/``.
+
+    Returns:
+        Absolute paths, sorted.
+    """
+    return sorted(_TESTS.rglob("*.py"))
+
+
+def _rel(path: Path) -> str:
+    """Return a path as the repo-relative string the dicts above are keyed by.
+
+    Args:
+        path: An absolute path inside the repository.
+
+    Returns:
+        The POSIX-style relative path.
+    """
+    return path.relative_to(_ROOT).as_posix()
+
+
+def _runs_a_subprocess(tree: ast.AST) -> bool:
+    """Report whether this module calls ``.run(...)`` anywhere.
+
+    Matched on the attribute alone rather than on ``subprocess.run``, so a module that aliases
+    the import is still caught.
+
+    Args:
+        tree: The parsed module.
+
+    Returns:
+        True when some ``.run()`` call is present.
+    """
+    return any(
+        isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "run"
+        for node in ast.walk(tree)
+    )
+
+
+def _derivers() -> list[str]:
+    """Return the modules that look like they derive something from the pinned CLI.
+
+    Over-inclusive by design -- see this module's docstring. A module qualifies two ways, and
+    the second is not a convenience: importing :mod:`tests.registry` derives from the CLI
+    *transitively*, with no subprocess of its own anywhere in the file. #1586 moved four
+    modules into exactly that shape, so a detector keyed on subprocesses alone would have
+    stopped seeing the majority of the derivations in this suite -- which
+    :func:`test_no_declaration_outlives_its_module` is what caught.
+
+    Returns:
+        Repo-relative paths, sorted.
+    """
+    found = []
+    for path in _modules():
+        text = path.read_text(encoding="utf-8")
+        borrows_the_reader = "from tests.registry import" in text or "from tests import registry" in text
+        runs_it_directly = _runs_a_subprocess(ast.parse(text)) and bool(
+            _TOUCHES_THE_PIN.search(text) or _NAMES_UV.search(text)
+        )
+        if borrows_the_reader or runs_it_directly:
+            found.append(_rel(path))
+    return found
+
+
+def _defines(path: Path, name: str) -> bool:
+    """Report whether a module defines a function or method of this name.
+
+    Args:
+        path: The module to read.
+        name: The function name to look for, at any nesting depth.
+
+    Returns:
+        True when some ``def``/``async def`` in the module carries that name.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    return any(
+        isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and node.name == name for node in ast.walk(tree)
+    )
+
+
+@pytest.mark.parametrize("module", _modules(), ids=_rel)
+def test_no_test_module_imports_another(module: Path) -> None:
+    """A test module must not import from another test module (#1583).
+
+    Shared helpers belong in a plain module -- :mod:`tests.registry`, :mod:`tests.util` -- not
+    in whichever ``test_*`` file happened to need them first. The import that prompted this
+    also shared an ``lru_cache`` between two files, which is a state dependency neither one
+    declares.
+    """
+    text = module.read_text(encoding="utf-8")
+    offenders = _CROSS_TEST_IMPORT.findall(text)
+    assert not offenders, (
+        f"{_rel(module)} imports from another test module: {[o.strip() for o in offenders]}. "
+        f"Move the shared helper into a non-test module (tests/registry.py, tests/util.py) and "
+        f"import it from both (#1583)."
+    )
+
+
+def test_the_cross_import_guard_can_actually_fire() -> None:
+    """Positive control for the guard above, which currently has nothing to find.
+
+    An assertion that passes because its pattern matches nothing is the exact defect this
+    file exists to prevent, and the guard above is in that position: the tree is clean, so it
+    would pass just as happily with a broken regex. Asserted against a literal instead.
+    """
+    assert _CROSS_TEST_IMPORT.search("from tests.bundles.test_layer_contract import _registry"), (
+        "the cross-test-import pattern no longer matches the import it was written for, so "
+        "test_no_test_module_imports_another is passing vacuously"
+    )
+    assert not _CROSS_TEST_IMPORT.search("from tests.registry import require"), (
+        "the pattern matches an import of a non-test helper, which is the thing #1586 moved "
+        "*to* -- it would fail the suite for doing the right thing"
+    )
+
+
+@pytest.mark.parametrize("module", _derivers())
+def test_every_cli_derivation_declares_its_control(module: str) -> None:
+    """A module reading the pinned CLI must name the control that protects it (#1584).
+
+    Failing here means one of three things, and the fix differs:
+
+    - the module derives an expectation from the CLI -> give it a control that fails when the
+      derivation returns less, and name it in ``_CONTROLS``;
+    - it runs ``uvx`` for an unrelated tool -> record it in ``_NOT_DERIVERS`` with which tool;
+    - it no longer touches the CLI at all -> remove its entry.
+    """
+    assert module in _CONTROLS or module in _NOT_DERIVERS, (
+        f"{module} runs the pinned CLI (or uv) but declares no control. A derivation that "
+        f"narrows instead of erroring passes while measuring nothing -- #1580 hit that twice "
+        f"in one bump. Add it to _CONTROLS naming the test or helper that guards it, or to "
+        f"_NOT_DERIVERS if it only runs an unrelated tool."
+    )
+
+
+@pytest.mark.parametrize("module", sorted(_CONTROLS))
+def test_each_declared_control_exists(module: str) -> None:
+    """The named control must be a real function, or ``_CONTROLS`` is decoration.
+
+    This is what stops the dict becoming the kind of allowlist that outlives what it lists.
+    Renaming a control without updating its entry fails here rather than silently leaving the
+    module unguarded.
+    """
+    path = _ROOT / module
+    assert path.is_file(), f"_CONTROLS names {module}, which does not exist"
+    assert _defines(path, _CONTROLS[module]), (
+        f"_CONTROLS says {module} is guarded by {_CONTROLS[module]!r}, but that module defines "
+        f"no such function. Either the control was renamed or it was removed -- if removed, the "
+        f"derivation is now unguarded."
+    )
+
+
+@pytest.mark.parametrize("module", sorted(_CONTROLS) + sorted(_NOT_DERIVERS))
+def test_no_declaration_outlives_its_module(module: str) -> None:
+    """Both dicts must describe modules the detector still flags.
+
+    A stale entry is not harmless: it is a claim that some file was reviewed for this property,
+    and the reader has no way to tell a current claim from one about a file that stopped
+    touching the CLI three refactors ago.
+    """
+    assert module in _derivers(), (
+        f"{module} is declared in _CONTROLS or _NOT_DERIVERS but no longer looks like it "
+        f"touches the pinned CLI. Drop the entry -- a declaration nobody can check reads as "
+        f"review that did not happen."
+    )


### PR DESCRIPTION
Closes #1587. Closes #1588.

Both invariants were established by hand and neither was guarded — one edit away from not holding. `tests/test_suite_structure.py` holds them now, and **building the second one found a live instance of the defect it guards against.**

## No test module imports another (#1587, guarding #1583)

#1586 removed the one cross-test import; #1587 pointed out why the invariant couldn't then be *guarded*. `tests/registry.py` quoted the removed import as a code block, making it the sole remaining match for the pattern and textually identical to what it replaced. A grep guard would have needed a carve-out for the module that documents the rule — keyed on a filename, exempting the one file where a regression would be least visible.

The citation is prose now and the guard exists. It carries its own positive control: the tree is clean, so `test_no_test_module_imports_another` would pass just as happily with a broken regex. `test_the_cross_import_guard_can_actually_fire` asserts the pattern still matches the import it was written for, and still ignores an import of a *non-test* helper — the thing #1586 moved to.

## Every CLI derivation declares its control (#1588, guarding #1584)

`_CONTROLS` maps each detected module to the function that protects it, and `test_each_declared_control_exists` resolves that name against the module's AST. That's what stops it becoming the kind of allowlist that outlives what it lists: rename a control without updating its entry and this fails, rather than silently leaving the module unguarded. `_NOT_DERIVERS` holds the detector's false positives with the tool each actually runs. Both dicts are checked for staleness in the other direction too — an entry naming a module that no longer touches the CLI is a claim of review that didn't happen.

**The detector is deliberately over-inclusive** (a missed deriver is worse than a written-down exception), and its two qualifying paths are not symmetric in a way worth knowing: importing `tests.registry` derives from the CLI **transitively**, with no subprocess anywhere in the file. #1586 moved four modules into exactly that shape, so a detector keyed on subprocesses alone would have stopped seeing most of the derivations in this suite. `test_no_declaration_outlives_its_module` caught that while I was writing it — the guard failing on its own author's first draft is about the best evidence it works.

Three of the fifteen entries are worth reading as examples of what a control can be, since it isn't always a named test:

| module | control | why it counts |
|---|---|---|
| `tests/registry.py` | `load` | the anchor check is inside it, so every importer inherits it |
| `test_rust_layer_sync.py` | `_cli_task_sources` | asserts `count(...) >= 2` — a lower bound fails when the derivation returns less |
| `test_bundle_cli_targets.py` | `cli_tasks` | structural: a thinner task list makes every `missing` assertion fail, so there's no direction in which it reads as green |

## The live instance

`test_docs_targets._cli_setting` fed two assertions:

```python
assert "mkdocstrings" in _cli_setting("mkdocs_extra_packages")   # fails on an empty answer
assert "--with" not in _cli_setting("mkdocs_extra_packages")      # PASSES on an empty answer
```

Same helper, one assertion that can't be fooled and one that can — the #1584 class, still live. Found by enumerating derivations to build the dict, not by reading the file. The non-empty check now lives in the helper, so both callers inherit it.

## Verification

`make all` green — **1600 passed**, every gate `ok`.

## Note on #1589

Not in this PR. The fence is generated: `update_readme_help.py` rewrites the whole span between the markers *including* the fence lines (`new_section = f"{START_MARKER}\n\`\`\`\n{help_output}\`\`\`\n{END_MARKER}"`), so a hand-tag here is overwritten by the next `make fmt`. I confirmed that in the hook's source rather than assuming it. The fix belongs in rhiza-hooks; PR to follow there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
