### PR TITLE
feat: enforce template ownership with check-managed-files in all three layers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -591,6 +591,56 @@ default for `mkdocs-extra-packages`, which this repo's `pyproject.toml` now mere
 > is a required status check in `.github/rulesets/main-branch-protection.json`, so
 > renaming it would leave every PR waiting on a context that never reports.
 
+### Enforcing template ownership
+
+Every managed repo's `CLAUDE.md` opens with the same rule — *managed files are overwritten
+by the next sync* — and from the removal of the `validate` gate after v1.1.3 until #1462
+nothing enforced it. (Deliberately not written as a `make` code span: it is a retired
+target, and `test_doc_consistency.py` holds every such span in the docs to a target that
+still resolves.) The failure that leaves is silent and total: the edit works, is
+reviewed, is merged, and disappears at the next sync with no error at any point.
+
+rhiza-hooks' `check-managed-files` closes it, and all three language layers now run it. It
+reads `.rhiza/template.lock`'s `files:` list minus anything under `exclude:` in
+`.rhiza/template.yml`, and reports only paths that **differ from HEAD** — not merely paths
+that are managed and present. That narrowing is what keeps `make fmt` and CI green: both
+pass every tracked file with `--all-files`, and without it the hook would report every
+managed file in the repo on a clean tree.
+
+**Adoption was gated on the sync path first, and the order is not optional.** A sync
+commit rewrites template-owned files wholesale — that is its whole purpose — so it is
+precisely the commit this hook is built to reject, and `/rhiza:update`'s `stage_synced.py`
+stages *exactly* the list the hook reads. The bypass is `SKIP=check-managed-files git
+commit`, landed in rhiza-claude#211 before this was adopted here. Two things are worth
+knowing about that sequencing:
+
+- **The break would have been immediate, not merely future.** prek's git shim reads
+  `.pre-commit-config.yaml` fresh at commit time, so the config is already on disk when
+  the sync commits it. Without the bypass in the plugin, the very sync that *delivers*
+  the hook is the one it rejects. What decouples the two is that the plugin updates
+  independently of a template sync, so consumers can have the fix before this ships.
+- **`SKIP` is honoured by prek, not just pre-commit.** Worth checking rather than
+  assuming, since prek differs from pre-commit elsewhere in this repo (it bakes
+  `--config` into the shim it generates). It works in both `prek run` and the installed
+  shim. One edge: if `SKIP` filters out *every* hook, prek exits non-zero with
+  `No hooks found after filtering with the given selectors` — irrelevant for these
+  twenty-hook configs, but it would bite a minimal one.
+
+**The bypass belongs to the sync commit and nowhere else.** `/rhiza:remote` commits CI
+fixes with `git commit -am`, and in a managed repo the likeliest thing such a fix touches
+is `.github/workflows/*` or `.gitlab-ci.yml` — both template-owned. The hook refusing that
+commit is it working: the fix really would vanish at the next sync. So that flow reports
+the managed path and says the change belongs upstream (or under `exclude:`), rather than
+reaching for `SKIP` and committing an edit with a known expiry date.
+
+**The mother repo's root override deliberately does not carry it.** rhiza has no
+`template.lock` — it *is* the template — so the hook can never fire here, and unlike
+`check-rhiza-config` (kept in `test_precommit_hook_reachability.py`'s `_INERT_BY_DESIGN`
+so a future `template.yml` starts being checked) that will not change. It also declares no
+`files:` pattern, so it would print **Passed** rather than **Skipped**: its inertness would
+be invisible in the output of the gate this repo runs most, which is the shape of #1535 and
+#1581. `TestLayerPreCommitConfig` asserts the three layers carry it and the root does not.
+
 > **Coverage in this repo (mother-repo specifics).** Rhiza has no `src/`, so the default
 > `source_folder` matches nothing and the scope has to be declared: `pyproject.toml`'s
 > `[tool.rhiza-task]` sets `source-folder = "utils"`, the tooling behind `make sync-self` and

--- a/bundles/go-core/.pre-commit-config.yaml
+++ b/bundles/go-core/.pre-commit-config.yaml
@@ -94,6 +94,13 @@ repos:
       - id: check-rhiza-workflow-names
       - id: update-readme-help
       - id: check-rhiza-config
+      # check-managed-files refuses a commit touching any path in .rhiza/template.lock's
+      # `files:` list (minus `exclude:` in template.yml), enforcing the rule every managed
+      # repo's CLAUDE.md opens with. Only paths differing from HEAD are reported, so
+      # `make fmt` and CI stay green on a clean tree under --all-files. Its adoption was
+      # gated on the sync commit gaining `SKIP=check-managed-files` -- see CLAUDE.md's
+      # "Enforcing template ownership" for why that order is not optional.
+      - id: check-managed-files
       - id: check-makefile-targets
       # Fails when `.go-version` is below go.mod's `go` directive. This layer ships no
       # `.go-version` — go.mod's directives are the source of truth here — so the hook is

