### PR TITLE
chore: release v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com),
 and entries are generated from [Conventional Commits](https://www.conventionalcommits.org).
 
+## [1.5.0] - 2026-08-22
+
+### New Features
+- Stop offering mutation testing in the rhiza ecosystem (#1492) (#1600)
+- Enforce template ownership with check-managed-files in all three layers (#1462) (#1601)
+- Tag shipped hooks with prek groups for subset execution (#1602)
+
+### Bug Fixes
+- Revive two silently inert guards, and watch the pin that ages (#1585)
+- Stop a failed conda job stranding the GitHub release as a draft (#1591)
+- Link the compiled paper from the book, and guard the two ways it goes missing (#1598)
+- Stop rhiza_paper pushing to a paper branch, which no repo with a paper/* branch can do (#1494) (#1603)
+
+### Documentation
+- Drop the last marimushka mentions (#1575)
+
+### Dependencies
+- *(deps)* Update pre-commit hook astral-sh/ruff-pre-commit to v0.16.4 (#1592)
+- *(deps)* Batch the six open renovate updates (#1599)
+- *(deps)* Bump rhiza-hooks to v1.3.0, tagging the generated make-help fence (#1589) (#1604)
+
+### Maintenance
+- Retire the fuzzing workflow and the GitHub issue/discussion templates (#1568)
+- Remove the Docker-backed GitLab check and its make target (#1569)
+- Move the mother-repo targets to local.mk, closing the Makefile (#1571)
+- Retire the mutation workflow (#1572)
+- Ship the root .gitignore as core's (#1574)
+- Ship the Makefile front door as core's (#1576)
+- Bump pytest-rhiza to 0.3.0, and revive the pin's Renovate manager (#1579)
+- Bump rhiza-task to 1.1.0, and de-fragilise the tests that read it (#1580)
+- One reader for the task registry, with the control it was missing (#1586)
+- Enforce the two suite invariants that were holding by convention (#1590)
+
+### Other Changes
+- Delete bundles/github/.github/ISSUE_TEMPLATE directory (#1567)
+- Delete bundles/github/.github/DISCUSSION_TEMPLATE directory (#1566)
+- Update .gitignore to refine ignored files (#1570)
+- Refactor/close the shim (#1573)
+
 ## [1.4.2] - 2026-08-19
 
 ### Maintenance

--- a/bundles/github-book/.github/workflows/rhiza_book.yml
+++ b/bundles/github-book/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.4.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.5.0
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml
+++ b/bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   devcontainer:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v1.4.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v1.5.0
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-docker/.github/workflows/rhiza_docker.yml
+++ b/bundles/github-docker/.github/workflows/rhiza_docker.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   docker:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v1.4.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v1.5.0
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-marimo/.github/workflows/rhiza_marimo.yml
+++ b/bundles/github-marimo/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.4.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.5.0
     secrets: inherit

--- a/bundles/github-paper/.github/workflows/rhiza_paper.yml
+++ b/bundles/github-paper/.github/workflows/rhiza_paper.yml
@@ -36,7 +36,7 @@ on:
 
 jobs:
   paper:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v1.4.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v1.5.0
     secrets: inherit
     # `contents: read` only. The `write` scope this stub used to grant existed solely for
     # the retired branch push; compiling and uploading an artifact need no write access.

--- a/bundles/github-quality-review/.github/workflows/rhiza_quality_review.yml
+++ b/bundles/github-quality-review/.github/workflows/rhiza_quality_review.yml
@@ -34,5 +34,5 @@ on:
 
 jobs:
   quality-review:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_quality_review.yml@v1.4.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_quality_review.yml@v1.5.0
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_benchmark.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.4.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.5.0
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_ci.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.4.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.5.0
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_codeql.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.4.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.5.0
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/bundles/github/.github/workflows/rhiza_scorecard.yml
+++ b/bundles/github/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.4.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.5.0
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/bundles/github/.github/workflows/rhiza_weekly.yml
+++ b/bundles/github/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.4.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.5.0
     secrets: inherit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rhiza"
-version = "1.4.2"
+version = "1.5.0"
 description = "Reusable configuration templates for modern Python projects"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -70,7 +70,7 @@ Issues = "https://github.com/jebel-quant/rhiza/issues"
 # python-core bundle no longer ships a `.rhiza/.cfg.toml` copy of this block; the
 # Rust and Go layers ship a root `.bumpversion.toml` instead, since neither
 # language has a discoverable file of its own.
-current_version = "1.4.2"
+current_version = "1.5.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:[-]?(?P<release>[a-z]+)[\\.]?(?P<pre_n>\\d+))?(?:\\+build\\.(?P<build_n>\\d+))?"
 serialize = [
     "{major}.{minor}.{patch}-{release}.{pre_n}+build.{build_n}",

--- a/uv.lock
+++ b/uv.lock
@@ -869,7 +869,7 @@ wheels = [
 
 [[package]]
 name = "rhiza"
-version = "1.4.2"
+version = "1.5.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Bumps this repo's declared version **1.4.2 → 1.5.0** and adds the matching CHANGELOG section.

## Merging this PR does not publish the release

There is **no tag yet, and this PR does not create one.** The tag is cut afterwards, from
the commit this PR merges as, by a second `/rhiza:release` run. That split is forced by
squash-merge: a tag created before the merge would name a SHA that never lands on `main`.

## What moved

| Location | Why |
| --- | --- |
| `pyproject.toml` — `[project].version` | the repo's own version, matched by the `[project]`-anchored regex so no `[tool.*]` table is touched |
| `pyproject.toml` — `[tool.bumpversion].current_version` | the config's own record of where it is |
| `uv.lock` — the `name = "rhiza"` entry | regenerated with `uv lock`; deliberately not a `[[files]]` entry, since a bare version search there would rewrite third-party pins |
| 11 × `bundles/**/.github/workflows/*.yml` | the `jebel-quant/rhiza/...@v1.4.2` stub pins downstream consumers sync — these must name a tag that exists, so they move with the release |

The live `.github/workflows/` are **not** in that list and carry no self-reference to this
repo, so every required check can resolve and this PR is mergeable like any other. (The
old self-referential shape is what used to make release PRs unmergeable: they published
workflows pointing at a tag that did not exist yet, failing at `Set up job`.)

## Changelog

`git-cliff --unreleased --tag v1.5.0 --prepend` — a pure insert: **39 additions, 0
deletions**, no existing section altered. 25 commits since `v1.4.2`: 3 `feat`, 4 `fix`,
1 `docs`, 3 `deps`, 10 `chore`, 4 unlabelled. No commit carries a `!` or a
`BREAKING CHANGE` footer.

`minor` was chosen over `patch` because the release carries real feature and behaviour
change beyond the fixes: prek hook groups (#1602), `check-managed-files` enforced in all
three language layers (#1462), mutation testing withdrawn from the ecosystem (#1492), and
the retirement of the synced make layer in favour of the template-owned `Makefile` front
door (#1576).

## After merge

Re-run `/rhiza:release` on `main`. It detects phase B from the repo's own state — the
declared version now exceeding the highest tag — re-runs the strictly-increases guard
against the merged history, tags the merged commit, and pushes the tag, which starts
release CI.
