### PR TITLE
fix: stop a failed conda job stranding the GitHub release as a draft

### DIFF
--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -665,7 +665,24 @@ jobs:
     name: Finalise Release
     runs-on: ubuntu-latest
     needs: [tag, pypi, conda, devcontainer]
-    if: needs.pypi.result == 'success' || needs.conda.result == 'success' || needs.devcontainer.result == 'success'
+    # `!cancelled() &&` is what makes the rest of this condition mean anything (#1537).
+    # GitHub combines a job's own `if` with an implicit `success()` over every entry in
+    # `needs` *unless* the expression names a status function -- so the OR below was
+    # evaluated only in runs where conda had already succeeded, and a conda failure skipped
+    # this job however true the OR was. That is not theoretical: releasing jointview v0.2.0,
+    # PyPI published successfully, grayskull 404'd on metadata that had not propagated, and
+    # the GitHub release was stranded as the draft `untagged-547fe31ec1ed6de3ef9b` holding
+    # SBOM and provenance assets that never became visible.
+    #
+    # `!cancelled()` rather than `always()`, deliberately: `always()` would finalise a
+    # release during a run somebody had cancelled, which is the one case where publishing is
+    # certainly wrong. A cancelled run still skips this job.
+    #
+    # The OR is unchanged, so the failure modes it encodes are too: if every publishing job
+    # fails or is skipped there is nothing to finalise, and this job skips. Recipe generation
+    # is the only one of the three that is a downstream convenience -- the workflow header
+    # has always called it optional, and now the failure path agrees.
+    if: ${{ !cancelled() && (needs.pypi.result == 'success' || needs.conda.result == 'success' || needs.devcontainer.result == 'success') }}
     permissions:
       contents: write   # Needed to undraft/publish the GitHub release
     steps:

--- a/bundles/github/.github/workflows/rhiza_release.yml
+++ b/bundles/github/.github/workflows/rhiza_release.yml
@@ -653,7 +653,24 @@ jobs:
     name: Finalise Release
     runs-on: ubuntu-latest
     needs: [tag, pypi, conda, devcontainer]
-    if: needs.pypi.result == 'success' || needs.conda.result == 'success' || needs.devcontainer.result == 'success'
+    # `!cancelled() &&` is what makes the rest of this condition mean anything (#1537).
+    # GitHub combines a job's own `if` with an implicit `success()` over every entry in
+    # `needs` *unless* the expression names a status function -- so the OR below was
+    # evaluated only in runs where conda had already succeeded, and a conda failure skipped
+    # this job however true the OR was. That is not theoretical: releasing jointview v0.2.0,
+    # PyPI published successfully, grayskull 404'd on metadata that had not propagated, and
+    # the GitHub release was stranded as the draft `untagged-547fe31ec1ed6de3ef9b` holding
+    # SBOM and provenance assets that never became visible.
+    #
+    # `!cancelled()` rather than `always()`, deliberately: `always()` would finalise a
+    # release during a run somebody had cancelled, which is the one case where publishing is
+    # certainly wrong. A cancelled run still skips this job.
+    #
+    # The OR is unchanged, so the failure modes it encodes are too: if every publishing job
+    # fails or is skipped there is nothing to finalise, and this job skips. Recipe generation
+    # is the only one of the three that is a downstream convenience -- the workflow header
+    # has always called it optional, and now the failure path agrees.
+    if: ${{ !cancelled() && (needs.pypi.result == 'success' || needs.conda.result == 'success' || needs.devcontainer.result == 'success') }}
     permissions:
       contents: write   # Needed to undraft/publish the GitHub release
     steps:

--- a/tests/api/test_release_workflow.py
+++ b/tests/api/test_release_workflow.py
@@ -138,3 +138,92 @@ class TestReleaseWorkflowStructure:
         upload_step = next((s for s in steps if s.get("name") == "Upload SBOM artifacts"), None)
         assert upload_step is not None, "Upload SBOM artifacts step must exist"
         assert "sbom.cdx.json.sigstore.json" in upload_step["with"]["path"]