--- a/bundles/python-core/.pre-commit-config.yaml
+++ b/bundles/python-core/.pre-commit-config.yaml
@@ -96,6 +96,13 @@ repos:
       - id: update-readme-help
       # Additional utility hooks
       - id: check-rhiza-config
+      # check-managed-files refuses a commit touching any path in .rhiza/template.lock's
+      # `files:` list (minus `exclude:` in template.yml), enforcing the rule every managed
+      # repo's CLAUDE.md opens with. Only paths differing from HEAD are reported, so
+      # `make fmt` and CI stay green on a clean tree under --all-files. Its adoption was
+      # gated on the sync commit gaining `SKIP=check-managed-files` -- see CLAUDE.md's
+      # "Enforcing template ownership" for why that order is not optional.
+      - id: check-managed-files
       - id: check-makefile-targets
       - id: check-python-version-consistency
       # check-bumpversion-config asserts that bump-my-version can actually discover the

--- a/bundles/rust-core/.pre-commit-config.yaml
+++ b/bundles/rust-core/.pre-commit-config.yaml
@@ -88,6 +88,13 @@ repos:
       - id: check-rhiza-workflow-names
       - id: update-readme-help
       - id: check-rhiza-config
+      # check-managed-files refuses a commit touching any path in .rhiza/template.lock's
+      # `files:` list (minus `exclude:` in template.yml), enforcing the rule every managed
+      # repo's CLAUDE.md opens with. Only paths differing from HEAD are reported, so
+      # `make fmt` and CI stay green on a clean tree under --all-files. Its adoption was
+      # gated on the sync commit gaining `SKIP=check-managed-files` -- see CLAUDE.md's
+      # "Enforcing template ownership" for why that order is not optional.
+      - id: check-managed-files
       - id: check-makefile-targets
       # Fails when rust-toolchain.toml's channel is *below* Cargo.toml's
       # `[package].rust-version`, which is genuinely unbuildable. It does not demand the

--- a/tests/bundles/test_bundle_content_validity.py
+++ b/tests/bundles/test_bundle_content_validity.py
@@ -301,6 +301,51 @@ class TestLayerPreCommitConfig:
             for repo, pins in sorted(drifted.items())
         )
 
+    @pytest.mark.parametrize("layer", _LAYER_BUNDLES)
+    def test_every_layer_enforces_template_ownership(self, root: Path, layer: str) -> None:
+        """Each layer must run check-managed-files (#1462).
+
+        It is the only thing enforcing the rule every managed repo's CLAUDE.md opens with --
+        managed files are overwritten by the next sync -- and nothing had enforced it since
+        `make validate` was removed after v1.1.3. What it guards against is silent: the edit
+        works, is reviewed, is merged, and disappears.
+
+        Asserted per layer rather than once, because the path is language-layer-owned: there
+        are three configs, so a hook can be dropped from one and kept in the other two, and
+        the consumer who loses it is whichever language that layer serves. The check itself is
+        entirely language-neutral -- it reads `.rhiza/template.lock` and nothing else -- so
+        there is no layer with a reason to opt out.
+        """
+        hook_ids = {hook["id"] for repo in _layer_precommit(root, layer)["repos"] for hook in repo["hooks"]}
+        assert "check-managed-files" in hook_ids, (
+            f"{layer} does not run check-managed-files, so a consumer on that layer can edit a "
+            "template-owned file and lose it at the next sync with no error at any point (#1462)"
+        )
+
+    def test_the_mother_repo_does_not_run_check_managed_files(self, root: Path) -> None:
+        """The root override must NOT carry the hook, and that is deliberate (#1462).
+
+        rhiza has no `.rhiza/template.lock` -- it *is* the template -- so the hook can never
+        fire here. Unlike `check-rhiza-config`, which the reachability test keeps in
+        `_INERT_BY_DESIGN` so that a future `template.yml` starts being checked without an
+        edit, this one will not change: the mother repo is never a consumer of itself.
+
+        The distinction that decides it is how the inertness would *look*. `check-managed-files`
+        declares no `files:` pattern, so prek always hands it the tracked files and it prints
+        **Passed** rather than **Skipped** -- a hook reporting success while measuring nothing,
+        in the output of the gate this repo runs most. That is the shape of #1535 and #1581,
+        and it is worth one assertion to keep it from being added here by symmetry with the
+        bundles.
+        """
+        with (root / ".pre-commit-config.yaml").open(encoding="utf-8") as fh:
+            hook_ids = {hook["id"] for repo in yaml.safe_load(fh)["repos"] for hook in repo["hooks"]}
+        assert "check-managed-files" not in hook_ids, (
+            "the root config adopted check-managed-files, but rhiza has no template.lock so the "
+            "hook can never fire -- and with no `files:` pattern it reports Passed, not Skipped, "
+            "so it would read as a check while measuring nothing. See CLAUDE.md, "
+            "'Enforcing template ownership'."
+        )
+
 
 # ---------------------------------------------------------------------------
 # GitLab CI uv-image single-source pinning


