### PR TITLE
chore: release v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com),
 and entries are generated from [Conventional Commits](https://www.conventionalcommits.org).
 
+## [1.5.1] - 2026-08-22
+
+### Bug Fixes
+- *(ci)* Check out LFS content in the jobs that run project code (#1606)
+
 ## [1.5.0] - 2026-08-22
 
 ### New Features

--- a/bundles/github-book/.github/workflows/rhiza_book.yml
+++ b/bundles/github-book/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.5.1
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml
+++ b/bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   devcontainer:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v1.5.1
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-docker/.github/workflows/rhiza_docker.yml
+++ b/bundles/github-docker/.github/workflows/rhiza_docker.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   docker:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v1.5.1
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-marimo/.github/workflows/rhiza_marimo.yml
+++ b/bundles/github-marimo/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.5.1
     secrets: inherit

--- a/bundles/github-paper/.github/workflows/rhiza_paper.yml
+++ b/bundles/github-paper/.github/workflows/rhiza_paper.yml
@@ -36,7 +36,7 @@ on:
 
 jobs:
   paper:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v1.5.1
     secrets: inherit
     # `contents: read` only. The `write` scope this stub used to grant existed solely for
     # the retired branch push; compiling and uploading an artifact need no write access.

--- a/bundles/github-quality-review/.github/workflows/rhiza_quality_review.yml
+++ b/bundles/github-quality-review/.github/workflows/rhiza_quality_review.yml
@@ -34,5 +34,5 @@ on:
 
 jobs:
   quality-review:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_quality_review.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_quality_review.yml@v1.5.1
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_benchmark.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.5.1
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_ci.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.5.1
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_codeql.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.5.1
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/bundles/github/.github/workflows/rhiza_scorecard.yml
+++ b/bundles/github/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.5.1
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/bundles/github/.github/workflows/rhiza_weekly.yml
+++ b/bundles/github/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.5.1
     secrets: inherit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rhiza"
-version = "1.5.0"
+version = "1.5.1"
 description = "Reusable configuration templates for modern Python projects"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -70,7 +70,7 @@ Issues = "https://github.com/jebel-quant/rhiza/issues"
 # python-core bundle no longer ships a `.rhiza/.cfg.toml` copy of this block; the
 # Rust and Go layers ship a root `.bumpversion.toml` instead, since neither
 # language has a discoverable file of its own.
-current_version = "1.5.0"
+current_version = "1.5.1"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:[-]?(?P<release>[a-z]+)[\\.]?(?P<pre_n>\\d+))?(?:\\+build\\.(?P<build_n>\\d+))?"
 serialize = [
     "{major}.{minor}.{patch}-{release}.{pre_n}+build.{build_n}",

--- a/uv.lock
+++ b/uv.lock
@@ -869,7 +869,7 @@ wheels = [
 
 [[package]]
 name = "rhiza"
-version = "1.5.0"
+version = "1.5.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Release **v1.5.0 → v1.5.1**, a patch: the single unreleased commit is a fix.

## Changelog section added

```markdown
## [1.5.1] - 2026-08-22

### Bug Fixes
- *(ci)* Check out LFS content in the jobs that run project code (#1606)
```

## Files the bump touched

Every location is declared in `[tool.bumpversion]` in `pyproject.toml` — nothing was hand-edited.

- `pyproject.toml` — `current_version` and the `[project].version` (anchored to the `[project]` table, so no `[tool.*]` version is at risk)
- `uv.lock` — the `name = "rhiza"` entry, regenerated with `uv lock`
- `CHANGELOG.md` — prepended, one new section; no existing section altered
- The eleven **bundle** CI stubs under `bundles/**/.github/workflows/`, whose `uses: jebel-quant/rhiza/...@vX.Y.Z` pins must name the tag downstream consumers will sync:
  - `bundles/github-book/.github/workflows/rhiza_book.yml`
  - `bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml`
  - `bundles/github-docker/.github/workflows/rhiza_docker.yml`
  - `bundles/github-marimo/.github/workflows/rhiza_marimo.yml`
  - `bundles/github-paper/.github/workflows/rhiza_paper.yml`
  - `bundles/github-quality-review/.github/workflows/rhiza_quality_review.yml`
  - `bundles/github-tests/.github/workflows/rhiza_benchmark.yml`
  - `bundles/github-tests/.github/workflows/rhiza_ci.yml`
  - `bundles/github-tests/.github/workflows/rhiza_codeql.yml`
  - `bundles/github/.github/workflows/rhiza_scorecard.yml`
  - `bundles/github/.github/workflows/rhiza_weekly.yml`

The **live** workflows under `.github/workflows/` are deliberately not in that list and were not touched — they reference no tag of this repo, which is what keeps a release PR's checks able to go green.

## Merging this does not publish the release

There is **no tag yet**. The tag is cut afterwards, from the commit this PR merges as — a squash-merge replaces the branch's commits, so a tag created before the merge would name a SHA that never lands on `main`. After merging, re-run `/rhiza:release`; it detects that the declared version has moved past the highest tag, tags the merged commit, and pushes the tag, which is what starts release CI.
