### PR TITLE
feat: stop offering mutation testing in the rhiza ecosystem

### DIFF
--- a/.rhiza/template-bundles.yml
+++ b/.rhiza/template-bundles.yml
@@ -125,7 +125,7 @@ bundles:
 
       It carries the test targets, as all three layers now do — Python's moved into
       `python-core` in #1475. What stays out of every layer is the optional extras
-      the `tests` bundle keeps (benchmarks, hypothesis, stress, mutation), and Rust
+      the `tests` bundle keeps (benchmarks, hypothesis, stress), and Rust
       has no equivalent: `test`, `coverage` and `typecheck` are cargo subcommands
       with nothing to configure, so a `rust-tests` bundle would own no files at all.
 
@@ -325,10 +325,10 @@ bundles:
       ANTHROPIC_API_KEY CI/CD variable is set (masked).
 
   # ============================================================================
-  # TESTS - Optional Python testing extras (benchmarks, hypothesis, stress, mutation)
+  # TESTS - Optional Python testing extras (benchmarks, hypothesis, stress)
   # ============================================================================
   tests:
-    description: "Optional Python testing extras: benchmark, hypothesis-test, stress and mutation gates"
+    description: "Optional Python testing extras: benchmark, hypothesis-test and stress gates"
     standalone: true
     requires:
       - book          # ships docs/development/TESTS.md, which needs the book's docs/ tree
@@ -348,12 +348,26 @@ bundles:
       `test_bundle_sync.py::TestALayersAllIsSatisfiableOnItsOwn` now pins the property
       for every layer.
 
-      What is left is genuinely optional: four gates, each needing its own tool and
-      folder convention (benchmarks, Hypothesis property tests, stress/load tests,
-      mutation testing), plus one line of `RHIZA_CHECKS` naming pytest-rhiza's
+      What is left is genuinely optional: three gates, each needing its own tool and
+      folder convention (benchmarks, Hypothesis property tests, stress/load tests),
+      plus one line of `RHIZA_CHECKS` naming pytest-rhiza's
       `test_readme_validation` — the half of the README checks that only means something
       on a Python project, its neutral half having moved to `core` in #1472. That was a
       synced file until #1540; the ownership is unchanged, only the delivery.
