### PR TITLE
fix: quote validate-pyproject rev so pre-commit accepts it

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,7 +65,7 @@ repos:
       - id: actionlint
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: 0.26
+    rev: "0.26"
     hooks:
       - id: validate-pyproject
 

--- a/bundles/python-core/.pre-commit-config.yaml
+++ b/bundles/python-core/.pre-commit-config.yaml
@@ -70,7 +70,7 @@ repos:
         groups: ["lint", "fast"]
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: 0.26
+    rev: "0.26"
     hooks:
       - id: validate-pyproject
         groups: ["python", "fast"]


### PR DESCRIPTION
## `rev: 0.26` is parsed as a float, which kills every hook run

`.pre-commit-config.yaml` and `bundles/python-core/.pre-commit-config.yaml` both pin `validate-pyproject` with a bare `rev: 0.26`. YAML reads that as a **float**; `pre-commit` requires `rev` to be a string, so it rejects the entire config:

```
==> At Repository(repo='https://github.com/abravalheri/validate-pyproject')
==> At key: rev
=====> Expected string got float
```

This is not a validate-pyproject failure — it is a config-load failure, so **no hook runs at all** and every `git commit` in the consumer is blocked until bypassed with `--no-verify`.

### Why it went unnoticed

`prek` coerces the float and runs fine, so repos on prek never saw it. Repos on classic `pre-commit` have a dead hook config. Found in `cvxgrp/cvxrisk`, which is on prek's alternative; present in the template at both **v1.5.0 and v1.5.1**.

### The fix

Quote it: `rev: "0.26"`.

### Scope check

I parsed all four bundled configs with `yaml.safe_load` and asserted every `rev` is a `str`. `0.26` was the only offender — `0.38.0`, `1.9.4`, `0.12.5` and `1.7.0` all carry two dots, so YAML already reads them as strings. The `None` revs belong to `repo: local` hooks, which correctly omit `rev`.

### Verification

`pre-commit validate-config` passes on all four configs after the change (root, python-core, go-core, rust-core); the root config failed before it.

Consumers on v1.5.x need a re-sync (or a follow-up release) to pick this up.