+
+
+# ---------------------------------------------------------------------------
+# #1537 -- asserted against *both* copies of the release workflow
+# ---------------------------------------------------------------------------
+
+# The live workflow is what runs here; the bundle copy is what every `github` consumer
+# gets. They are real files rather than symlinks (Actions will not run a symlinked
+# workflow), so a fix applied to one and not the other leaves the bug shipped. This is the
+# pattern test_release_tag_reachability.py already uses for the same pair.
+_RELEASE_WORKFLOWS = [
+    Path(".github") / "workflows" / "rhiza_release.yml",
+    Path("bundles") / "github" / ".github" / "workflows" / "rhiza_release.yml",
+]
+
+
+def _finalise_condition(root: Path, relative: Path) -> str:
+    """Return the ``if`` expression on a release workflow's finalise-release job.
+
+    Args:
+        root: Repository root.
+        relative: Path to the workflow, relative to the root.
+
+    Returns:
+        The condition as written, or the empty string when the job has none.
+    """
+    workflow = yaml.safe_load((root / relative).read_text(encoding="utf-8"))
+    return str(workflow["jobs"]["finalise-release"].get("if", ""))
+
+
+@pytest.mark.parametrize("relative", _RELEASE_WORKFLOWS, ids=lambda p: p.as_posix())
+def test_finalise_release_survives_a_failed_conda_job(root, relative):
+    """The condition must name a status function, or the OR inside it is unreachable (#1537).
+
+    GitHub combines a job's own ``if`` with an implicit ``success()`` over every entry in
+    ``needs`` **unless** the expression names one of ``always()``, ``cancelled()``,
+    ``failure()`` or ``success()``. Without one, the OR is evaluated only in runs where conda
+    already succeeded -- so a conda failure skipped ``finalise-release`` however true the OR
+    was. Releasing jointview v0.2.0 is the record of it: PyPI published, grayskull 404'd on
+    metadata that had not propagated, and the release was stranded as the draft
+    ``untagged-547fe31ec1ed6de3ef9b`` holding SBOM and provenance assets nobody could see.
+
+    ``test_finalise_release_includes_conda_signal`` cannot catch this, and that is the point
+    worth remembering: an ``if`` naming ``needs.conda.result`` reads as though it handles a
+    conda failure, and looks identical whether or not it can ever be reached.
+    """
+    condition = _finalise_condition(root, relative)
+    assert any(fn in condition for fn in ("cancelled()", "always()", "failure()")), (
+        f"{relative.as_posix()}: finalise-release's `if` is {condition!r}, which names no "
+        f"status function -- so GitHub adds an implicit success() over needs and a failed "
+        f"`conda` job skips the release finalisation regardless (#1537)."
+    )
+
+
+@pytest.mark.parametrize("relative", _RELEASE_WORKFLOWS, ids=lambda p: p.as_posix())
+def test_finalise_release_is_not_unconditional(root, relative):
+    """``always()`` would finalise a release during a run somebody cancelled.
+
+    The counterpart to the test above, and why the fix is ``!cancelled()`` rather than the
+    more obvious ``always()``: a cancelled release run is the one case where publishing is
+    certainly not wanted, and ``always()`` ignores exactly that.
+    """
+    condition = _finalise_condition(root, relative)
+    assert "always()" not in condition, (
+        f"{relative.as_posix()}: finalise-release uses always(), so cancelling a release run "
+        f"still publishes the GitHub release. Use `!cancelled()`, which skips on cancellation "
+        f"but survives a failed conda job (#1537)."
+    )
+
+
+@pytest.mark.parametrize("relative", _RELEASE_WORKFLOWS, ids=lambda p: p.as_posix())
+def test_conda_waits_for_pypi_metadata_to_propagate(root, relative):
+    """Grayskull must retry, because PyPI's index lags the upload it just accepted.
+
+    The other half of #1537, and the half that was already fixed before the issue was
+    revisited. A first release has no existing PyPI entry to fall back on, so grayskull 404s
+    on metadata that appears minutes later. Asserted because a retry loop is exactly the kind
+    of thing a later simplification removes as noise -- it reads as defensive clutter until
+    the release it protects is the one that fails.
+    """
+    workflow = yaml.safe_load((root / relative).read_text(encoding="utf-8"))
+    commands = "\n".join(_step_commands(workflow["jobs"]["conda"]))
+    lost_the_retry = (
+        f"{relative.as_posix()}: the conda job no longer retries grayskull. PyPI metadata for "
+        f"a just-published version can lag the upload by minutes, and a first release has "
+        f"nothing to fall back on (#1537)."
+    )
+    assert "MAX_ATTEMPTS" in commands, lost_the_retry
+    assert "sleep" in commands, lost_the_retry