### PR DESCRIPTION
Closes #1462. Step 2 of the two-step sequence the issue asked for; step 1 landed as **Jebel-Quant/rhiza-claude#211** (merged, all checks green), so this is unblocked rather than gated.

Every managed repo's `CLAUDE.md` opens with the rule that managed files are overwritten by the next sync, and nothing had enforced it since the `validate` gate was removed after v1.1.3. The failure that leaves is silent and total: the edit works, is reviewed, is merged, and disappears with no error at any point. `check-managed-files` makes it loud at the commit that causes it.

## Retargeted: three configs, not one

The issue asks for `bundles/core/.pre-commit-config.yaml`. That file no longer exists — the path became language-layer-owned — so this is three edits, and the issue's own follow-up comment flagged that it was worth deciding whether all three want it.

**All three do.** The check reads `.rhiza/template.lock` and nothing else, so it is entirely language-neutral: there is no layer with a reason to opt out. It sits with the other four neutral rhiza-hooks that all three already share, and the new test is parametrised per layer rather than asserted once — three configs means a hook can be dropped from one and kept in the other two, and the consumer who silently loses it is whichever language that layer serves.

## Why step 1 had to land first, sharper than the issue put it

`stage_synced.py` stages *exactly* the lock's `files:` list, which is the same list this hook reads. The issue said adopting first would break future syncs; it is worse than that. **prek's git shim reads `.pre-commit-config.yaml` fresh at commit time**, so the config is already on disk when the sync commits it — the very sync that *delivers* the hook is the one it rejects. What decouples the two is that the plugin updates independently of a template sync, so consumers can have the bypass before this ships.

There is a residual case worth naming: a consumer running a stale plugin who syncs to a release carrying this will hit the refusal. It is self-mitigating rather than mysterious — the hook prints the fix itself, verified below:

```
Bypass this hook for a sync commit with: SKIP=check-managed-files git commit ...
```

## Verified behaviourally, not from the docstring

Built a repo with a real `.rhiza/template.lock` and ran the hook from rhiza-hooks v1.2.0:

| case | result |
| --- | --- |
| clean tree, every file passed (the `make fmt` / CI case under `--all-files`) | `rc=0` |
| a lock-listed file modified | `rc=1`, naming the path |
| a lock-listed path that is under `exclude:` in `template.yml` | `rc=0` |

The first row is the one that matters for CI: the hook reports only paths that **differ from HEAD**, not merely managed-and-present, so `make fmt` and PR runs stay green.

**And `SKIP` works under prek, not just pre-commit.** The issue proposed it on the grounds that it is "pre-commit's own mechanism", which was worth checking rather than assuming — prek is this repo's runner and differs elsewhere (it bakes `--config` into the shim it generates). It honours `SKIP` in both `prek run` and the installed git shim; I verified both against a two-hook repo. One edge, irrelevant here but real: if `SKIP` filters out *every* hook, prek exits non-zero with `No hooks found after filtering with the given selectors`.

`check-managed-files` is already at the `rev: v1.2.0` all three layers pin, so no rev bump is needed.

## The mother repo deliberately does not adopt it

rhiza has no `template.lock` — it *is* the template — so the hook can never fire here. Unlike `check-rhiza-config`, which `test_precommit_hook_reachability.py` keeps in `_INERT_BY_DESIGN` precisely so a future `template.yml` starts being checked without an edit, this one will not change: the mother repo is never a consumer of itself.

What decides it is how the inertness would *look*. `check-managed-files` declares no `files:` pattern, so prek always hands it the tracked files and it prints **Passed**, not **Skipped** — a hook reporting success while measuring nothing, in the output of the gate this repo runs most. That is the shape of #1535 and #1581, so it gets an assertion (`test_the_mother_repo_does_not_run_check_managed_files`) rather than a comment that someone later "fixes" by symmetry with the bundles.

## Also fixed upstream: a gap in the issue's audit

#1462's comment audited rhiza-claude's `git commit` sites and cleared `/rhiza:init`, `/rhiza:uninstall` and `/rhiza:release`. It did not cover **`/rhiza:remote`**, which commits CI fixes with `git commit -am` — and in a managed repo the likeliest thing such a fix touches is `.github/workflows/*` or `.gitlab-ci.yml`, both template-owned. rhiza-claude#211 gives that flow guidance rather than a bypass: `SKIP=` there would silently commit an edit with a known expiry date, which is the exact failure the hook exists to prevent.

## Verification

- `make fmt` — clean.
- `uv run pytest` — **1625 passed, 45 skipped**, the two new tests included.
- The prose-drift gate caught a real slip while writing this: `test_doc_consistency.py::TestProseDrift` rejects a `make <target>` code span naming a target that no longer resolves, which is what my first draft of the CLAUDE.md section did with `validate`. Reworded, and the reason noted inline so the next person does not reintroduce it. Worth knowing if you compare counts: that gate is parametrised over the `make` spans it finds, so removing the bad mention removed a case — the run went 1626 collected / 1 failed to 1625 collected / 0 failed, which is why adding two tests did not raise the total by two.
