### PR TITLE
chore(deps): bump rhiza-hooks to v1.3.0, tagging the generated make-help fence

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -113,7 +113,7 @@ repos:
         files: ^(utils|tests)/.*\.py$
 
   - repo: https://github.com/Jebel-Quant/rhiza-hooks
-    rev: v1.2.0  # Use the latest release
+    rev: v1.3.0  # Use the latest release
     hooks:
       # Migrated from rhiza
       - id: check-rhiza-workflow-names
@@ -170,3 +170,15 @@ repos:
       # the template — so the hook is inert here. Disabled in #660 (rhiza-hooks 0.3.0)
       # with no reason recorded.
       # - id: check-template-bundles
+      # check-test-layout is new in v1.3.0 and stays off *here* for the reason the block
+      # above keeps restating: it would report success while measuring nothing. This repo
+      # already carries the `[tool.check_test_layout]` table added in #1513 with
+      # `enforce = false` and a reason — there is no `src/` tree to mirror — so the hook
+      # prints "Test layout OK: parity not enforced by request …" and exits 0 on every run,
+      # whatever the tests do. Verified against v1.3.0, not assumed. A hook whose result
+      # cannot change is the #1535/#1581 shape again, and the table is what makes it so.
+      #
+      # Whether the *bundles* should ship it is a separate call, deliberately not made in a
+      # rev bump: downstream has a real `src/` and the hook would enforce parity there, so
+      # adopting it changes behaviour for every consumer rather than for this repo.
+      # - id: check-test-layout

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ Run `make help` for a complete list of 40+ available targets.
 <summary>Show all available targets</summary>
 
 <!-- MAKE_HELP_START -->
-```
+```text
  task                section         needs                 does                 
  book                Book            test benchmark        build the companion  
                                      stress                book                 

--- a/bundles/go-core/.pre-commit-config.yaml
+++ b/bundles/go-core/.pre-commit-config.yaml
@@ -100,7 +100,7 @@ repos:
         groups: ["security", "slow"]
 
   - repo: https://github.com/Jebel-Quant/rhiza-hooks
-    rev: v1.2.0  # Use the latest release
+    rev: v1.3.0  # Use the latest release
     hooks:
       - id: check-rhiza-workflow-names
         groups: ["fast"]

--- a/bundles/python-core/.pre-commit-config.yaml
+++ b/bundles/python-core/.pre-commit-config.yaml
@@ -104,7 +104,7 @@ repos:
         groups: ["python", "lint", "slow"]
 
   - repo: https://github.com/Jebel-Quant/rhiza-hooks
-    rev: v1.2.0  # Use the latest release
+    rev: v1.3.0  # Use the latest release
     hooks:
       # Migrated from rhiza
       - id: check-rhiza-workflow-names

--- a/bundles/rust-core/.pre-commit-config.yaml
+++ b/bundles/rust-core/.pre-commit-config.yaml
@@ -94,7 +94,7 @@ repos:
         groups: ["security", "slow"]
 
   - repo: https://github.com/Jebel-Quant/rhiza-hooks
-    rev: v1.2.0  # Use the latest release
+    rev: v1.3.0  # Use the latest release
     hooks:
       - id: check-rhiza-workflow-names
         groups: ["fast"]


### PR DESCRIPTION
Closes #1589. rhiza-hooks v1.3.0 is out and carries the generator fix from Jebel-Quant/rhiza-hooks#358, so the rev can move and the block regenerates itself.

Route 1 from the issue, as the thread settled on: the tag had to come from the generator. `update_readme_with_help` substitutes the whole span between the `MAKE_HELP` markers — **fence lines included** — so a hand-added ` ```text ` here would have been reverted by the next `make fmt`.

## What changed

`rev: v1.2.0` → `v1.3.0` in all four configs (the root override plus the three language layers), then `make fmt`.

**README.md now has zero untagged opening fences** — 16 of 16 carry a language. Before this, line 382 was the only fence in the file that was neither `ok` nor an explicit `skipped`, which is precisely what the issue objected to: not that the block was wrong, but that "needs no checking" and "nobody decided" were indistinguishable, so a future fence that should have been tagged `python` or `bash` would arrive into a README where one untagged fence is already normal.

The issue's "done when" also required the result to survive the hook. A second `make fmt` is clean, so it does.

## Verified before the bump, not after

I ran v1.3.0's generator against a copy of this README first, to see what a rev bump would actually do to a 120-line generated block:

```
$ diff README.md README.probe.md
382c382
< ```
---
> ```text
```

Exactly one line. That was worth knowing in advance, because the block is regenerated wholesale and a generator change could have reflowed all of it.

I also diffed the hook inventory between the two revs rather than assuming a patch-shaped change — v1.3.0 adds one hook (below) and removes none, so nothing this repo or the bundles already enable disappears.

## The new hook stays off here, and that is recorded

v1.3.0 adds **`check-test-layout`** (tests mirror sources 1:1, both directions). A rev bump that silently introduces an unadopted hook is exactly how "nobody decided" happens, so:

**Off in this repo, because it cannot fail here.** The `[tool.check_test_layout]` table added in #1513 sets `enforce = false` with a reason — rhiza ships configuration templates, so there is no `src/` tree to mirror. Confirmed against v1.3.0 rather than reasoned about:

```
$ check-test-layout
Test layout OK: parity not enforced by request — Rhiza ships configuration templates,
not a runtime library: there is no src/ tree to mirror. …
rc=0
```

It exits 0 whatever the tests do. A hook whose result cannot change is the #1535 / #1581 shape — a line that reads like a check in the output of the gate this repo runs most — and here the config table is what guarantees it. So it gets a commented-out entry with the reasoning, in the same style as `check-makefile-targets` and `check-template-bundles` above it.

**Whether the bundles should ship it is deliberately left open.** Downstream has a real `src/`, so there the hook would genuinely enforce parity — adopting it changes behaviour for every consumer rather than for this repo, and that is not a call to slip into a dependency bump.

## Verification

- `make fmt` — clean, and idempotent on a second run.
- `uv run pytest` — **1637 passed, 45 skipped**.
- `tests/api/test_precommit_hook_reachability.py` passes at the new rev; its network half reads the *pinned* rev's `files:` patterns, so the bump is what it was written to catch, and no shipped hook became inert.
