### PR TITLE
fix(ci): check out LFS content in the jobs that run project code

### DIFF
--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -228,6 +228,12 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          # Runs the project's own pytest suite, so a repo whose fixtures are LFS-tracked
+          # needs the content here for the same reason `test` does. Passing there and
+          # failing here on identical tests reads as a resolution problem, which is the
+          # one thing this job exists to report.
+          lfs: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
@@ -335,6 +341,14 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          # README validation executes the ```python fences, and a consumer's example
+          # reads the demo data that ships with the repo. Without this the pointer file
+          # reaches the reader and the check dies on content, not on the repo being wrong
+          # -- polars reports `parquet: File out of specification: The file must end with
+          # PAR1`. The `test` job above has always had it; this job is newer (#1523) and
+          # runs project code the same way, so it needs the same checkout.
+          lfs: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0

--- a/tests/api/test_ci_workflow.py
+++ b/tests/api/test_ci_workflow.py
@@ -235,3 +235,53 @@ def test_ci_workflow_generate_matrix_uses_baipp_classifier_output(root):
     assert "supported_python_classifiers_json_array" in versions_output_step["run"]
     assert generate_matrix["outputs"]["matrix"] == "${{ steps.versions-output.outputs.list }}"
     assert "make -f .rhiza/rhiza.mk -s version-matrix" not in versions_output_step["run"]
+
+
+# Gates that execute the consumer's own code, rather than reading its source as text.
+# `docs-coverage` is not one of them despite the name: the pattern requires the space,
+# so `"$RHIZA_TASK" docs-coverage` does not match `"$RHIZA_TASK" coverage`.
+_RUNS_PROJECT_CODE = re.compile(
+    r'"\$RHIZA_TASK" (test|rhiza-test|coverage|benchmark|stress|hypothesis-test)\b|\bpytest\b'
+)
+
+
+def test_ci_jobs_that_run_project_code_check_out_lfs(root):
+    """Any CI job that executes the consumer's code must fetch its LFS content.
+
+    A checkout without `lfs: true` writes the pointer file — a few lines of text naming
+    an oid — where the payload belongs. Nothing fails at checkout; it fails later, inside
+    whatever opens the file, as a corrupt-content error about the consumer's data rather
+    than about the checkout. Jebel-Quant/trends#256 hit exactly that: `rhiza-test` runs
+    README validation, which executes the ```python fences, and a fence reading the demo
+    parquet that ships with the repo died on
+
+        polars: parquet: File out of specification: The file must end with PAR1
+
+    while `test` — same repo, same file, `lfs: true` since long before — passed. `rhiza-test`
+    was new in #1523, and the job was written from the static-analysis jobs beside it.
+
+    Derived from what each job runs rather than a hand-kept list of job names, so a future
+    job wired to a code-running gate fails here instead of shipping the same bug. The
+    static jobs (typecheck, deps, fmt, security, license, docs-coverage) read the tree as
+    text and are deliberately left alone: LFS content costs bandwidth and a smudge on every
+    file, and none of them open the data.
+    """
+    with (root / WORKFLOW_PATH).open(encoding="utf-8") as fh:
+        workflow = yaml.safe_load(fh)
+
+    offenders = {}
+    for name, job in workflow["jobs"].items():
+        steps = job.get("steps") or []
+        if not any(_RUNS_PROJECT_CODE.search(step.get("run") or "") for step in steps):
+            continue
+        checkout = next((s for s in steps if "actions/checkout" in str(s.get("uses", ""))), None)
+        assert checkout is not None, f"{name} runs project code but never checks the repository out"
+        if (checkout.get("with") or {}).get("lfs") is not True:
+            offenders[name] = checkout.get("with")
+
+    assert not offenders, (
+        f"these jobs execute the consumer's code but check out without `lfs: true`, so an "
+        f"LFS-tracked fixture reaches the reader as a pointer file: {sorted(offenders)}. "
+        f"The failure surfaces as corrupt data, not as a checkout problem "
+        f"(Jebel-Quant/trends#256)."
+    )


### PR DESCRIPTION
## Problem

`rhiza-test` and `lowest-deps` check out without `lfs: true`, so an LFS-tracked file arrives as its **pointer** — a few lines of text naming an oid — where the payload belongs.

Nothing fails at checkout. It fails later, inside whatever opens the file, as a corrupt-content error about the consumer's data rather than about the checkout that caused it.

[Jebel-Quant/trends#256](https://github.com/Jebel-Quant/trends/pull/256) is the case. `rhiza-test` runs README validation, which executes the ` ```python ` fences, and a fence reading the demo parquet that ships with that repo died on:

```
polars.exceptions.ComputeError: parquet: File out of specification: The file must end with PAR1
```

…while `test` — same repo, same file, `lfs: true` since long before — passed. `rhiza-test` is new in #1523, and was written from the static-analysis jobs beside it rather than from `test`, the job it actually resembles.

Because the reusable workflow's `workflow_call` accepts only `GH_PAT` and `UV_EXTRA_INDEX_URL`, a consumer cannot ask for an LFS checkout — the fix has to live here.

## Also fixed: `lowest-deps`

Same hole, not yet known to have bitten anyone. It runs the project's own `pytest tests`, so a repo whose fixtures are LFS-tracked fails there while `test` passes on identical tests — surfacing as a lowest-direct **resolution** problem, which is the one thing that job exists to detect.

## Left alone, deliberately

The six static jobs — `typecheck`, `deptry`, `pre-commit`, `docs-coverage`, `security`, `license` — read the tree as text and never open the data. LFS content costs bandwidth and a smudge on every tracked file.

| job | runs | `lfs` |
|---|---|---|
| `generate-matrix` | package metadata | ✅ (pre-existing) |
| `test` | `"$RHIZA_TASK" test` | ✅ (pre-existing) |
| `lowest-deps` | `pytest tests` | ✅ **this PR** |
| `rhiza-test` | `"$RHIZA_TASK" rhiza-test` | ✅ **this PR** |
| 6 static jobs | lint / typecheck / scan | — by design |

## Regression test

`test_ci_jobs_that_run_project_code_check_out_lfs` derives the set from **what each job runs**, not from a hand-kept list of job names, so the next job wired to a code-running gate fails the suite instead of shipping this bug again.

I verified it has teeth: reverting the workflow change while keeping the test fails with both `lowest-deps` and `rhiza-test` named.

## Verification

- `make fmt` — all hooks pass, including `Validate GitHub Workflows` and actionlint
- `make test` — 1627 passed, 45 skipped (opt-in e2e), coverage 100% ≥ 90%

## Note for consumers

This lands for a repo only when it moves to a release carrying it; anything pinned at `v1.5.0` keeps the old behaviour. trends#256 routes around it locally by storing its 51 KB demo parquet outside LFS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)