+
+      **There was a fourth, and mutation testing is deliberately not offered any more**
+      (#1492). `mutation` had been broken in every consumer since mutmut 3 shipped: the
+      recipe passed `--paths-to-mutate`, `--tests-dir` and called `mutmut html`, all
+      three removed, and it installed mutmut unpinned — so the breakage was
+      time-triggered rather than arriving by sync. Porting it is not a flag rename.
+      mutmut 3.x resolves source paths during config loading with no CLI path at all, so
+      a task would have to require `[tool.mutmut]` in every consumer's `pyproject.toml`
+      or write one behind their back; `tests_dir` is itself already deprecated in favour
+      of `pytest_add_cli_args_test_selection`; the HTML report the recipe relocated no
+      longer exists; and `results` prints nothing when nothing survived. That is a new
+      config contract with consumers, for a gate no `all` names and no workflow ran —
+      `rhiza_mutation.yml` went in #1583 because `MUTATION_ENABLED` was unset here and
+      everywhere we could see. Removal of the task itself is Jebel-Quant/rhiza-task#135.
 
   # ============================================================================
   # GITHUB-TESTS - GitHub Actions workflows for CI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,8 +70,8 @@ The core abstraction is the **bundle** — a named group of configuration files.
   pre-commit config, `.bumpversion.toml`, and a starter `internal/version/version.go`
   with its `version_test.go`. Its gates are rhiza-task's `go` layer, test targets
   included, like the other two.
-- `tests`: optional Python testing extras — `benchmark`, `hypothesis-test`, `stress`,
-  `mutation` (requires `python-core`; the gates `all` names live in the layer)
+- `tests`: optional Python testing extras — `benchmark`, `hypothesis-test`, `stress`
+  (requires `python-core`; the gates `all` names live in the layer)
 - `benchmarks`: pytest-benchmark infrastructure and reporting
 - `github`: GitHub repository configuration (actions, dependabot, core workflows)
 - `gitlab`: GitLab CI/CD pipeline configuration and core workflows
@@ -267,11 +267,37 @@ alone had an `all` that died on a missing rule (#1475). No shipped profile reach
 which is why it survived; `tests/bundles/test_layer_contract.py::TestALayersAllIsSatisfiableOnItsOwn`
 now pins the property for every layer.
 
-What `tests` still owns is what is genuinely optional — `benchmark`, `hypothesis-test`,
-`stress` and `mutation`, each needing its own tool and folder convention, and none named
-by any `all`. There is still no `rust-tests` or `go-tests` bundle, for the original
-reason: `cargo nextest` and `go test` need no configuration, so such a bundle would own
-nothing at all.
+What `tests` still owns is what is genuinely optional — `benchmark`, `hypothesis-test`
+and `stress`, each needing its own tool and folder convention, and none named by any
+`all`. There is still no `rust-tests` or `go-tests` bundle, for the original reason:
+`cargo nextest` and `go test` need no configuration, so such a bundle would own nothing
+at all.
+
+**Mutation testing is not part of the ecosystem, and that is now a decision rather than
+an omission (#1492).** `mutation` was a fourth extra, and it had been broken in every
+consumer since mutmut 3 shipped: the recipe passed `--paths-to-mutate` and `--tests-dir`
+and called `mutmut html`, all three removed, and installed mutmut unpinned — so the
+breakage was time-triggered, arriving on the day of a release rather than on a sync. It
+survived because nothing invoked it. No `all` names it, and `rhiza_mutation.yml` was
+removed in #1583 after `MUTATION_ENABLED` turned out to be unset here and in every
+consumer we could see, so the only signal was someone typing `make mutation`.
+
+What settled it against a port is that mutmut 3.x resolves source paths *during config
+loading*, with no CLI path at all — so a task cannot pass them, and would instead have to
+require a `[tool.mutmut]` table in every consumer's `pyproject.toml` or write one behind
+their back. On top of that `tests_dir` is itself already deprecated in favour of
+`pytest_add_cli_args_test_selection`, the HTML report the recipe relocated does not exist
+any more (artifacts land in `mutants/`, and `export-cicd-stats` writes the JSON that
+replaces it), and `results` prints nothing when nothing survived. A new config contract
+with consumers, for a gate none of them had switched on. Removing the task is
+Jebel-Quant/rhiza-task#135; until that lands, the pinned CLI still carries it and
+`make mutation` still fails as described.
+
+One consequence: **the `mutation` row in README.md cannot be removed by hand.** That block
+lives between the `MAKE_HELP_START`/`MAKE_HELP_END` markers and is regenerated from
+`make help` by the `update-readme-help` hook on every `make fmt`, so it reports the pinned
+CLI's task list rather than this repo's policy. Deleting the row makes the hook put it
+straight back. It goes when the pin does.
 
 **Where Go differs from both.** A Go module has no manifest: its version *is* the git
 tag, so unlike `pyproject.toml` and `Cargo.toml` there is no file in the tree for

--- a/docs/operations/CI_ENFORCEMENT.md
+++ b/docs/operations/CI_ENFORCEMENT.md
@@ -26,8 +26,16 @@ None in CI. `rhiza_mutation.yml` was the only one: a reusable workflow here plus
 stub in `github-tests`, both gated on a `MUTATION_ENABLED` repository variable that
 was unset in this repo and, as far as we can tell, in every consumer — so the whole
 path ran nowhere while carrying badge publishing, a Pages deploy and two test
-modules. `mutation` is still a `rhiza-task` task, so `make mutation` works locally
-for anyone who wants it; what went is the CI wiring nobody switched on.
+modules.
+
+The gate behind it went too. This page used to say `make mutation` still worked
+locally for anyone who wanted it, and that was **false**: mutmut 3 removed
+`--paths-to-mutate`, `--tests-dir` and the `html` subcommand, and the recipe
+installed mutmut unpinned, so the target had been failing immediately in every
+consumer since the day mutmut 3 was released (#1492). Nothing caught it, because
+nothing ran it — which is exactly what removing the workflow had established. Rhiza
+no longer offers mutation testing at all; removing the task from the pinned CLI is
+Jebel-Quant/rhiza-task#135.
 
 ## Report-only (monitoring) workflows
 

--- a/docs/reference/ARCHITECTURE.md
+++ b/docs/reference/ARCHITECTURE.md
@@ -93,7 +93,7 @@ template owns it again, so `RHIZA_TASK` travels with the sync — the property
 | was | is |
 | --- | --- |
 | `bootstrap.mk` — `install`, uv bootstrap | the `install` task, plus three lines of the shim |
-| `test.mk` — test, coverage, typecheck, stress, mutation | the `python`/`rust`/`go` layers and the testing extras |
+| `test.mk` — test, coverage, typecheck, stress, mutation | the `python`/`rust`/`go` layers and the testing extras — except `mutation`, dropped rather than carried (#1492) |
 | `quality.mk` — `fmt`, lint, `rhiza-test` | the neutral quality tasks |
 | `book.mk`, `marimo.mk` | the `book` and `marimo` tasks |
 | `doctor.mk` | the `doctor` task |
@@ -405,7 +405,7 @@ catch-all, so it can call the CLI and then the extra step.
 
 3. **Dependency provisioning** (no `.rhiza/requirements/`):
    - Libraries the test suite imports live in `pyproject.toml` `[dependency-groups]`
-   - Per-target tooling (pytest plugins, interrogate, mutmut, marimo, zensical, …)
+   - Per-target tooling (pytest plugins, interrogate, marimo, zensical, …)
      is installed on the fly by its `make` target via `uv run --with` / `uvx`
 
 ### Template Bundle and Profile Naming

--- a/tests/bundles/test_bundle_sync.py
+++ b/tests/bundles/test_bundle_sync.py
@@ -225,10 +225,10 @@ class TestCoreAndTestsBundleSync:
     def test_tests_bundle_ships_no_make_fragment(self):
         """The optional extras are CLI tasks now, not ``test.mk`` targets.
 
-        ``benchmark``, ``hypothesis-test``, ``stress`` and ``mutation`` are what this bundle
-        exists for, and all four are registered tasks — so the fragment that defined them has
-        nothing left to own. What the bundle still ships is its *configuration*, which the
-        assertions below cover.
+        ``benchmark``, ``hypothesis-test`` and ``stress`` are what this bundle exists for, and
+        all three are registered tasks — so the fragment that defined them has nothing left to
+        own. (A fourth, ``mutation``, was dropped outright in #1492 rather than moved.) What the
+        bundle still ships is its *configuration*, which the assertions below cover.
         """
         stale = sorted((self.project / ".rhiza").rglob("*.mk"))
         assert not stale, f"the tests bundle ships make fragments again: {[f.name for f in stale]}"

--- a/tests/bundles/test_dependency_groups.py
+++ b/tests/bundles/test_dependency_groups.py
@@ -57,7 +57,6 @@ _PROVISIONED_ON_THE_FLY = frozenset(
         "prek",
         "deptry",
         "bandit",
-        "mutmut",
         "hypothesis",
         "pip-licenses",
         "pytest-cov",

--- a/tests/integration/test_benchmark_targets.py
+++ b/tests/integration/test_benchmark_targets.py
@@ -2,8 +2,9 @@
 
 This module read the fragment: that `benchmark` was defined, was `.PHONY`, depended on `install`,
 and drove pytest-benchmark. All four assertions were about a file's text, and the file is gone —
-`benchmark`, `hypothesis-test`, `stress` and `mutation` are registered tasks now, and rhiza-task
-tests their recipes where those recipes live.
+`benchmark`, `hypothesis-test` and `stress` are registered tasks now, and rhiza-task tests their
+recipes where those recipes live. There was a fourth, `mutation`, and it is gone rather than
+moved (#1492).
 
 Rewritten rather than deleted because of *how* it failed. Each test skipped itself when `test.mk`
 was absent, so retiring the fragment turned four tests into four silent skips: green suite, four
@@ -14,23 +15,33 @@ change, which is the argument for assertions that go red when their subject move
 from __future__ import annotations
 
 import subprocess  # nosec B404
+import tomllib
 from pathlib import Path
 
 import pytest
+import yaml
 
 _ROOT = Path(__file__).resolve().parents[2]
 
 # What the `tests` bundle exists to provide. None is named by `all` — they are the opt-in extras,
-# each needing its own tool and folder convention.
-_EXTRA_TARGETS = ("benchmark", "hypothesis-test", "stress", "mutation")
+# each needing its own tool and folder convention. `mutation` was a fourth until #1492; rhiza no
+# longer offers mutation testing, and `test_no_bundle_offers_a_mutation_gate` below pins that.
+_EXTRA_TARGETS = ("benchmark", "hypothesis-test", "stress")
 
 
 @pytest.mark.parametrize("target", _EXTRA_TARGETS)
 def test_extra_target_resolves(target: str) -> None:
     """Each optional extra must still resolve, so retiring `test.mk` cost no entry point.
 
-    A dry run rather than a real one: these are the expensive gates — mutation testing especially —
-    and what is in question is whether the target exists, not whether the tool passes.
+    A dry run rather than a real one: these are the expensive gates, and what is in question is
+    whether the target exists, not whether the tool passes.
+
+    Be clear about how little that proves, because the docstring here used to overstate it. The
+    shim resolves *every* target through its ``%:`` catch-all, and ``make -n`` prints the ``uvx``
+    line without running it — so ``make -n definitely-not-a-task`` also exits 0. This asserts that
+    the shim is intact, not that the CLI has a task by this name; the pin's task inventory is
+    ``test_bundle_cli_targets.py``'s job. That gap is why ``mutation`` passed here for as long as
+    it was broken (#1492).
     """
     proc = subprocess.run(  # nosec B603
         ["make", "-n", target], cwd=_ROOT, capture_output=True, text=True, check=False
@@ -63,3 +74,43 @@ def test_the_benchmark_gate_has_something_to_measure_or_is_known_not_to() -> Non
     assert sorted(folder.glob("test_*.py")), (
         "tests/benchmarks/ exists but holds no benchmark modules, so the gate collects nothing"
     )
+
+
+def test_no_bundle_offers_a_mutation_gate() -> None:
+    """No bundle may ship or advertise a mutation-testing gate (#1492).
+
+    Rhiza offered `mutation` for as long as it was broken: mutmut 3 removed the two options and
+    the subcommand the recipe used, and the recipe installed mutmut unpinned, so it failed in
+    every consumer from the day of that release. Nothing caught it because no `all` named it and
+    no workflow ran it.
+
+    The decision is not to port it — mutmut 3.x has no CLI path for source paths at all, so a
+    task would have to require `[tool.mutmut]` in every consumer's `pyproject.toml` or write one
+    for them. This asserts the decision rather than trusting the prose: a bundle must ship no
+    file mentioning mutmut, and no bundle description may promise a mutation gate.
+
+    Scoped to shipped files and descriptions on purpose, so the rationale recorded in
+    `template-bundles.yml`'s `notes` — which has to name the thing to explain it — stays legal.
+
+    The dependency-group half is here rather than in `test_dependency_groups.py`, and the reason
+    is worth stating: `mutmut` used to sit in that module's `_PROVISIONED_ON_THE_FLY` set, whose
+    contract is "a target already injects this, so do not also declare it". No target injects it
+    any more, so leaving it there would have asserted something untrue, and simply deleting the
+    entry would have *permitted* a group to declare a tool nothing runs. It is a policy about
+    mutation, so it belongs with the rest of the policy.
+    """
+    offenders = [
+        str(path.relative_to(_ROOT))
+        for path in sorted((_ROOT / "bundles").rglob("*"))
+        if path.is_file() and "mutmut" in path.read_text(encoding="utf-8", errors="ignore").lower()
+    ]
+    assert not offenders, f"bundles ship mutation tooling again: {offenders}"
+
+    bundles = yaml.safe_load((_ROOT / ".rhiza" / "template-bundles.yml").read_text())["bundles"]
+    promising = sorted(name for name, spec in bundles.items() if "mutation" in (spec.get("description") or "").lower())
+    assert not promising, f"bundle descriptions advertise a mutation gate again: {promising}"
+
+    with (_ROOT / "pyproject.toml").open("rb") as fh:
+        groups = tomllib.load(fh).get("dependency-groups", {})
+    declaring = sorted(f"{group}:{dep}" for group, deps in groups.items() for dep in deps if "mutmut" in dep.lower())
+    assert not declaring, f"a dependency group declares mutmut, which no target runs: {declaring}"


### PR DESCRIPTION
Closes #1492 by removing mutation testing from the ecosystem rather than porting it.

`mutation` had been broken in every consumer since mutmut 3 shipped, and rhiza went on advertising it — including a line on this repo's own CI-enforcement page saying `make mutation` "works locally for anyone who wants it", which was false. The recipe passed `--paths-to-mutate` and `--tests-dir` and called `mutmut html`, all three removed in 3.x, and installed mutmut unpinned. So the breakage was **time-triggered, not version-triggered**: it arrived on the day of a mutmut release, for every repo, at every template version, with no sync needed.

## Why removal rather than a port

I scoped the port first, against mutmut **3.7.0**, and the findings are the argument against doing it. `[tool.mutmut] source_paths` does work — verified end to end on a minimal `src/pkg` + `tests` project, 1/1 mutants killed, no flags — but four things around it do not survive a key-for-flag swap:

- **mutmut 3.x has no CLI path for source paths at all.** They resolve during config loading, before click parses argv. So a task cannot pass them; it would have to require `[tool.mutmut]` in every consumer's `pyproject.toml` or generate one behind their back — a new category of thing the CLI does.
- **`tests_dir` is itself already deprecated:** `UserWarning: The config tests_dir is deprecated. Please add the path to pytest_add_cli_args_test_selection instead`. Porting to the obvious key buys one release.
- **The HTML report the recipe relocated no longer exists.** Artifacts land in `mutants/`, so `cfg.root / "html"` is never created; `export-cicd-stats` → `mutants/mutmut-cicd-stats.json` is the machine-readable successor and `browse` is interactive-only.
- **`results` prints nothing when nothing survived.** It is not a summary command, so a score has to come from the stats JSON.

That is a config contract with consumers, a new report format and a new score source — for a gate no `all` names and no workflow runs. `rhiza_mutation.yml` went in #1583 because `MUTATION_ENABLED` was unset here and in every consumer we could see, so the only signal the gate was broken was someone typing `make mutation`, and the evidence is that nobody did.

The task itself lives in rhiza-task, so this PR drops the claims and adds the guard; **Jebel-Quant/rhiza-task#135** removes the task.

## Two things found while doing it

- **`test_extra_target_resolves[mutation]` never proved the task existed.** The shim resolves every target through its `%:` catch-all and `make -n` prints the `uvx` line without running it — `make -n definitely-not-a-task` also exits 0. That gap is exactly why the target passed here for as long as it was broken. The docstring now says what the dry run does and does not prove, and points at `test_bundle_cli_targets.py` as the thing that actually checks the pin's inventory.
- **`mutmut` sat in `test_dependency_groups.py`'s `_PROVISIONED_ON_THE_FLY`**, whose contract is "a target already injects this, so do not also declare it". No target injects it now, so leaving the entry asserted something untrue — and deleting it alone would have *permitted* a group to declare a tool nothing runs. The assertion moved into the new policy test instead of being dropped.

## The guard

`test_no_bundle_offers_a_mutation_gate` pins the decision on three axes: no bundle may ship a file mentioning mutmut, no bundle description may promise a mutation gate, and no dependency group may declare mutmut. I verified both file and description halves go red when violated rather than trusting that they would.

It is scoped to *shipped files and descriptions* on purpose, so the rationale recorded in `template-bundles.yml`'s `notes` — which has to name the thing in order to explain it — stays legal.

## One deliberate non-change, and one retraction

**README.md is untouched, and its `mutation` row stays for now.** I removed it by hand first; `make fmt` put it straight back. The block sits between the `MAKE_HELP_START`/`MAKE_HELP_END` markers and is regenerated from `make help` by the `update-readme-help` hook, so it reports the *pinned CLI's* task list rather than this repo's policy. It goes when the pin moves past rhiza-task#135. Noted in CLAUDE.md so the next person does not repeat the attempt.

**Retracting one claim from #1492's own comment:** it reported mutmut failing at import on Python 3.14 (`mutmut/utils/safe_setproctitle.py`). That **no longer reproduces** — 3.7.0 imports and runs on 3.14.6. Recording it so it does not get cited as extra justification; the case rests on the CLI churn and the absent users, not on a fixed interpreter bug.

## Verification

- `make fmt` — clean (after the hook reverted the README edit).
- `uv run pytest` — **1621 passed, 45 skipped**.
- Negative-tested the new guard: both halves fail with the intended message when violated.
