### PR TITLE
fix: link the compiled paper from the book, and guard the two ways it goes missing

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,5 +53,7 @@ nav:
     - ADR-0008 Use Marimo for Interactive Notebooks: adr/0008-use-marimo-for-interactive-notebooks.md
     - ADR-0009 Use Pre-commit Hooks for Code Quality: adr/0009-use-pre-commit-hooks-for-code-quality.md
     - ADR-0010 Layered Bundle and Profile Model: adr/0010-layered-bundle-profile-model.md
+    - ADR-0011 Replace the Synced Make Layer with a Pinned CLI: adr/0011-replace-the-synced-make-layer-with-a-pinned-cli.md
   - Notebooks:
     - Rhiza: notebooks/rhiza.html
+  - Paper: paper/rhiza.pdf

--- a/tests/integration/test_book_targets.py
+++ b/tests/integration/test_book_targets.py
@@ -77,3 +77,36 @@ def test_the_docs_folder_the_book_builds_from_exists() -> None:
     """
     assert (_ROOT / "mkdocs.yml").is_file(), "mkdocs.yml is missing, so `make book` has no config"
     assert (_ROOT / "docs").is_dir(), "docs/ is missing, so `make book` would build an empty site"
+
+
+def test_the_compiled_paper_is_reachable_from_the_book() -> None:
+    """A paper the book compiles must be linked from the nav, or nobody can find it.
+
+    ``book`` gained ``paper`` as a prerequisite in rhiza-task 1.1.0, and the PDF reaches the
+    site with no copy step at all -- ``paper_folder`` defaults to ``docs/paper``, which is
+    inside ``docs_dir``, so mkdocs sweeps it up as an asset. That is the whole mechanism, and
+    it has no opinion about whether anything *links* to the result.
+
+    So this repo spent a release compiling ``docs/paper/rhiza.tex``, publishing the PDF into
+    the built site, and referencing it from no nav entry in any mkdocs config. Every gate
+    passed: the paper task succeeded, the book built, and ``book-nav`` -- which exists to
+    catch a nav entry resolving to nothing -- had nothing to check, because nothing had been
+    claimed.
+
+    The two halves compose and neither is sufficient. This test says the paper is claimed;
+    ``book-nav`` says the claim resolves in the built site. Asserted against the nav *text*
+    rather than a built file, deliberately: the PDF only exists after ``make paper``, which
+    needs a LaTeX distribution, so requiring the artefact here would make this skip on every
+    machine without latexmk -- which is most of them, including CI's cheaper jobs.
+    """
+    tex = sorted((_ROOT / "docs" / "paper").glob("*.tex"))
+    if not tex:
+        pytest.skip("this repo ships no paper, so there is nothing for the book to link")
+
+    config = (_ROOT / "mkdocs.yml").read_text(encoding="utf-8")
+    unlinked = [t.stem for t in tex if f"paper/{t.stem}.pdf" not in config]
+    assert not unlinked, (
+        f"docs/paper/ holds {unlinked}, compiled by `book`'s `paper` prerequisite and published "
+        f"into the site as an asset, but no nav entry in mkdocs.yml points at "
+        f"paper/{unlinked[0]}.pdf. The build succeeds and the paper is unreachable."
+    )

--- a/tests/utils/test_gate_scope.py
+++ b/tests/utils/test_gate_scope.py
@@ -46,6 +46,14 @@ _BUNDLES = _ROOT / "bundles"
 # folder: both skip with the folder in the reason, so a wrong value is visible rather than
 # silent. They are listed to acknowledge them, which is what this set is for.
 #
+# That reasoning has since gone half stale for `paper_folder`, and
+# :func:`test_paper_folder_is_inside_the_docs_tree` is the correction. It held while `paper`
+# stood alone -- a skip names its folder, so a wrong value announces itself. rhiza-task 1.1.0
+# made `paper` a prerequisite of `book`, and the PDF reaches the site with no copy step: it is
+# published only because `paper_folder` sits inside `docs_dir` and mkdocs sweeps that tree.
+# Move it out and the paper still compiles, the task still reports ok, and the site simply
+# never gets the file. That half is silent, so it is asserted rather than acknowledged.
+#
 # ``docs_folder`` arrived with rhiza-task 1.1.0 and scopes the new ``docs-examples`` gate,
 # which executes the fenced examples in the docs tree. This repo does not run it: `all` does
 # not name it, and the fences here are checked by tests/docs/test_doc_consistency.py instead.
@@ -321,3 +329,28 @@ def test_interrogate_hook_and_gate_agree_on_the_threshold() -> None:
         assert table.get(flag) is True, (
             f"[tool.interrogate] must set {flag} = true to match the `--{flag}` the docs-coverage recipe passes."
         )
+
+
+def test_paper_folder_is_inside_the_docs_tree() -> None:
+    """``paper_folder`` must sit inside ``docs/``, or the compiled PDF is never published.
+
+    There is no copy step. ``book`` builds the paper, latexmk writes the PDF beside its source,
+    and the file reaches the site because mkdocs copies everything under ``docs_dir``. So the
+    publication depends entirely on where this setting points, and pointing it elsewhere fails
+    in the quietest possible way -- ``paper`` succeeds, ``book`` succeeds, and the artefact is
+    absent from the site with nothing reporting it.
+
+    ``docs`` is spelled out rather than resolved from mkdocs, for the reason rhiza-task spells
+    it out in the same place: ``docs_dir`` is mkdocs's setting, not one the CLI resolves, so
+    both ends assume the default and this test pins that assumption rather than hiding it.
+    """
+    paper = _cli_print("paper_folder")
+    assert paper, "paper_folder resolves to nothing, so `make paper` has no folder to search"
+
+    resolved = (_ROOT / paper).resolve()
+    docs = (_ROOT / "docs").resolve()
+    assert resolved.is_relative_to(docs), (
+        f"paper_folder resolves to {paper!r}, which is outside docs/. The book publishes the "
+        f"PDF only because mkdocs sweeps docs_dir -- from there it would compile, report ok, "
+        f"and never appear in the site."
+    )


### PR DESCRIPTION
Refs #1494 — this is the follow-up from the question "should we have a simple test that there is no paper folder at root level?"

**Short answer: not that test.** #1494's collision is between `refs/heads/paper` and `refs/heads/paper/*` — both *branch refs*, which git keeps outside the worktree, so a `paper/` directory cannot collide with a `paper` branch. The "directory file conflict" in that error is git talking about ref paths. A repo-content test can't see the thing that breaks, and `bundles/paper` is itself a root-level directory called `paper`, so the naive glob starts with a false positive.

Checking what such a test *would* protect turned up something that had actually gone wrong.

## The paper was published and unreachable

`book` gained `paper` as a prerequisite in rhiza-task 1.1.0, and the PDF reaches the site with **no copy step** — `paper_folder` defaults to `docs/paper`, inside `docs_dir`, so mkdocs sweeps it up as an asset. That mechanism has no opinion about whether anything *links* to the result, and nothing did:

```
$ grep -rn -i paper mkdocs.yml docs/mkdocs-base.yml bundles/book/docs/mkdocs-base.yml
(no paper reference in any mkdocs config)
```

So the repo compiled `docs/paper/rhiza.tex`, published the PDF into the built site, and referenced it from nowhere. Every gate passed — and `book-nav`, which exists precisely to catch a nav entry resolving to nothing, had nothing to check because nothing had been claimed.

**ADR-0011 was missing from the nav too** — the record of replacing the synced make layer with a pinned CLI, the most consequential recent decision here and the one a reader is most likely to go looking for. Same defect, one line away in the same file, so it's fixed here rather than filed separately.

## Two guards, because the failure has two shapes

| test | asserts | why it's separate |
|---|---|---|
| `test_the_compiled_paper_is_reachable_from_the_book` | a `.tex` under `docs/paper/` has a matching nav entry | composes with `book-nav`: this says the paper is *claimed*, `book-nav` says the claim *resolves*. Neither alone catches this. |
| `test_paper_folder_is_inside_the_docs_tree` | the setting still points inside `docs/` | publication depends entirely on it; outside, the paper compiles, the task reports ok, and the site never gets the file |

The first asserts against the nav **text**, not a built artefact — deliberately, so it doesn't skip on machines without latexmk, which is most of them.

The second **corrects reasoning that had gone half stale.** `tests/utils/test_gate_scope.py` deliberately *acknowledged* `paper_folder` without asserting on it: "neither reports success on an empty folder: both skip with the folder in the reason, so a wrong value is visible rather than silent." That held while `paper` stood alone. Once `book` depended on it, placement started deciding whether the PDF is published at all — and that half is silent. The comment now says so and points at the assertion.

## Both guards were checked against their negative case

```
# nav entry removed
E AssertionError: docs/paper/ holds ['rhiza'] ... but no nav entry in mkdocs.yml points at paper/rhiza.pdf
# RHIZA_PAPER_FOLDER=paper
E AssertionError: paper_folder resolves to 'paper', which is outside docs/
```

## Verification

`make all` green — **1608 passed**, every gate `ok`.

## Not in this PR

#1494 itself stays open: the hardcoded branch name is untouched, and the choice between renaming it, making it configurable, and retiring the push now that the book publishes the PDF is still yours. This PR strengthens the *book* delivery path, which is the one that argues for retiring the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