### PR DESCRIPTION
Closes #1537.

The issue offered two suggestions. **The first was already in place** — the conda job retries grayskull five times with 60s backoff, because PyPI's index lags the upload it just accepted. The second was not, and it is the half that caused the damage.

## The bug is in a condition that looks like it already handles this

```yaml
finalise-release:
    needs: [tag, pypi, conda, devcontainer]
    if: needs.pypi.result == 'success' || needs.conda.result == 'success' || needs.devcontainer.result == 'success'
```

GitHub combines a job's own `if` with an implicit `success()` over **every** entry in `needs` unless the expression names one of `always()`, `cancelled()`, `failure()` or `success()`. This one named none — so the OR was only ever evaluated in runs where conda had *already* succeeded, and a conda failure skipped the job however true the OR was.

That's on record rather than deduced. From the issue's own evidence, releasing `jointview@v0.2.0`:

| Job | Result |
|---|---|
| Publish to PyPI | **success** — wheel + sdist uploaded |
| Generate Conda Recipe | **failure** — grayskull 404 on metadata that returns 200 now |
| Finalise Release | **skipped** |

The OR was true and the job was skipped anyway. The release was left as the draft `untagged-547fe31ec1ed6de3ef9b`, holding SBOM and provenance assets that never became visible. The package was installable; the release looked like it had failed.

## `!cancelled()`, not `always()`

```yaml
if: ${{ !cancelled() && (needs.pypi.result == 'success' || needs.conda.result == 'success' || needs.devcontainer.result == 'success') }}
```

`always()` is the more obvious spelling and it's wrong here: it would finalise a release during a run somebody had **cancelled**, which is the one case where publishing is certainly not wanted. The OR is otherwise untouched, so its own failure modes are preserved — if every publishing job fails or skips, there is nothing to finalise and this job still skips.

## Both copies

The live workflow is what runs here; `bundles/github/.github/workflows/rhiza_release.yml` is what every `github` consumer gets. They're real files rather than symlinks — Actions won't run a symlinked workflow — so a fix in one is a bug shipped from the other.

## Three guards, over both copies

Parametrised over the pair, following the pattern `test_release_tag_reachability.py` already uses for it:

- **the `if` must name a status function.** `test_finalise_release_includes_conda_signal` already asserted `needs.conda.result == 'success'` appears in the condition — and passed throughout, which is precisely why this survived. An `if` mentioning `needs.conda.result` reads as though it handles a conda failure and looks identical whether or not it can ever be reached.
- **it must not be `always()`**, so cancelling a release run still cancels it.
- **the conda job must keep retrying.** A retry loop reads as defensive clutter right up until the release it protects is the one that fails, which makes it exactly what a later simplification deletes as noise.

## Verification

`make all` green — **1606 passed**, every gate `ok`. Both conditions parse and are identical:

```
.github/workflows/rhiza_release.yml                     -> ${{ !cancelled() && (...) }}
bundles/github/.github/workflows/rhiza_release.yml      -> ${{ !cancelled() && (...) }}
```

What this PR cannot prove is the fix end-to-end: the failure mode needs a real release with a slow PyPI index. The guards assert the condition's *shape*, which is where the defect was, and actionlint accepts both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
