### PR TITLE
docs: retire rhiza-cli from the docs, shorten the README, and rewrite the two guides built on the make layer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What is Rhiza?
 
-Rhiza is a **collection of reusable configuration templates** for Python projects — not a runtime library. It has no `src/` directory and no runtime dependencies. Its purpose is to provide and continuously synchronize development infrastructure (Makefiles, CI workflows, linting configs, test setups) into downstream projects via the separate `rhiza-cli` tool.
+Rhiza is a **collection of reusable configuration templates** for Python, Rust and Go projects — not a runtime library. It has no `src/` directory and no runtime dependencies. Its purpose is to provide and continuously synchronize development infrastructure (the `Makefile` front door, CI workflows, linting configs, test setups) into downstream projects. The sync is performed by the `rhiza` Claude Code plugin ([rhiza-claude](https://github.com/Jebel-Quant/rhiza-claude)) — `/rhiza:update`. The `rhiza-cli` package that used to do it is unpublished and its repository archived; nothing in this repo depends on it any more.
 
 Downstream projects adopt Rhiza by adding a `.rhiza/template.yml` that lists which bundles to sync from this repository.
 
@@ -89,14 +89,14 @@ The core abstraction is the **bundle** — a named group of configuration files.
 
 ### Dogfooding (root files ↔ bundle sources)
 
-Rhiza dogfoods its own templates: the files it ships in `bundles/<name>/...` also live at the repo root so the mother repo runs on its own infrastructure. `bundles/` is the **single source of truth**, and each root dogfood file is a **relative symlink into its owning bundle** (e.g. `.rhiza/rhiza.mk` → `bundles/core/.rhiza/rhiza.mk`). Edit the bundle file; the root reflects it automatically — no second edit. Run `make sync-self` (mother-repo-only, `utils/link_dogfood.py`) to (re)create links after adding a bundle file.
+Rhiza dogfoods its own templates: the files it ships in `bundles/<name>/...` also live at the repo root so the mother repo runs on its own infrastructure. `bundles/` is the **single source of truth**, and each root dogfood file is a **relative symlink into its owning bundle** (e.g. `Makefile` → `bundles/core/Makefile`). Edit the bundle file; the root reflects it automatically — no second edit. Run `make sync-self` (mother-repo-only, `utils/link_dogfood.py`) to (re)create links after adding a bundle file.
 
 A few files **cannot** be symlinks and stay as **real copies**, kept in sync by tests (`tests/bundles/test_bundle_*_sync.py`) rather than by symlink:
 
 - `.github/*` platform config (Dependabot, release notes, secret scanning, PR template, rulesets) — GitHub reads these blobs directly and does not resolve symlinks. **Live `.github/workflows/*` are also real** (Actions won't run a symlinked workflow) and differ from the bundle stubs by design. So does **`rulesets/main-branch-protection.json`**, and for a subtler reason (#1448): here `rhiza_ci.yml` has `push:`/`pull_request:` triggers, so its jobs run top-level and report bare check-run names, while downstream the `github-tests` stub delegates via `jobs.ci` and GitHub reports them as `ci / <job name>`. The bundle copy therefore prefixes all six required contexts; `tests/bundles/test_bundle_github_sync.py` pins that relationship, including the coupling to the stub's job id.
 - `.rhiza/.gitignore` (and any `.gitignore`/`.gitattributes`) — git opens these with `O_NOFOLLOW`, so a symlink yields an ELOOP warning and the rules are ignored.
 
-Plus intentional mother-repo overrides that deliberately diverge from their bundle source: root `.gitignore`, `.pre-commit-config.yaml`, `.python-version`, `SECURITY.md`, `renovate.json`. The exclusion list lives in `utils/link_dogfood.py`. Downstream consumers are unaffected: `rhiza-cli` sparse-checks-out a bundle and dereferences symlinks on copy, so synced projects always receive real files (guarded by `test_no_symlinks_in_*`).
+Plus intentional mother-repo overrides that deliberately diverge from their bundle source: root `.gitignore`, `.pre-commit-config.yaml`, `.python-version`, `SECURITY.md`, `renovate.json`. The exclusion list lives in `utils/link_dogfood.py`. Downstream consumers are unaffected: the sync checks out a bundle and dereferences symlinks on copy, so synced projects always receive real files (guarded by `test_no_symlinks_in_*`).
 
 **What guards the invariant in CI is `tests/bundles/test_bundle_dogfood_symlinks.py`, not `make sync-self-check`.** The test runs inside `make test` on every push and PR, and it reuses `link_dogfood`'s own carve-out predicate and bundle index, so the guard and the linker cannot disagree about the rules. `sync-self-check` is the *local* equivalent — the same `--check` pass, for running before you commit a new bundle file — and no workflow invokes it. It was described as "the CI drift guard" in four places until #1532, which is the kind of claim that stops anyone checking whether the real guard still exists.
 
@@ -249,11 +249,15 @@ worth knowing before moving anything there:
   repo's own `MKDOCS_EXTRA_PACKAGES` override made that trip: it sat above the include in the
   old root `Makefile`, was lost silently when the shim replaced that file, and is
   `mkdocs-extra-packages` in `pyproject.toml` now.
-- **It is Python-only.** `_from_pyproject` reads `pyproject.toml` and nothing else, so
-  `rust-core` and `go-core` have no equivalent — a crate has `Cargo.toml`, a Go module has
-  no manifest at all. Those layers are left with `.rhiza/.env` and an exported `RHIZA_*` in
-  `local.mk` until rhiza-task grows a language-neutral source — not the `Makefile`, which is
-  synced for them too.
+- **It is no longer Python-only.** It was: `_from_pyproject` read `pyproject.toml` and
+  nothing else, so `rust-core` and `go-core` had no equivalent — a crate has `Cargo.toml`, a
+  Go module has no manifest at all — and those layers were left with `.rhiza/.env` and an
+  exported `RHIZA_*` in `local.mk`. The pinned CLI reads a root **`rhiza.toml`** as well, in
+  either the `[tool.rhiza-task]` or a flat top-level form, which is the language-neutral
+  source that was missing. Where both files exist `pyproject.toml` wins, so a Python repo
+  cannot be surprised by one. Verified against the pin rather than read off a changelog:
+  `uvx rhiza-task print <setting>` in a directory holding only a `rhiza.toml` resolves from
+  it.
 
 `.rhiza/.env` itself stays supported and `rhiza.mk` still `-include`s it — what changed is
 that the file is now unambiguously **repo-owned**, which also resolves the standing
@@ -352,7 +356,7 @@ That is fast, runs everywhere, and catches a renamed target or a gate dropped fr
 it happily.
 
 `tests/e2e/` closes that gap. For each layer it copies the bundles into a temp
-directory (standing in for a `rhiza-cli` sync), writes the smallest project the layer
+directory (standing in for a `/rhiza:update` sync), writes the smallest project the layer
 should be green on (`tests/e2e/scaffolds.py`), commits it, and runs every gate for
 real — `install`, `test`, `coverage`, `typecheck`, `docs-coverage`, `security`,
 `license`, `deps`, `fmt` and the `all` aggregate. The failure mode it exists for is

--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ In the original Greek, spelt **ῥίζα**, pronounced *ree-ZAH*, and having the
 
 ## 🌟 Why Rhiza?
 
-**Unlike traditional project templates** (like cookiecutter or copier) that generate a one-time snapshot of configuration files, **Rhiza provides living templates** that evolve with your project. Classic templates help you start a project, but once generated, your configuration drifts away from the template as best practices change. Rhiza takes a different approach: it enables **continuous synchronization**, allowing you to selectively pull template updates into your project over time through automated workflows. This means you can benefit from improvements to CI/CD workflows, linting rules, and development tooling without manually tracking upstream changes. Think of it as keeping your project's foundation fresh and aligned with modern practices, while maintaining full control over what gets updated.
+Cookiecutter and copier generate a project once and then let go of it. Rhiza keeps the
+connection: your configuration is **synced** from a template repository, so improvements to CI
+workflows, linting rules and tooling reach every project that follows it — on your schedule, and
+only where you allow. For the full comparison, see
+[Why not copier or cruft?](docs/reference/WHY_NOT_COPIER_CRUFT.md).
 
 ### Rhiza and its companions
 
@@ -55,10 +59,9 @@ In short: **rhiza** is the *what* (the template files you receive); the companio
 
 ### How It Works
 
-Rhiza uses a simple configuration file (`.rhiza/template.yml`) to control which templates sync to your project. The recommended approach is to select a **profile** — a named preset for common project contexts — or to select individual **bundles** for full control:
+One file, `.rhiza/template.yml`, says which template you follow and what you want from it:
 
 ```yaml
-# .rhiza/template.yml — profile-based (recommended)
 repository: "Jebel-Quant/rhiza"
 ref: "v1.5.1"
 
@@ -66,62 +69,28 @@ profiles:
   - github-project
 ```
 
-```yaml
-# .rhiza/template.yml — bundle-based (advanced)
-repository: "Jebel-Quant/rhiza"
-ref: "v1.5.1"
+A **profile** is a named preset that expands to a set of **bundles**; you can add individual
+bundles alongside it, and `include`/`exclude` patterns for the last mile. `ref` is a tag, so
+Renovate can raise it for you — its manager only matches the quoted form shown above, which is
+what `/rhiza:init` writes.
 
-templates:
-  - core
-  - python-core
-  - tests
-  - github
-  - github-tests
-  - docker
-```
+`/rhiza:update` then fetches what your selection owns and three-way merges it into a branch, so
+local edits survive and you review the result as a pull request.
 
-**What you're seeing:**
-- **`repository`** - The upstream template source (**can be any repository, not just Rhiza!**)
-- **`ref`** - Which version tag/branch to sync from (e.g., `v1.5.1` or `main`)
-- **`profiles`** - Named presets that expand to a set of bundles (see [Profiles](#profiles-recommended-starting-point) below)
-- **`templates`** - Individual template bundles for advanced or additional selection
-
-For advanced use cases you can still use explicit `include`/`exclude` file patterns alongside or instead of bundles:
-
-```yaml
-# Advanced: file-pattern based selection
-include: |
-  .github/workflows/*.yml
-  ruff.toml
-
-exclude: |
-  docs/development/DOCKER.md
-```
-
-> **💡 Automated Updates:** When using a version tag (e.g., `v1.5.1`) instead of a branch name, Renovate will automatically create pull requests to update the `ref` field when new versions are released. This keeps your templates up-to-date with minimal manual intervention.
->
-> To enable this in your project, copy the `customManagers` entry that matches `.rhiza/template.yml` from this repository's [`renovate.json`](renovate.json) into your own Renovate configuration.
->
-> **Quote the values.** That manager's `matchStrings` only match `repository: "..."` and
-> `ref: "..."` — an unquoted pin is not an error, it simply never gets found, and the `ref`
-> then ages silently. `/rhiza:init` writes the quoted form for exactly this reason.
-
-When you run `/rhiza:update`, Rhiza fetches only the files your bundle selection owns, skips anything in `exclude`, and three-way merges them into a branch — so local edits survive and you review the result as a pull request. You stay in control of what updates and when.
-
-**💡 Pro Tip:** While you can use `Jebel-Quant/rhiza` directly, **we recommend creating your own template repository** using GitHub's "Use this template" button. This gives you a clean copy to customise for your organisation's specific needs and constraints—adjusting CI workflows, coding standards, or tooling choices—while still benefiting from Rhiza's sync mechanism. Your template repo becomes your team's source of truth, and you can selectively pull updates from upstream Rhiza when desired.
+**The anatomy of that file, the sync lifecycle and the Renovate wiring are
+[rhiza-education](https://github.com/Jebel-Quant/rhiza-education) Lessons 7–9** — this README
+does not try to teach them.
 
 ## 📚 Table of Contents
 
 - [Why Rhiza?](#-why-rhiza)
 - [Quick Start](#-quick-start)
 - [What You Get](#-what-you-get)
-- [Architecture Decision Records](#-architecture-decision-records)
 - [Available Templates](#-available-templates)
 - [Integration Guide](#-integration-guide)
 - [Available Tasks](#-available-tasks)
-- [Advanced Topics](#-advanced-topics)
-- [CI/CD Support](#-cicd-support)
-- [Project Maintainability](#-project-maintainability)
+- [Customising Safely](#-customising-safely)
+- [Documentation Map](#-documentation-map)
 - [Learning Resources](#-learning-resources)
 - [Contributing to Rhiza](#-contributing-to-rhiza)
 
@@ -147,20 +116,9 @@ nothing, so its PR looks almost empty — that is correct. `/rhiza:update` is wh
 workflows, the `Makefile` and the rest, which keeps one code path responsible for
 materialising template files.
 
-See the [Integration Guide](#-integration-guide) for more options, or follow the [step-by-step tutorial](https://github.com/Jebel-Quant/rhiza-education) in rhiza-education (Lessons 6–8).
-
-### For Contributing to Rhiza
-
-If you want to develop Rhiza itself:
-
-```bash
-# Clone the repository
-git clone https://github.com/jebel-quant/rhiza.git
-cd rhiza
-
-# Install dependencies
-make install
-```
+More options are in the [Integration Guide](#-integration-guide); the step-by-step version is
+[rhiza-education Lesson 6](https://github.com/Jebel-Quant/rhiza-education/blob/main/lessons/06-getting-started.md).
+To work on Rhiza itself rather than use it, see [Contributing](#-contributing-to-rhiza).
 
 ## ✨ What You Get
 
@@ -177,39 +135,14 @@ Adopt a Rhiza bundle and your project immediately gains:
 
 ## 📝 Architecture Decision Records
 
-This project maintains Architecture Decision Records (ADRs) to document important architectural and design decisions.
-
-ADRs help preserve the reasoning behind key decisions, making it easier for current and future contributors to understand why the project is structured the way it is.
-
-**Browse ADRs**: See [docs/adr/](docs/adr/) for all architecture decisions.
-
-**Key decisions documented:**
-- [ADR-0001: Use Architecture Decision Records](docs/adr/0001-use-architecture-decision-records.md)
-- [ADR-0002: Use uv for Python Package and Environment Management](docs/adr/0002-use-uv-for-python-package-management.md)
-- [ADR-0003: Use Ruff for Linting and Formatting](docs/adr/0003-use-ruff-for-linting-and-formatting.md)
-- [ADR-0004: Adopt a Modular Makefile Architecture](docs/adr/0004-adopt-modular-makefile-architecture.md) *(superseded by ADR-0011)*
-- [ADR-0005: Separate rhiza Template Repository from rhiza-cli](docs/adr/0005-separate-rhiza-template-from-cli.md)
-- [ADR-0006: Organise Templates into Bundles](docs/adr/0006-organise-templates-into-bundles.md)
-- [ADR-0007: Support Dual CI/CD with GitHub Actions and GitLab CI](docs/adr/0007-support-dual-cicd-github-and-gitlab.md)
-- [ADR-0008: Use Marimo for Interactive Notebooks](docs/adr/0008-use-marimo-for-interactive-notebooks.md)
-- [ADR-0009: Use Pre-commit Hooks for Automated Code Quality Enforcement](docs/adr/0009-use-pre-commit-hooks-for-code-quality.md)
-- [ADR-0010: Introduce a Layered Bundle and Profile Model](docs/adr/0010-layered-bundle-profile-model.md)
-- [ADR-0011: Replace the Synced Make Layer with a Pinned CLI](docs/adr/0011-replace-the-synced-make-layer-with-a-pinned-cli.md)
-
-**Create a new ADR**: Copy the template in [docs/adr/](docs/adr/), give it the next number, and open a pull request for review.
-
-For more information about the ADR format and how to create new records, see the [ADR README](docs/adr/README.md).
+The reasoning behind Rhiza's structural decisions — bundles, the layered profile model, the
+uv/ruff/prek choices, the retirement of the synced make layer — is recorded as ADRs.
+**[docs/adr/](docs/adr/)** holds the index, with each record's status and date.
 
 ## 📁 Available Templates
 
-- 🚀 **CI/CD Templates** - Ready-to-use GitHub Actions and GitLab CI workflows
-- 🧪 **Testing Framework** - Comprehensive test setup with pytest
-- 📚 **Documentation** - Automated documentation site via MkDocs + zensical, with optional Marimo notebook exports
-- 🔍 **Code Quality** - Linting with ruff, formatting, and dependency checking with deptry
-- 📝 **Editor Configuration** - Cross-platform .editorconfig for consistent coding style
-- 📊 **Marimo Integration** - Interactive notebook support for documentation and exploration
-- 🎤 **Presentations** - Generate slides from Markdown using Marp
-- 🐳 **Containerization** - Docker and Dev Container configurations
+Bundles are the atomic unit: each owns a coherent set of files, and any bundle can be selected
+on its own — its dependencies resolve automatically. Profiles compose them for common contexts.
 
 ### Profiles (Recommended Starting Point)
 
@@ -299,91 +232,25 @@ For a complete reference of every file included in each bundle, see [`.rhiza/tem
 
 ## 🧩 Integration Guide
 
-Rhiza provides reusable configuration templates that you can integrate into your existing Python, Rust or Go projects.
+**Prerequisites:** [Claude Code](https://claude.com/claude-code) with the `rhiza` plugin,
+[uv](https://docs.astral.sh/uv/), Git, GNU Make 3.81+, and a toolchain for your language (`uv`
+manages the Python one). A `python-core` project also needs a `[project]` table in
+`pyproject.toml` and a `.python-version`; a Rust or Go project needs neither.
 
-### Prerequisites
+Run `/rhiza:init`, merge, then `/rhiza:update`. Afterwards:
 
-- **[Claude Code](https://claude.com/claude-code)** with the `rhiza` plugin installed — this is the interface
-- **[uv](https://docs.astral.sh/uv/)** - runs the plugin's scripts and every gate, whatever the project's language
-- **Git** - Your project should be a Git repository
-- **A toolchain for your language** - Python 3.11+, a Rust toolchain, or Go; `uv` manages the Python one for you
-- **Backup** - Consider committing any uncommitted changes before integration
+| Command | What it tells you |
+|---------|-------------------|
+| `/rhiza:status` | What the pointer says, and what the last sync actually delivered |
+| `/rhiza:status --check` | Whether the template has moved on — read-only |
+| `/rhiza:update v1.4.2` | Sync a specific release rather than the latest |
+| `/rhiza:quality` | A score for the result, with findings |
+| `/rhiza:detach` | Stop being template-managed, keeping the files |
+| `make doctor` | Whether your local tools and versions are what the gates expect |
 
-### Automated Integration (Recommended)
-
-The fastest way to integrate Rhiza, from your repository's directory in Claude Code:
-
-```text
-/rhiza:init      # writes .rhiza/template.yml, picking a profile from your platform and language
-/rhiza:update    # applies the sync and opens a PR of template-owned files only
-```
-
-**Options:**
-- `/rhiza:update v1.4.2` - sync a specific template release instead of the latest
-- `/rhiza:status` - report what the pointer says and what the last sync actually delivered
-- `/rhiza:status --check` - report upstream drift without changing anything
-- `/rhiza:detach` - stop being template-managed, keeping the files
-
-For a full step-by-step tutorial covering init, bundle selection, first materialise, and the sync lifecycle, see **[rhiza-education Lessons 6–8](https://github.com/Jebel-Quant/rhiza-education)**.
-
-### What to Expect After Integration
-
-- **Automated CI/CD** - GitHub Actions workflows for testing, linting, and releases
-- **Code Quality Tools** - Pre-commit hooks, ruff formatting, and pytest configuration
-- **Task Automation** - Makefile with common development tasks
-- **Dev Container** - Optional VS Code/Codespaces environment
-- **Documentation** - Automated documentation generation
-
-### Downstream Project Requirements
-
-For Rhiza templates to work correctly, your project must satisfy these expectations before and after sync.
-
-**Project structure**
-
-| Requirement | Details |
-|-------------|---------|
-| Git repository | `git init` or cloned — Rhiza does not initialise git |
-| `pyproject.toml` | *(`python-core`)* Must have `[project]` with `name`, `version`, `description`, `readme`, and `requires-python` (all non-empty strings), plus a `[dependency-groups]` table |
-| `.python-version` | *(`python-core`)* Single line specifying the target Python version (e.g. `3.13`) — used by `uv` and CI. A Rust or Go project ships none |
-| `.rhiza/template.yml` | Created by `/rhiza:init` — specifies `repository`, `ref`, and bundle/profile selection |
-| `.rhiza/template.lock` | Written by each sync — the record of what actually arrived, and the list `/rhiza:update` is allowed to stage |
-
-**Tool requirements**
-
-| Tool | Minimum version | Notes |
-|------|-----------------|-------|
-| **GNU Make** | 3.81 | macOS ships BSD make; install via `brew install make` and use `gmake` |
-| **uv** | 0.5.0 | Installed automatically by any `make` target if missing (into `./bin`) |
-| **Python** | 3.11 | *(`python-core`)* Managed automatically by `uv` via `.python-version` |
-
-**What Rhiza owns vs what you own**
-
-| Path | Owner | Notes |
-|------|-------|-------|
-| `.rhiza/` | Rhiza | Template-managed; overwritten on sync — except `.rhiza/.env`, which is yours (and gitignored, so developer-local) |
-| `.github/workflows/rhiza_*.yml` | Rhiza | Template-managed workflow stubs |
-| `Makefile` | Rhiza | Template-managed, and it carries the `RHIZA_TASK` pin — nothing you append to it survives a sync |
-| `ruff.toml`, `.editorconfig`, `.pre-commit-config.yaml` | Rhiza | Template-managed config files |
-| `pyproject.toml` | Yours | Never synced — `/rhiza:init` creates it, then it's yours; `rhiza-test` only checks its structure |
-| `src/` or application code | Yours | Never touched by Rhiza |
-| `tests/` | Yours | Never touched by Rhiza |
-| `local.mk` | Yours | Your own make targets — `-include`d by the `Makefile`, never synced, and deliberately *not* gitignored, so commit it (anything your CI invokes has to be in the repository) |
-
-**Safe extension points** (survive every sync):
-- **`local.mk`** — your own targets. An explicit rule beats the shim's `%:` catch-all, so an `install:` rule here can call `uvx $(RHIZA_TASK) install` and then your extra step. This is what replaced the retired `pre-install::` / `post-install::` hooks
-- **`[tool.rhiza-task]` in `pyproject.toml`** — project settings such as `source-folder`, read by the task runner. `uvx rhiza-task print <setting>` shows what one currently resolves to
-- **`pyproject.toml`** — add dependencies, scripts, and tool configs freely
-
-See [docs/guides/CUSTOMIZATION.md](docs/guides/CUSTOMIZATION.md) for worked examples.
-
-### Troubleshooting Integration
-
-- Start with `make doctor` to validate required tools and versions.
-- For bundle sync failures and recovery steps, see [docs/troubleshooting.md](docs/troubleshooting.md).
-- **Makefile conflicts**: Merge targets with existing build scripts
-- **Pre-commit failures**: Run `make fmt` to fix formatting issues
-- **Workflow failures**: Check Python version in `.python-version` and `pyproject.toml`
-- **Dev container issues**: See [.devcontainer/README.md](bundles/devcontainer/.devcontainer/README.md)
+**A worked first run — empty directory to synced, scored repository — is
+[rhiza-education Lesson 6](https://github.com/Jebel-Quant/rhiza-education/blob/main/lessons/06-getting-started.md).**
+For sync failures and recovery, see [docs/troubleshooting.md](docs/troubleshooting.md).
 
 ## 📋 Available Tasks
 
@@ -532,36 +399,44 @@ Repo-owned targets:
 > When you modify Makefile targets, the `update-readme-help` pre-commit hook
 > updates this section automatically.
 
-## 🎯 Advanced Topics
+## 🎯 Customising Safely
 
-### Marimo Notebooks
+Everything a sync delivers is **template-owned and overwritten by the next one** — the
+`Makefile` included, since `core` ships it. Extensions live in four places no sync touches:
 
-This project supports [Marimo](https://marimo.io/) notebooks for interactive documentation and exploration.
+| Where | For |
+|-------|-----|
+| `local.mk` | Your own make targets, and extending a template task by shadowing it |
+| `[tool.rhiza-task]` in `pyproject.toml` (or `rhiza.toml`) | Settings — `source-folder`, `coverage-fail-under`, … |
+| `pyproject.toml` | Dependencies, scripts, other tools' configuration |
+| `.rhiza/.env` | Developer-local overrides (gitignored) |
 
-```bash
-make marimo  # Start Marimo server
-```
+`local.mk` is deliberately **not** gitignored: commit it, because anything CI invokes has to be
+in the repository.
 
-For configuration details including dependency management and pythonpath setup, see the [Marimo documentation](https://marimo.io/).
+### Makefile Customisation
 
-### Presentations
+The `Makefile` pins `RHIZA_TASK`, and that pin is the whole version contract: syncing a newer
+template moves your gates forward. A `%:` catch-all forwards unmatched targets to that CLI, and
+an explicit rule always beats it:
 
-Generate presentation slides using [Marp](https://marp.app/):
+- **Add a target** — write it in `local.mk`, which the `Makefile` `-include`s. A `##` comment
+  puts it in `make help` under *Repo-owned targets*.
+- **Extend a task** — shadow it. An explicit `install:` rule can call `uvx $(RHIZA_TASK) install`
+  and then your extra step. This replaces the `pre-install::` / `post-install::` hooks the synced
+  make layer anchored, which are gone.
+- **Change a setting** — the table above. `uvx rhiza-task list` shows the tasks and
+  `uvx rhiza-task print <setting>` what one currently resolves to.
 
-```bash
-make presentation        # Generate HTML slides
-make presentation-pdf    # Generate PDF slides
-make presentation-serve  # Serve with live reload
-```
-
-For detailed information about creating and customising presentations, see [presentation/README.md](docs/presentations/README.md).
+Worked examples: [CUSTOMIZATION.md](docs/guides/CUSTOMIZATION.md) and
+[EXTENDING_RHIZA.md](docs/guides/EXTENDING_RHIZA.md). The tutorial version is
+[rhiza-education Lesson 10](https://github.com/Jebel-Quant/rhiza-education/blob/main/lessons/10-customizing-safely.md).
 
 ### Documentation Examples
 
 README code blocks are executable documentation. With the `tests` bundle selected,
-`make rhiza-test` runs each `python` fence and diffs its output against the `result` block
-that follows, so an example cannot quietly stop working. (`make docs-examples` does the
-same job for the fences under the docs tree.)
+`make rhiza-test` runs each `python` fence and diffs its output against the `result` block that
+follows, so an example cannot quietly stop working.
 
 ```python
 # Example code block
@@ -579,143 +454,67 @@ Hello, World!
 0.71
 ```
 
-### Documentation Customisation
+## 📚 Documentation Map
 
-For information on customising the look and feel of your documentation, see [book/README.md](docs/guides/BOOK.md).
+| Topic | Where |
+|-------|-------|
+| Command and file cheat sheet | [QUICK_REFERENCE.md](docs/guides/QUICK_REFERENCE.md) |
+| Every bundle and profile | [BUNDLE_TAXONOMY.md](docs/reference/BUNDLE_TAXONOMY.md) |
+| Terms used throughout | [GLOSSARY.md](docs/reference/GLOSSARY.md) |
+| The tools in the stack | [TOOLS_REFERENCE.md](docs/reference/TOOLS_REFERENCE.md) |
+| Docs site (MkDocs + zensical) | [BOOK.md](docs/guides/BOOK.md) |
+| Marimo notebooks · Marp slides | [MARIMO.md](docs/development/MARIMO.md) · [PRESENTATION.md](docs/development/PRESENTATION.md) |
+| Dev containers · Docker | [DEVCONTAINER.md](docs/development/DEVCONTAINER.md) · [DOCKER.md](docs/development/DOCKER.md) |
+| Releases and the changelog | [CHANGELOG_GUIDE.md](docs/ops/CHANGELOG_GUIDE.md) |
+| What CI enforces, and where | [CI_ENFORCEMENT.md](docs/operations/CI_ENFORCEMENT.md) |
+| Technical debt · roadmap | [TECHNICAL_DEBT.md](docs/ops/TECHNICAL_DEBT.md) · [PROJECT_BOARD.md](docs/ops/PROJECT_BOARD.md) |
+| One patch across many bundles | [GLOBAL_PATCH.md](docs/ops/GLOBAL_PATCH.md) |
 
-### Python Version Management
-
-The `.python-version` file specifies the default Python version for local development. Tools like `uv` and `pyenv` automatically use this version. Simply update this file to change your local Python version.
-
-### Makefile Customisation
-
-The `Makefile` comes from the `core` bundle like every other config file, so a sync delivers it
-and a sync overwrites it — nothing you add to it survives. It pins `RHIZA_TASK`, which is the
-whole version contract: syncing a newer template moves your gates forward. A `%:` catch-all
-forwards unmatched targets to the pinned CLI, and an explicit rule always beats it:
-
-- **Add a target** — write it in `local.mk`, which the `Makefile` `-include`s and which no sync
-  touches. It is deliberately not gitignored, so commit it: anything your CI invokes has to be
-  in the repository.
-- **Extend a task** — shadow it. An explicit `install:` rule wins over the catch-all, so it can
-  call `uvx $(RHIZA_TASK) install` and then your extra step. This replaces the
-  `pre-install::`/`post-install::` hooks the synced make layer anchored.
-- **Change a setting** — a `[tool.rhiza-task]` table in `pyproject.toml`, or `rhiza.toml` for a
-  project with no Python manifest. See `uvx rhiza-task list` for the tasks and
-  `uvx rhiza-task print <setting>` for what a setting currently resolves to.
-
-### Custom Build Scripts
-
-For system dependencies and custom build steps, see [docs/guides/CUSTOMIZATION.md](docs/guides/CUSTOMIZATION.md).
-
-### Private GitHub Packages
-
-Rhiza's template workflows automatically support private GitHub packages from the same organization. Simply add them to your `pyproject.toml`:
-
-**In `pyproject.toml`:**
-```toml
-[tool.uv.sources]
-my-package = { git = "https://github.com/jebel-quant/my-package.git", rev = "v1.0.0" }
-```
-
-**Git authentication is already configured** in all Rhiza workflows (CI, book, release, etc.) using the default `GITHUB_TOKEN`, which automatically provides read access to repositories in the same organization.
-
-For custom workflows or local development setup, see [docs/development/DOCKER.md](docs/development/DOCKER.md).
-
-### Release Management
-
-For information on versioning, tagging, and publishing releases, run `make help` and see the `Releasing and Versioning` section, or refer to [docs/ops/CHANGELOG_GUIDE.md](docs/ops/CHANGELOG_GUIDE.md).
-
-### Dev Container
-
-This repository includes a template Dev Container configuration for seamless development in VS Code and GitHub Codespaces. See [docs/development/DEVCONTAINER.md](docs/development/DEVCONTAINER.md) for setup, configuration, and troubleshooting.
-
-For details about the VS Code extensions configured in the Dev Container, see [docs/development/VSCODE_EXTENSIONS.md](docs/development/VSCODE_EXTENSIONS.md).
+**Private packages:** the workflows already configure git authentication with the default
+`GITHUB_TOKEN`, so a `[tool.uv.sources]` entry pointing at another repository in the same
+organisation works with no extra setup.
 
 ## 🔄 CI/CD Support
 
-### GitHub Actions
+GitHub Actions and GitLab CI have feature parity: tests across operating systems and Python
+versions, hooks and gates, docs publishing, notebooks, containers, releases, security scanning
+and weekly maintenance. Choose the platform by profile — `github-project` or `gitlab-project` —
+and the matching workflow stubs arrive with it. Syncing is not a workflow: `/rhiza:update` runs
+it from your machine and opens the PR.
 
-The `.github/` directory contains comprehensive GitHub Actions workflows for:
-- CI testing across multiple Python versions and operating systems
-- Pre-commit checks and code quality
-- The gates — typecheck, security, licences, dependencies
-- Documentation building, and Marimo notebook publishing
-- Docker and devcontainer validation
-- Release automation, CodeQL, Scorecard, and weekly maintenance
-
-Syncing is not a workflow: `/rhiza:update` performs it from your machine and opens the PR.
-
-### GitLab CI/CD
-
-Rhiza provides GitLab CI/CD workflow configurations with feature parity to GitHub Actions. The `gitlab` bundle materialises a `.gitlab-ci.yml` plus `.gitlab/workflows/` pipelines for CI, quality, documentation, Renovate, paper compilation, weekly maintenance, and releases.
-
-**Quick setup:** select the `gitlab-project` profile in `.rhiza/template.yml` and run `/rhiza:update`:
-
-```yaml
-profiles:
-  - gitlab-project
-```
-
-For complete GitLab setup instructions, configuration variables, and troubleshooting, see **[.gitlab/README.md](bundles/gitlab/.gitlab/README.md)**.
-
-## 📋 Project Maintainability
-
-Rhiza includes comprehensive maintainability features to help track project health and evolution:
-
-### Roadmap & Planning
-
-- **[docs/PROJECT_BOARD.md](docs/ops/PROJECT_BOARD.md)** - Guide for setting up GitHub Project Boards to track enhancements and roadmap items
-- **[docs/GLOBAL_PATCH.md](docs/ops/GLOBAL_PATCH.md)** - Workflow for propagating the same patch across repeated bundle files
-
-### Technical Debt Tracking
-
-- **[docs/TECHNICAL_DEBT.md](docs/ops/TECHNICAL_DEBT.md)** - Scope and standing trade-offs; open items are tracked as GitHub issues labelled `technical-debt`
-- **`make todos`** - Automated scanning for TODO, FIXME, and HACK comments across the codebase
-
-### Changelog Management
-
-- **[docs/CHANGELOG_GUIDE.md](docs/ops/CHANGELOG_GUIDE.md)** - Guide for enhanced changelog generation with PR categorization
-- **[.github/release.yml](.github/release.yml)** - Automated PR categorization for release notes
-
-Run `make todos` to scan for technical debt markers in your codebase, or explore the roadmap and technical debt documents to understand project evolution and planned improvements.
+GitLab specifics (variables, runners, Pages) are in
+**[.gitlab/README.md](bundles/gitlab/.gitlab/README.md)**; what each check enforces and where it
+runs is in [CI_ENFORCEMENT.md](docs/operations/CI_ENFORCEMENT.md).
 
 ## 📖 Learning Resources
 
-For a structured, tutorial-style introduction to Rhiza — covering CI/CD concepts, `uv`, Python project conventions, the sync lifecycle, and the full Rhiza ecosystem — see the companion education repository:
+This README is a reference. The **tutorial** is a separate repository, and the better place to
+start if any of this is new:
 
-**[jebel-quant/rhiza-education](https://github.com/Jebel-Quant/rhiza-education)** · [Rendered site](https://jebel-quant.github.io/rhiza-education/)
+**[jebel-quant/rhiza-education](https://github.com/Jebel-Quant/rhiza-education)** ·
+[rendered site](https://jebel-quant.github.io/rhiza-education/)
 
-The curriculum walks you through twelve lessons in order, from the motivation for living templates all the way to running your first sync, configuring Renovate, and customising safely.
+Twelve lessons in order, from the problem living templates solve to running your first sync:
+CI/CD concepts and `uv` (1–2), Python project conventions (3), why Rhiza and its core concepts
+(4–5), **getting started** (6), configuring `template.yml` (7), the sync lifecycle (8), Renovate
+(9), customising safely (10), the wider ecosystem (11), further reading (12). Appendices cover
+GitLab users and real projects using Rhiza.
 
 ## 🛠️ Contributing to Rhiza
 
-Contributions are welcome! To contribute to Rhiza itself (not using Rhiza in your project):
+To work on Rhiza itself, you need GNU Make, Git and `uv`; `make install` provisions the rest,
+Python included.
 
-### Prerequisites
+```bash
+git clone https://github.com/jebel-quant/rhiza.git
+cd rhiza
+make install
+make test && make fmt
+```
 
-| Tool | Minimum version | Notes |
-|---|---|---|
-| **GNU Make** | 3.81 | Must be GNU Make — macOS ships BSD make; install via `brew install make` and use `gmake` |
-| **uv** | 0.5.0 | Installed automatically by `make install` if missing |
-| **Git** | 2.x | |
-| **Python** | 3.11 | Managed automatically by `uv` |
-
-### Steps
-
-1. Fork the repository
-2. Clone and setup:
-   ```bash
-   git clone https://github.com/your-username/rhiza.git
-   cd rhiza
-   make install
-   ```
-3. Create your feature branch (`git checkout -b feature/amazing-feature`)
-4. Make your changes and test (`make test && make fmt`)
-5. Commit your changes (`git commit -m 'Add some amazing feature'`)
-6. Push to the branch (`git push origin feature/amazing-feature`)
-7. Open a Pull Request
-
+Branch, commit, open a PR. [CONTRIBUTING.md](.rhiza/CONTRIBUTING.md) has the conventions,
+[TESTS.md](docs/development/TESTS.md) explains the suite's layout, and
+[EXTENDING_RHIZA.md](docs/guides/EXTENDING_RHIZA.md) is the checklist for adding a bundle.
 
 ## 📄 License
 

--- a/README.md
+++ b/README.md
@@ -49,13 +49,11 @@ This repository is the *template content* only. Everything that **acts** on that
 
 In short: **rhiza** is the *what* (the template files you receive); the companions are the *how*.
 
-> **⚠️ `rhiza-cli` is retired.** Earlier versions of this README documented `uvx rhiza init`
-> and `uvx rhiza sync`. Those commands no longer work: the package is unpublished and
-> [its repository](https://github.com/Jebel-Quant/rhiza-cli) is archived. The sync is now a
-> stdlib-only script bundled with the Claude Code plugin, so beyond `uv`, `git` and `make`
-> there is nothing to install but the plugin itself. The boundary
-> [ADR-0005](docs/adr/0005-separate-rhiza-template-from-cli.md) drew is unchanged — template
-> content here, engine elsewhere; only the engine moved.
+> **⚠️ `rhiza-cli` is retired.** `uvx rhiza init` and `uvx rhiza sync`, which earlier versions
+> of this README documented, no longer work: the package is unpublished and
+> [its repository](https://github.com/Jebel-Quant/rhiza-cli) archived. Its sync now ships
+> inside the Claude Code plugin, so beyond `uv`, `git` and `make` there is nothing to install
+> but the plugin itself.
 
 ### How It Works
 
@@ -132,12 +130,6 @@ Adopt a Rhiza bundle and your project immediately gains:
 - **Documentation** via MkDocs + zensical, with optional Marimo notebook exports
 - **Release automation** — version bumping, OIDC PyPI publishing, optional grayskull conda recipe generation (`vars.PUBLISH_CONDA`, defaults to `true`), SLSA provenance
 - **Security scanning** — CodeQL, bandit, secret scanning, Dependabot
-
-## 📝 Architecture Decision Records
-
-The reasoning behind Rhiza's structural decisions — bundles, the layered profile model, the
-uv/ruff/prek choices, the retirement of the synced make layer — is recorded as ADRs.
-**[docs/adr/](docs/adr/)** holds the index, with each record's status and date.
 
 ## 📁 Available Templates
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 Creating and maintaining technical harmony across repositories.
 
 A collection of reusable configuration templates
-for modern Python projects.
+for modern Python, Rust and Go projects.
 Save time and maintain consistency across your projects
 with these pre-configured templates.
 
@@ -31,16 +31,27 @@ In the original Greek, spelt **ῥίζα**, pronounced *ree-ZAH*, and having the
 
 **Unlike traditional project templates** (like cookiecutter or copier) that generate a one-time snapshot of configuration files, **Rhiza provides living templates** that evolve with your project. Classic templates help you start a project, but once generated, your configuration drifts away from the template as best practices change. Rhiza takes a different approach: it enables **continuous synchronization**, allowing you to selectively pull template updates into your project over time through automated workflows. This means you can benefit from improvements to CI/CD workflows, linting rules, and development tooling without manually tracking upstream changes. Think of it as keeping your project's foundation fresh and aligned with modern practices, while maintaining full control over what gets updated.
 
-### Rhiza and rhiza-cli
+### Rhiza and its companions
 
-Rhiza has two distinct components:
+This repository is the *template content* only. Everything that **acts** on that content — syncing it, running the gates it configures, checking the result — lives in a separate, independently versioned package:
 
-- **[rhiza](https://github.com/jebel-quant/rhiza)** (this repository) — the *template content*: the curated set of configuration files, Makefile modules, CI/CD workflows, and tooling files that downstream projects sync from.
-- **[rhiza-cli](https://pypi.org/project/rhiza-cli/)** — the *CLI engine*: a separate Python package (installed on-the-fly via `uvx`) that provides the `rhiza` command and implements operations such as `init`, `sync`, `bump`, and `release`.
+| Component | What it is | How you get it |
+|-----------|------------|----------------|
+| **[rhiza](https://github.com/jebel-quant/rhiza)** (this repository) | The template content: bundles of config files, CI/CD workflow stubs, and docs | Synced into your project |
+| **[rhiza-claude](https://github.com/Jebel-Quant/rhiza-claude)** | The Claude Code plugin that drives adoption — `/rhiza:init`, `/rhiza:update`, `/rhiza:status`, `/rhiza:quality`, `/rhiza:docs`, `/rhiza:release` | `/plugin install rhiza@rhiza-claude` |
+| **[rhiza-task](https://pypi.org/project/rhiza-task/)** | The task runner behind every target the `Makefile` forwards: `install`, `test`, `fmt` and every gate | Pinned as `RHIZA_TASK` in the synced `Makefile`, run through `uvx` |
+| **[pytest-rhiza](https://github.com/jebel-quant/pytest-rhiza)** | The conformance checks a managed repo runs against itself (`make rhiza-test`) | Installed by that gate, at the version pinned in `[tool.rhiza-task]` |
+| **[rhiza-hooks](https://github.com/Jebel-Quant/rhiza-hooks)** | The Rhiza-specific hooks named by the synced `.pre-commit-config.yaml` | Pinned by that config |
 
-In short: **rhiza** is the *what* (the template files you receive); **rhiza-cli** is the *how* (the tool that fetches and applies them).
+In short: **rhiza** is the *what* (the template files you receive); the companions are the *how*.
 
-When you run `uvx rhiza init` or `uvx rhiza sync`, you are invoking the `rhiza-cli` package — it reads your `.rhiza/template.yml` and syncs the matching files from this repository (or your own fork) into your project. The two components are versioned independently, so templates and the CLI can be updated separately.
+> **⚠️ `rhiza-cli` is retired.** Earlier versions of this README documented `uvx rhiza init`
+> and `uvx rhiza sync`. Those commands no longer work: the package is unpublished and
+> [its repository](https://github.com/Jebel-Quant/rhiza-cli) is archived. The sync is now a
+> stdlib-only script bundled with the Claude Code plugin, so beyond `uv`, `git` and `make`
+> there is nothing to install but the plugin itself. The boundary
+> [ADR-0005](docs/adr/0005-separate-rhiza-template-from-cli.md) drew is unchanged — template
+> content here, engine elsewhere; only the engine moved.
 
 ### How It Works
 
@@ -48,8 +59,8 @@ Rhiza uses a simple configuration file (`.rhiza/template.yml`) to control which 
 
 ```yaml
 # .rhiza/template.yml — profile-based (recommended)
-repository: Jebel-Quant/rhiza
-ref: v0.14.0
+repository: "Jebel-Quant/rhiza"
+ref: "v1.5.1"
 
 profiles:
   - github-project
@@ -57,11 +68,12 @@ profiles:
 
 ```yaml
 # .rhiza/template.yml — bundle-based (advanced)
-repository: Jebel-Quant/rhiza
-ref: v0.14.0
+repository: "Jebel-Quant/rhiza"
+ref: "v1.5.1"
 
 templates:
   - core
+  - python-core
   - tests
   - github
   - github-tests
@@ -70,7 +82,7 @@ templates:
 
 **What you're seeing:**
 - **`repository`** - The upstream template source (**can be any repository, not just Rhiza!**)
-- **`ref`** - Which version tag/branch to sync from (e.g., `v0.14.0` or `main`)
+- **`ref`** - Which version tag/branch to sync from (e.g., `v1.5.1` or `main`)
 - **`profiles`** - Named presets that expand to a set of bundles (see [Profiles](#profiles-recommended-starting-point) below)
 - **`templates`** - Individual template bundles for advanced or additional selection
 
@@ -86,11 +98,15 @@ exclude: |
   docs/development/DOCKER.md
 ```
 
-> **💡 Automated Updates:** When using a version tag (e.g., `v0.7.1`) instead of a branch name, Renovate will automatically create pull requests to update the `ref` field when new versions are released. This keeps your templates up-to-date with minimal manual intervention.
+> **💡 Automated Updates:** When using a version tag (e.g., `v1.5.1`) instead of a branch name, Renovate will automatically create pull requests to update the `ref` field when new versions are released. This keeps your templates up-to-date with minimal manual intervention.
 >
-> To enable this in your project, copy the [`regexManagers` configuration](renovate.json#L31-L40) from this repository's `renovate.json` file into your own Renovate configuration. See the linked configuration for the complete setup.
+> To enable this in your project, copy the `customManagers` entry that matches `.rhiza/template.yml` from this repository's [`renovate.json`](renovate.json) into your own Renovate configuration.
+>
+> **Quote the values.** That manager's `matchStrings` only match `repository: "..."` and
+> `ref: "..."` — an unquoted pin is not an error, it simply never gets found, and the `ref`
+> then ages silently. `/rhiza:init` writes the quoted form for exactly this reason.
 
-When you run `uvx rhiza sync` or trigger the automated sync workflow, Rhiza fetches only the files matching your `include` patterns, skips anything in `exclude`, and creates a clean diff for you to review. You stay in control of what updates and when.
+When you run `/rhiza:update`, Rhiza fetches only the files your bundle selection owns, skips anything in `exclude`, and three-way merges them into a branch — so local edits survive and you review the result as a pull request. You stay in control of what updates and when.
 
 **💡 Pro Tip:** While you can use `Jebel-Quant/rhiza` directly, **we recommend creating your own template repository** using GitHub's "Use this template" button. This gives you a clean copy to customise for your organisation's specific needs and constraints—adjusting CI workflows, coding standards, or tooling choices—while still benefiting from Rhiza's sync mechanism. Your template repo becomes your team's source of truth, and you can selectively pull updates from upstream Rhiza when desired.
 
@@ -99,6 +115,7 @@ When you run `uvx rhiza sync` or trigger the automated sync workflow, Rhiza fetc
 - [Why Rhiza?](#-why-rhiza)
 - [Quick Start](#-quick-start)
 - [What You Get](#-what-you-get)
+- [Architecture Decision Records](#-architecture-decision-records)
 - [Available Templates](#-available-templates)
 - [Integration Guide](#-integration-guide)
 - [Available Tasks](#-available-tasks)
@@ -110,16 +127,25 @@ When you run `uvx rhiza sync` or trigger the automated sync workflow, Rhiza fetc
 
 ## 🚀 Quick Start
 
-```bash
-# Navigate to your project directory
-cd /path/to/your/project
+Rhiza is driven from [Claude Code](https://claude.com/claude-code). Install the plugin once:
 
-# Initialise Rhiza configuration and pick your bundles
-uvx rhiza init
-
-# Edit .rhiza/template.yml to review the bundle selection, then apply
-uvx rhiza sync
+```text
+/plugin marketplace add Jebel-Quant/rhiza-claude
+/plugin install rhiza@rhiza-claude
 ```
+
+Then, from your project directory:
+
+```text
+/rhiza:init      # write .rhiza/template.yml (the pointer) — merge that PR
+/rhiza:update    # the first sync: brings the template content in — merge that PR too
+/rhiza:quality   # score the result
+```
+
+**Bootstrapping is two pull requests, not one.** `/rhiza:init` writes the pointer and syncs
+nothing, so its PR looks almost empty — that is correct. `/rhiza:update` is what delivers the
+workflows, the `Makefile` and the rest, which keeps one code path responsible for
+materialising template files.
 
 See the [Integration Guide](#-integration-guide) for more options, or follow the [step-by-step tutorial](https://github.com/Jebel-Quant/rhiza-education) in rhiza-education (Lessons 6–8).
 
@@ -140,9 +166,10 @@ make install
 
 Adopt a Rhiza bundle and your project immediately gains:
 
-- **Makefile** with 40+ targets for install, test, fmt, release, docs, and more
-- **CI/CD workflows** for GitHub Actions and/or GitLab CI — test, lint, release, sync
-- **Pre-commit hooks** — ruff, bandit, markdownlint, interrogate, actionlint, and more
+- **A `Makefile` front door** — a thin shim that pins `RHIZA_TASK` and forwards 40+ tasks (install, test, fmt, the gates, docs, release) to that CLI
+- **A language layer** — Python, Rust or Go: one set of target names (`install`, `test`, `coverage`, `typecheck`, `security`, `license`, `deps`), a different engine behind each
+- **CI/CD workflows** for GitHub Actions and/or GitLab CI — test, lint, release, docs
+- **Pre-commit hooks** run by [prek](https://github.com/j178/prek) — ruff, bandit, markdownlint, interrogate, actionlint, and the `rhiza-hooks` checks
 - **pytest** with coverage, benchmarks, and property-based testing via Hypothesis
 - **Documentation** via MkDocs + zensical, with optional Marimo notebook exports
 - **Release automation** — version bumping, OIDC PyPI publishing, optional grayskull conda recipe generation (`vars.PUBLISH_CONDA`, defaults to `true`), SLSA provenance
@@ -160,12 +187,14 @@ ADRs help preserve the reasoning behind key decisions, making it easier for curr
 - [ADR-0001: Use Architecture Decision Records](docs/adr/0001-use-architecture-decision-records.md)
 - [ADR-0002: Use uv for Python Package and Environment Management](docs/adr/0002-use-uv-for-python-package-management.md)
 - [ADR-0003: Use Ruff for Linting and Formatting](docs/adr/0003-use-ruff-for-linting-and-formatting.md)
-- [ADR-0004: Adopt a Modular Makefile Architecture](docs/adr/0004-adopt-modular-makefile-architecture.md)
+- [ADR-0004: Adopt a Modular Makefile Architecture](docs/adr/0004-adopt-modular-makefile-architecture.md) *(superseded by ADR-0011)*
 - [ADR-0005: Separate rhiza Template Repository from rhiza-cli](docs/adr/0005-separate-rhiza-template-from-cli.md)
 - [ADR-0006: Organise Templates into Bundles](docs/adr/0006-organise-templates-into-bundles.md)
 - [ADR-0007: Support Dual CI/CD with GitHub Actions and GitLab CI](docs/adr/0007-support-dual-cicd-github-and-gitlab.md)
 - [ADR-0008: Use Marimo for Interactive Notebooks](docs/adr/0008-use-marimo-for-interactive-notebooks.md)
 - [ADR-0009: Use Pre-commit Hooks for Automated Code Quality Enforcement](docs/adr/0009-use-pre-commit-hooks-for-code-quality.md)
+- [ADR-0010: Introduce a Layered Bundle and Profile Model](docs/adr/0010-layered-bundle-profile-model.md)
+- [ADR-0011: Replace the Synced Make Layer with a Pinned CLI](docs/adr/0011-replace-the-synced-make-layer-with-a-pinned-cli.md)
 
 **Create a new ADR**: Copy the template in [docs/adr/](docs/adr/), give it the next number, and open a pull request for review.
 
@@ -197,8 +226,8 @@ Rhiza provides **profiles** — named presets that select a sensible set of bund
 Declare a profile in `.rhiza/template.yml`:
 
 ```yaml
-repository: Jebel-Quant/rhiza
-ref: v0.14.0
+repository: "Jebel-Quant/rhiza"
+ref: "v1.5.1"
 
 profiles:
   - github-project
@@ -226,11 +255,11 @@ Any bundle can be selected on its own — its dependencies are resolved and inst
 
 | Bundle | Description | Auto-installs |
 |--------|-------------|---------------|
-| `core` | Core Rhiza infrastructure, language-neutral (Makefile, help, uv as tool runner) | — |
+| `core` | Core Rhiza infrastructure, language-neutral (the `Makefile` shim that pins `RHIZA_TASK`, editor and changelog config, uv as tool runner) | — |
 | `python-core` | Python language layer (`install`/`all`, virtualenv, ruff, bandit, deptry) | `core` |
 | `rust-core` | Rust language layer (`install`/`all`, cargo, clippy, nextest, llvm-cov, cargo-deny) | `core` |
 | `go-core` | Go language layer (`install`/`all`, go test, golangci-lint, govulncheck, revive) | `core` |
-| `tests` | Local testing infrastructure with pytest, coverage, and type checking | `book`, `core`, `python-core` |
+| `tests` | Optional Python testing extras — the `benchmark`, `hypothesis-test` and `stress` gates (`test`, `coverage` and `typecheck` live in the language layer) | `book`, `core`, `python-core` |
 | `book` | Comprehensive documentation book (API docs, coverage, notebooks) | `core` |
 | `marimo` | Interactive Marimo notebooks for data exploration and documentation | `book`, `core`, `python-core` |
 | `benchmarks` | Performance benchmarking with pytest-benchmark and reporting | `tests` |
@@ -253,7 +282,7 @@ Any bundle can be selected on its own — its dependencies are resolved and inst
 | `github-marimo` | GitHub Actions workflow for Marimo notebook automation | `github`, `marimo`, `book`, `core` |
 | `github-docker` | GitHub Actions workflow for Docker image building and publishing | `github`, `docker`, `core` |
 | `github-devcontainer` | GitHub Actions workflow for DevContainer image publishing | `github`, `devcontainer`, `core` |
-| `github-paper` | GitHub Actions workflow for LaTeX paper compilation and PDF publishing | `github`, `paper`, `core` |
+| `github-paper` | GitHub Actions workflow for LaTeX paper compilation — the PDF is a run artifact, and ships durably as a book asset | `github`, `paper`, `core` |
 | `github-quality-review` | Advisory Claude design review of PR diffs — architecture, complexity, test gaps (opt-in) | `github`, `core` |
 
 **Platform bundles — GitLab**
@@ -270,33 +299,30 @@ For a complete reference of every file included in each bundle, see [`.rhiza/tem
 
 ## 🧩 Integration Guide
 
-Rhiza provides reusable configuration templates that you can integrate into your existing Python projects.
+Rhiza provides reusable configuration templates that you can integrate into your existing Python, Rust or Go projects.
 
 ### Prerequisites
 
-- **Python 3.11+** - Ensure your project supports Python 3.11 or newer
+- **[Claude Code](https://claude.com/claude-code)** with the `rhiza` plugin installed — this is the interface
+- **[uv](https://docs.astral.sh/uv/)** - runs the plugin's scripts and every gate, whatever the project's language
 - **Git** - Your project should be a Git repository
+- **A toolchain for your language** - Python 3.11+, a Rust toolchain, or Go; `uv` manages the Python one for you
 - **Backup** - Consider committing any uncommitted changes before integration
 
 ### Automated Integration (Recommended)
 
-The fastest way to integrate Rhiza:
+The fastest way to integrate Rhiza, from your repository's directory in Claude Code:
 
-```bash
-# Navigate to your repository
-cd /path/to/your/project
-
-# Initialise configuration templates
-uvx rhiza init
-
-# Edit .rhiza/template.yml to select desired templates
-# Then sync the templates
-uvx rhiza sync
+```text
+/rhiza:init      # writes .rhiza/template.yml, picking a profile from your platform and language
+/rhiza:update    # applies the sync and opens a PR of template-owned files only
 ```
 
 **Options:**
-- `--branch <branch>` - Use a specific rhiza branch (default: main)
-- `--help` - Show detailed usage information
+- `/rhiza:update v1.4.2` - sync a specific template release instead of the latest
+- `/rhiza:status` - report what the pointer says and what the last sync actually delivered
+- `/rhiza:status --check` - report upstream drift without changing anything
+- `/rhiza:detach` - stop being template-managed, keeping the files
 
 For a full step-by-step tutorial covering init, bundle selection, first materialise, and the sync lifecycle, see **[rhiza-education Lessons 6–8](https://github.com/Jebel-Quant/rhiza-education)**.
 
@@ -317,34 +343,35 @@ For Rhiza templates to work correctly, your project must satisfy these expectati
 | Requirement | Details |
 |-------------|---------|
 | Git repository | `git init` or cloned — Rhiza does not initialise git |
-| `pyproject.toml` | Must have `[project]` with `name`, `version`, `description`, `readme`, and `requires-python` (all non-empty strings), plus a `[dependency-groups]` table |
-| `.python-version` | Single line specifying the target Python version (e.g. `3.13`) — used by `uv` and CI |
-| `.rhiza/template.yml` | Created by `uvx rhiza init` — specifies `repository`, `ref`, and bundle/profile selection |
+| `pyproject.toml` | *(`python-core`)* Must have `[project]` with `name`, `version`, `description`, `readme`, and `requires-python` (all non-empty strings), plus a `[dependency-groups]` table |
+| `.python-version` | *(`python-core`)* Single line specifying the target Python version (e.g. `3.13`) — used by `uv` and CI. A Rust or Go project ships none |
+| `.rhiza/template.yml` | Created by `/rhiza:init` — specifies `repository`, `ref`, and bundle/profile selection |
+| `.rhiza/template.lock` | Written by each sync — the record of what actually arrived, and the list `/rhiza:update` is allowed to stage |
 
 **Tool requirements**
 
 | Tool | Minimum version | Notes |
 |------|-----------------|-------|
 | **GNU Make** | 3.81 | macOS ships BSD make; install via `brew install make` and use `gmake` |
-| **uv** | 0.5.0 | Installed automatically by any `make` target if missing |
-| **Python** | 3.11 | Managed automatically by `uv` via `.python-version` |
+| **uv** | 0.5.0 | Installed automatically by any `make` target if missing (into `./bin`) |
+| **Python** | 3.11 | *(`python-core`)* Managed automatically by `uv` via `.python-version` |
 
 **What Rhiza owns vs what you own**
 
 | Path | Owner | Notes |
 |------|-------|-------|
-| `.rhiza/` | Rhiza | Template-managed; overwritten on sync |
+| `.rhiza/` | Rhiza | Template-managed; overwritten on sync — except `.rhiza/.env`, which is yours (and gitignored, so developer-local) |
 | `.github/workflows/rhiza_*.yml` | Rhiza | Template-managed workflow stubs |
-| `Makefile` | Rhiza | Template-managed; add your hooks *above* the `include` line |
+| `Makefile` | Rhiza | Template-managed, and it carries the `RHIZA_TASK` pin — nothing you append to it survives a sync |
 | `ruff.toml`, `.editorconfig`, `.pre-commit-config.yaml` | Rhiza | Template-managed config files |
 | `pyproject.toml` | Yours | Never synced — `/rhiza:init` creates it, then it's yours; `rhiza-test` only checks its structure |
 | `src/` or application code | Yours | Never touched by Rhiza |
 | `tests/` | Yours | Never touched by Rhiza |
-| `local.mk` | Yours | Local shortcuts — not committed, not synced, auto-loaded |
+| `local.mk` | Yours | Your own make targets — `-include`d by the `Makefile`, never synced, and deliberately *not* gitignored, so commit it (anything your CI invokes has to be in the repository) |
 
 **Safe extension points** (survive every sync):
-- **Root `Makefile` hooks** — add `pre-install::` / `post-install::` etc. above `include .rhiza/rhiza.mk`
-- **`local.mk`** — untracked local shortcuts, auto-loaded by `rhiza.mk`
+- **`local.mk`** — your own targets. An explicit rule beats the shim's `%:` catch-all, so an `install:` rule here can call `uvx $(RHIZA_TASK) install` and then your extra step. This is what replaced the retired `pre-install::` / `post-install::` hooks
+- **`[tool.rhiza-task]` in `pyproject.toml`** — project settings such as `source-folder`, read by the task runner. `uvx rhiza-task print <setting>` shows what one currently resolves to
 - **`pyproject.toml`** — add dependencies, scripts, and tool configs freely
 
 See [docs/guides/CUSTOMIZATION.md](docs/guides/CUSTOMIZATION.md) for worked examples.
@@ -360,7 +387,7 @@ See [docs/guides/CUSTOMIZATION.md](docs/guides/CUSTOMIZATION.md) for worked exam
 
 ## 📋 Available Tasks
 
-The project uses a [Makefile](Makefile) as the primary entry point for all tasks, powered by [uv](https://github.com/astral-sh/uv) for fast Python package management.
+The synced [`Makefile`](Makefile) is a shim: it pins `RHIZA_TASK` and forwards every unmatched target to that CLI, so `make test` resolves because `test` is a *task* — not because anything in the `Makefile` mentions it. `make` stays the front door (it is what CI calls and what a stranger types), but the tasks come from [rhiza-task](https://pypi.org/project/rhiza-task/), and `uvx rhiza-task list` is the authoritative list for the pinned version.
 
 ### Key Commands
 
@@ -531,7 +558,10 @@ For detailed information about creating and customising presentations, see [pres
 
 ### Documentation Examples
 
-README code blocks can be tested when tests are configured.
+README code blocks are executable documentation. With the `tests` bundle selected,
+`make rhiza-test` runs each `python` fence and diffs its output against the `result` block
+that follows, so an example cannot quietly stop working. (`make docs-examples` does the
+same job for the fences under the docs tree.)
 
 ```python
 # Example code block
@@ -607,22 +637,24 @@ For details about the VS Code extensions configured in the Dev Container, see [d
 ### GitHub Actions
 
 The `.github/` directory contains comprehensive GitHub Actions workflows for:
-- CI testing across multiple Python versions
+- CI testing across multiple Python versions and operating systems
 - Pre-commit checks and code quality
-- Dependency checking with deptry
-- Documentation building
+- The gates — typecheck, security, licences, dependencies
+- Documentation building, and Marimo notebook publishing
 - Docker and devcontainer validation
-- Release automation
-- Template synchronization
+- Release automation, CodeQL, Scorecard, and weekly maintenance
+
+Syncing is not a workflow: `/rhiza:update` performs it from your machine and opens the PR.
 
 ### GitLab CI/CD
 
-Rhiza provides GitLab CI/CD workflow configurations with feature parity to GitHub Actions. The `.gitlab/` directory includes workflows for CI, validation, dependency checking, documentation, sync, and releases.
+Rhiza provides GitLab CI/CD workflow configurations with feature parity to GitHub Actions. The `gitlab` bundle materialises a `.gitlab-ci.yml` plus `.gitlab/workflows/` pipelines for CI, quality, documentation, Renovate, paper compilation, weekly maintenance, and releases.
 
-**Quick setup:**
-```bash
-cp -r .gitlab/ /path/to/your/project/
-cp .gitlab-ci.yml /path/to/your/project/
+**Quick setup:** select the `gitlab-project` profile in `.rhiza/template.yml` and run `/rhiza:update`:
+
+```yaml
+profiles:
+  - gitlab-project
 ```
 
 For complete GitLab setup instructions, configuration variables, and troubleshooting, see **[.gitlab/README.md](bundles/gitlab/.gitlab/README.md)**.

--- a/bundles/gitlab/.gitlab/COMPARISON.md
+++ b/bundles/gitlab/.gitlab/COMPARISON.md
@@ -160,7 +160,7 @@ script:
 
 | Feature | GitHub Actions | GitLab CI |
 |---------|----------------|-----------|
-| Template sync | ✅ `rhiza sync` | ✅ `rhiza sync` |
+| Template sync | ✅ `/rhiza:update` (run locally) | ✅ `/rhiza:update` (run locally) |
 | PR/MR creation | ✅ Automatic | ⚠️ Manual (API call needed) |
 | Token requirement | PAT_TOKEN | PAT_TOKEN |
 | Scheduling | ✅ Cron syntax | ✅ Pipeline schedules |

--- a/bundles/presentation/docs/development/PRESENTATION.md
+++ b/bundles/presentation/docs/development/PRESENTATION.md
@@ -83,8 +83,8 @@ A curated collection of **battle-tested templates** that:
 <div>
 
 ### 📚 Documentation
-- API docs with pdoc
-- Companion book with minibook
+- Docs site with MkDocs + zensical
+- API docs with mkdocstrings
 - Presentation slides with Marp
 - Interactive notebooks
 
@@ -122,34 +122,27 @@ A curated collection of **battle-tested templates** that:
 - `.github/workflows/` — GitHub Actions
 - Automated testing & releases
 - Documentation generation
-- Template synchronization
+- Security scanning (CodeQL, Scorecard)
 
 ---
 
 ## 🎯 Quick Start
 
-### 1. Automated Injection (Recommended)
+### 1. Install the plugin (once)
 
-```bash
-cd /path/to/your/project
-uvx rhiza .
+```text
+/plugin marketplace add Jebel-Quant/rhiza-claude
+/plugin install rhiza@rhiza-claude
 ```
 
-This creates `.github/template.yml` and syncs templates automatically.
+### 2. Adopt, in two pull requests
 
-### 2. Manual Integration
-
-```bash
-# Clone Rhiza
-git clone https://github.com/jebel-quant/rhiza.git /tmp/rhiza
-
-# Copy sync mechanism
-cp /tmp/rhiza/.github/template.yml .github/
-cp /tmp/rhiza/.rhiza/scripts/sync.sh .rhiza/scripts/
-
-# Sync templates
-./.rhiza/scripts/sync.sh
+```text
+/rhiza:init      # writes .rhiza/template.yml — the pointer. Merge it.
+/rhiza:update    # the first sync: the workflows, the Makefile, the rest
 ```
+
+`/rhiza:init` syncs nothing, so its PR looks almost empty — that is correct.
 
 ---
 
@@ -157,36 +150,33 @@ cp /tmp/rhiza/.rhiza/scripts/sync.sh .rhiza/scripts/
 
 Templates stay up-to-date with Rhiza's latest improvements:
 
-### Configuration: `.github/template.yml`
+### Configuration: `.rhiza/template.yml`
 
 ```yaml
-repository: Jebel-Quant/rhiza
-ref: v0.7.1
+repository: "Jebel-Quant/rhiza"
+ref: "v1.5.1"
 
-include: |
-  .github/workflows/*.yml
-  .pre-commit-config.yaml
-  ruff.toml
-  pytest.ini
+profiles:
+  - github-project
 
 exclude: |
-  .rhiza/scripts/customisations/*
+  docs/development/DOCKER.md
 ```
+
+A profile expands to its bundles; `exclude` opts out of individual files.
 
 ---
 
-## 🔄 Automated Sync Workflow
+## 🔄 Staying Current
 
-The `sync.yml` workflow keeps your project current:
+Syncing is a local command, not a scheduled job — nothing needs a write-scoped
+token on a timer:
 
-- 📅 Runs weekly (configurable)
-- 🔄 Fetches latest templates from Rhiza
-- 🔍 Applies only included files
-- 🎯 Respects exclude patterns
-- 📝 Creates pull request with changes
-- 🤖 Fully automated
-
-**Manual trigger**: GitHub Actions → "Sync Templates" → "Run workflow"
+- 🤖 Renovate opens a PR when the template's `ref` has a newer release
+- 🔄 `/rhiza:update` applies it: fetch the bundles, three-way merge, open the PR
+- 🔍 Only template-owned paths are staged — `.rhiza/template.lock` is the list
+- 🎯 `exclude` patterns and local edits both survive
+- 📋 `/rhiza:status --check` reports drift without changing anything
 
 ---
 
@@ -278,40 +268,40 @@ make workflow-status
 
 ## 🔧 Customization
 
-### Build Extras
+### Your own targets, in `local.mk`
 
-Create `.rhiza/scripts/customisations/build-extras.sh`:
+The `Makefile` is template-owned and `-include`s `local.mk`, which no sync
+touches. An explicit rule beats its `%:` catch-all, so shadowing extends a task:
 
-```bash
-#!/bin/bash
-set -euo pipefail
+```makefile
+# local.mk — committed
+install: $(UVX)
+	@sudo apt-get update && sudo apt-get install -y graphviz
+	@$(UVX) $(RHIZA_TASK) install
 
-# Install system dependencies
-sudo apt-get update
-sudo apt-get install -y graphviz
-
-# Your custom setup here
+train-model: ## Train the ML model
+	@uv run python scripts/train.py
 ```
 
-Runs during: `make install`, `make test`, `make book`
+Settings go in `pyproject.toml`'s `[tool.rhiza-task]` table.
 
 ---
 
 ## 🎨 Documentation Customization
 
-### API Documentation (pdoc)
+### The docs site (MkDocs + zensical)
 
-```bash
-mkdir -p book/pdoc-templates
-# Add custom Jinja2 templates
+Override anything from the base config in your own `mkdocs.yml`:
+
+```yaml
+INHERIT: docs/mkdocs-base.yml
+
+theme:
+  logo: assets/my-logo.png
 ```
 
-### Companion Book (minibook)
-
-```bash
-mkdir -p book/minibook-templates
-# Create custom.html.jinja2
-```
+API pages come from mkdocstrings; extra packages go in the
+`mkdocs-extra-packages` setting.
 
 ### Presentations (Marp)
 
@@ -503,8 +493,8 @@ classifiers = [
 - **Pytest** — Testing framework
 - **Marimo** — Interactive notebooks
 - **Marp** — This presentation!
-- **pdoc** — API documentation
-- **minibook** — Companion book
+- **MkDocs + zensical** — The docs site
+- **mkdocstrings** — API documentation
 
 ---
 
@@ -512,9 +502,9 @@ classifiers = [
 
 ### Three Simple Steps
 
-1. **Try it**: `uvx rhiza .` in your project
-2. **Review**: Check the generated `.github/template.yml`
-3. **Sync**: Run `./.rhiza/scripts/sync.sh`
+1. **Install**: `/plugin install rhiza@rhiza-claude` in Claude Code
+2. **Point**: `/rhiza:init` writes `.rhiza/template.yml` — review and merge
+3. **Sync**: `/rhiza:update` brings the template content in
 
 ### Or Explore First
 
@@ -546,8 +536,9 @@ make test
 ## 📋 Quick Reference Card
 
 ```bash
-# Setup
-uvx rhiza .                    # Auto-inject Rhiza
+# Setup (in Claude Code)
+# /rhiza:init                  # become rhiza-managed
+# /rhiza:update                # sync the template content
 
 # Development
 make install                   # Install dependencies

--- a/docs/adr/0005-separate-rhiza-template-from-cli.md
+++ b/docs/adr/0005-separate-rhiza-template-from-cli.md
@@ -4,7 +4,9 @@ Date: 2024-05-01
 
 ## Status
 
-Accepted
+Accepted. Amended 2026-08-22: the engine half is now the `rhiza` Claude Code plugin
+rather than the `rhiza-cli` PyPI package — see **Amendment: the engine moved** at the end
+of this record. The decision this ADR made, content separated from engine, is unchanged.
 
 ## Context
 
@@ -82,3 +84,34 @@ CLI. The CLI is generic; the template content is specific.
 - **Distributed codebase**: Bugs that span both components (e.g., a sync issue caused
   by CLI logic interacting with a specific template structure) require debugging across
   two repositories.
+
+## Amendment: the engine moved (2026-08-22)
+
+`rhiza-cli` is unpublished and [its repository](https://github.com/Jebel-Quant/rhiza-cli)
+is archived. The engine role it filled belongs to
+[rhiza-claude](https://github.com/Jebel-Quant/rhiza-claude), a Claude Code plugin whose
+`/rhiza:update` reads `.rhiza/template.yml`, fetches the selected bundles at the pinned
+`ref`, three-way merges them into the working tree and records what arrived in
+`.rhiza/template.lock`. That sync is stdlib-only Python shipped inside the plugin, so
+there is no package to install and no `uvx rhiza` entry point at all.
+
+Every property the decision rests on survives the substitution, which is why this is an
+amendment and not a superseding ADR:
+
+- **Two components, versioned independently.** Template tags here, plugin releases there.
+- **Any repository can be the template.** `repository:` is still read from the consumer's
+  own config, so a variant is pointed at rather than forked into.
+- **Nothing of the engine is synced.** A plugin install is the modern form of the
+  no-persistent-installation property `uvx` provided.
+
+Two claims in the record above no longer hold as written:
+
+- **PyPI discoverability is gone**, because the engine is not a PyPI package. The four
+  operations went to three places: `init` and `sync` are `/rhiza:init` and
+  `/rhiza:update`; `bump` and `release` are `/rhiza:release` driving bump-my-version and
+  `rhiza_release.yml`; and the developer tasks that were never this CLI's — `install`,
+  `test`, every gate — are [rhiza-task](https://pypi.org/project/rhiza-task/), pinned as
+  `RHIZA_TASK` in the synced `Makefile`, with the conformance checks in
+  [pytest-rhiza](https://github.com/jebel-quant/pytest-rhiza).
+- **"Two repositories to follow" is now five.** The boundary held; it multiplied. The
+  README's companions table is the current map.

--- a/docs/adr/0010-layered-bundle-profile-model.md
+++ b/docs/adr/0010-layered-bundle-profile-model.md
@@ -4,7 +4,9 @@ Date: 2026-05-02
 
 ## Status
 
-Accepted
+Accepted. Amended 2026-08-22: the engine that expands `profiles:` is the `rhiza` Claude
+Code plugin, not `rhiza-cli` — see the amendment at the end of this record. The
+template-side structure decided here is unchanged.
 
 ## Context
 
@@ -143,3 +145,17 @@ separate concern; this ADR covers the template repository structure and metadata
   resulting bundle list.
 - **Profile maintenance overhead**: Profiles must be kept current as bundles are added
   or renamed. Automated tests enforce that every bundle referenced in a profile exists.
+
+## Amendment: the engine that expands profiles (2026-08-22)
+
+Two places above name `rhiza-cli` as the consumer of this metadata: the *Decision*'s note
+that the CLI expands profiles to bundles, and the *CLI changes required* negative. The
+engine is [rhiza-claude](https://github.com/Jebel-Quant/rhiza-claude) now — `rhiza-cli` is
+unpublished and archived, see the amendment to
+[ADR-0005](0005-separate-rhiza-template-from-cli.md) — and that negative is discharged
+rather than inherited: `/rhiza:init` writes a `profiles:` key chosen from the repo's host
+and language, and `/rhiza:update` expands it, so nobody has to approximate local mode by
+hand-picking bundles.
+
+The `rhiza init` mention in the *Better onboarding* consequence reads `/rhiza:init` today.
+Nothing else about the layered model changed.

--- a/docs/guides/CUSTOMIZATION.md
+++ b/docs/guides/CUSTOMIZATION.md
@@ -4,84 +4,48 @@ This guide covers how to extend and adapt Rhiza-based projects without breaking 
 
 ## Safe Extension Points
 
-Rhiza provides three extension mechanisms that survive every `/rhiza:update`. **Never edit files inside `.rhiza/` directly** — that directory is template-managed and will be overwritten on the next sync.
+Rhiza provides four extension mechanisms that survive every `/rhiza:update`. **Never edit template-managed files** — `.rhiza/`, the workflow stubs, and (since the make layer retired) the `Makefile` itself are overwritten on the next sync. `check-managed-files` refuses a commit that touches one, so this is enforced rather than merely advised.
 
 | Extension point | Where to add | Committed? | Use for |
 |-----------------|--------------|------------|---------|
-| Root `Makefile` hooks | Root `Makefile`, above `include .rhiza/rhiza.mk` | Yes | Team-wide hooks, custom make targets |
-| `local.mk` | Project root | No | Per-developer shortcuts and local overrides |
+| `local.mk` | Project root | Yes | Your own make targets, and extending a template task |
+| `[tool.rhiza-task]` | `pyproject.toml` | Yes | Settings — `source-folder`, `coverage-fail-under`, … |
 | `pyproject.toml` | Project root | Yes | Dependencies, scripts, tool configuration |
+| `.rhiza/.env` | Project root | No (gitignored) | Per-developer setting overrides |
 
-### `local.mk` — per-developer overrides
+### `local.mk` — the project's own targets
 
-`local.mk` is automatically loaded by `rhiza.mk` if it exists. It is listed in `.gitignore` and never synced. Use it for shortcuts that only make sense on your machine:
+The `Makefile` is template-owned and `-include`s `local.mk`, which no sync touches. It is deliberately **not** gitignored: commit it, because anything CI invokes has to be in the repository.
 
 ```makefile
-# local.mk — not committed
-post-install::
-	@echo "Hi $(USER), local setup done"
-
-my-shortcut: ## Shortcut I use locally
-	@uv run python -m my_debug_script
+# local.mk — committed
+train-model: ## Train the ML model
+	@uv run python scripts/train.py
 ```
 
-## 🛠️ Makefile Hooks & Extensions
+Targets carrying a `##` comment are listed by `make help` under *Repo-owned targets*, so they stay discoverable next to the template's tasks.
 
-Rhiza uses a modular Makefile system with extension points (hooks) that let you customize workflows without modifying core files.
+## 🛠️ Extending a Template Task
 
-**Important**: All customizations should be made in your root `Makefile`, not in `.rhiza/`. The `.rhiza/` directory is template-managed and will be overwritten during sync operations.
-
-### Available Hooks
-
-You can hook into standard workflows using double-colon syntax (`::`) in your root `Makefile`:
-
-- `pre-install / post-install` - Runs around `make install`
-- `pre-sync / post-sync` - Runs around repository synchronization
-- `pre-validate / post-validate` - Runs around validation checks
+The `pre-install::` / `post-install::` hooks the synced make layer anchored are **gone**: the tasks live in the pinned `rhiza-task` CLI, which knows nothing about make targets. The replacement is to **shadow** the target from `local.mk` — an explicit rule always beats the shim's `%:` catch-all, so the rule can call the task and then do the extra work.
 
 ### Example: Installing System Dependencies
 
-Add to your root `Makefile` (before the `include .rhiza/rhiza.mk` line):
-
 ```makefile
-pre-install::
+# local.mk
+install: $(UVX)
 	@if ! command -v dot >/dev/null 2>&1; then \
 		echo "Installing graphviz..."; \
 		sudo apt-get update && sudo apt-get install -y graphviz; \
 	fi
+	@$(UVX) $(RHIZA_TASK) install
 ```
 
-This hook runs automatically before `make install`, ensuring graphviz is available.
+`RHIZA_TASK` and `UVX` are defined by the `Makefile` above the `-include`, so a shadowing rule runs the same pinned CLI the rest of the project does — and naming `$(UVX)` as a prerequisite keeps the bootstrap that installs `uv` on a runner without one. Put the extra step before or after the delegation to get the old `pre-` or `post-` behaviour.
 
-### Example: Post-Sync Tasks
-
-Add to your root `Makefile`:
-
-```makefile
-post-sync::
-	@echo "Running post-sync tasks..."
-	@./scripts/notify-team.sh
-```
-
-This runs automatically after repository synchronization completes.
-
-> Releasing is not a `make` hook. Releases are driven by the rhiza-claude
-> `/release` command, which bumps the version, regenerates `CHANGELOG.md`, and
+> Releasing is not a `make` target at all. Releases are driven by the rhiza-claude
+> `/rhiza:release` command, which bumps the version, regenerates `CHANGELOG.md`, and
 > creates the tag locally; pushing the tag triggers the release workflow.
-
-### Example: Custom Build Steps
-
-Add to your root `Makefile`:
-
-```makefile
-post-install::
-	@echo "Installing specialized dependencies..."
-	@uv pip install some-private-lib
-
-##@ Custom Tasks
-train-model: ## Train the ML model
-	@uv run python scripts/train.py
-```
 
 ## 🔒 CodeQL Configuration
 
@@ -134,30 +98,30 @@ git commit -m "Remove CodeQL workflow"
 
 ## ⚙️ Configuration Variables
 
-You can configure certain aspects of the Makefile by overriding variables. These can be set in your main `Makefile` (before the `include` line), a `local.mk` file (for local developer overrides), or passed as environment variables / command-line arguments.
+Settings belong to the task runner, not to the `Makefile` — which is template-owned, so an assignment there would not survive a sync. `rhiza-task` resolves each one through five layers, later winning over earlier: its defaults, `.rhiza/.env`, `pyproject.toml`, the environment, then CLI flags.
 
-### Global Configuration
+### Project-wide configuration
 
-Add these to your root `Makefile` (before `include .rhiza/rhiza.mk`) or `local.mk`:
+A `[tool.rhiza-task]` table in `pyproject.toml`, typed by TOML rather than parsed out of strings:
 
-```makefile
-# Override default Python version
-PYTHON_VERSION = 3.12
-
-# Override test coverage threshold (default: 90)
-COVERAGE_FAIL_UNDER = 80
-
-# Include the Rhiza API (template-managed)
-include .rhiza/rhiza.mk
+```toml
+[tool.rhiza-task]
+source-folder = "src/my_package"
+coverage-fail-under = 80
 ```
+
+`uvx rhiza-task print coverage-fail-under` shows what a setting currently resolves to, which is the quickest way to tell whether an override is being read at all. A project with no Python manifest uses `.rhiza/.env`, or exports `RHIZA_*` from `local.mk` for anything that must be committed.
+
+### Per-developer configuration
+
+`.rhiza/.env` is gitignored and read as layer 2, so it is the place for values that should not travel with the repository.
 
 ### On-Demand Configuration
 
-You can also pass variables directly to `make` for one-off commands:
+Environment variables outrank both files, so a one-off looks like:
 
 ```bash
-# Run tests requiring only 80% coverage
-make test COVERAGE_FAIL_UNDER=80
+RHIZA_COVERAGE_FAIL_UNDER=80 make test
 ```
 
 ## 🎨 Documentation Customization

--- a/docs/guides/EXTENDING_RHIZA.md
+++ b/docs/guides/EXTENDING_RHIZA.md
@@ -1,260 +1,123 @@
 # Extending Rhiza
 
-This guide provides comprehensive examples and best practices for extending and customizing Rhiza-based projects.
+Two different jobs share this page:
+
+- **Extending a rhiza-managed project** — adding your own targets, settings and steps to a
+  repository that syncs from a template, in ways that survive the next `/rhiza:update`.
+- **Extending Rhiza itself** — adding a bundle to this repository so every consumer can
+  select it.
+
+The first is what most readers want. Both rest on the same rule: **template-owned files are
+overwritten by the next sync**, so an extension has to live somewhere the sync does not
+write.
 
 ## Table of Contents
 
-- [Overview](#overview)
-- [Step-by-Step: Add a New Bundle](#step-by-step-add-a-new-bundle)
-- [Extension Points](#extension-points)
-- [Common Patterns](#common-patterns)
-- [Advanced Techniques](#advanced-techniques)
-- [Real-World Examples](#real-world-examples)
-- [Best Practices](#best-practices)
+- [Where extensions live](#where-extensions-live)
+- [Extending a managed project](#extending-a-managed-project)
+  - [Add a target](#add-a-target)
+  - [Extend a template task](#extend-a-template-task)
+  - [Change a setting](#change-a-setting)
+  - [What not to do](#what-not-to-do)
+- [Adding a bundle to Rhiza](#adding-a-bundle-to-rhiza)
 - [Troubleshooting](#troubleshooting)
-- [Bundle Sync Troubleshooting Guide](../troubleshooting.md)
-- [CodeQL Configuration](#codeql-configuration)
-- [Documentation Customization](#documentation-customization)
+- [See Also](#see-also)
 
 ---
 
-## Overview
+## Where extensions live
 
-Rhiza's modular design allows you to extend functionality without modifying template-managed files. This ensures:
+| Location | Purpose | Committed? |
+|----------|---------|------------|
+| `local.mk` | Your own make targets, and shadowing a template task | ✅ Yes — it is deliberately not gitignored |
+| `[tool.rhiza-task]` in `pyproject.toml` | Project settings, typed by TOML | ✅ Yes |
+| `rhiza.toml` | The same settings for a project with no Python manifest | ✅ Yes |
+| `pyproject.toml` (elsewhere) | Dependencies, scripts, other tools' config | ✅ Yes |
+| `.rhiza/.env` | Developer-local setting overrides | ❌ No — gitignored |
 
-- ✅ **Template sync compatibility** - Your customizations survive template updates
-- ✅ **Clean separation** - Project-specific code stays separate from framework code  
-- ✅ **Easy maintenance** - Changes are localized and well-organized
-- ✅ **Team flexibility** - Developers can have personal local overrides
+**The `Makefile` is not on that list, and that is the change to absorb.** It used to be
+repo-owned above an `include` line, which is where a decade of advice told you to put hooks and
+variables. It is now shipped by the `core` bundle like every other config file: it pins
+`RHIZA_TASK`, forwards unmatched targets to that CLI, and is overwritten wholesale by the next
+sync. Anything appended to it is lost, silently — the edit works, reviews fine, merges, and
+disappears at a sync weeks later.
 
-### Where to Add Customizations
+Two things make that safe rather than merely strict. `local.mk` exists and is committable, so
+repo-owned targets have a real home; and `check-managed-files` (a rhiza-hooks hook every
+language layer runs) fails the commit when a managed file differs from `HEAD`, so the mistake
+surfaces at commit time instead of at sync time.
 
-| Location | Purpose | Committed to Git? |
-|----------|---------|-------------------|
-| Root `Makefile` | Project-wide customizations | ✅ Yes |
-| `local.mk` | Developer-local overrides | ❌ No (gitignored) |
-| `.rhiza/.env` | Environment variables | ✅ Yes (optional) |
-| `pyproject.toml` `[tool.rhiza-task]` | Project settings | ✅ Yes (optional) |
-
-**Important**: Never modify files in `.rhiza/` directly—they are template-managed and will be overwritten during sync operations. `.rhiza/.env` is the exception, and only because Rhiza ships no such file: core once did, setting two variables to values identical to its own built-in defaults, which carried no information while taking those variables out of reach of any caller that exported them (#1545). The file is yours to create; nothing overwrites it.
-
----
-
-## Step-by-Step: Add a New Bundle
-
-Use this checklist when you want to add a new bundle to Rhiza itself.
-
-### Worked Example: `linter`
-
-This example adds a minimal `linter` bundle that injects a `.ruff.toml` override into downstream projects.
-
-1. **Create the bundle directory under `bundles/`**
-
-   Every bundle must have a matching directory under `bundles/<name>/`.
-
-   ```text
-   bundles/
-   └── linter/
-       └── .ruff.toml
-   ```
-
-2. **Add the bundle files**
-
-   Files inside `bundles/linter/` are copied into the downstream project at the same relative path. A minimal Ruff override can extend the `core` bundle's `ruff.toml` and add stricter rules:
-
-   ```toml
-   # bundles/linter/.ruff.toml
-   extend = "ruff.toml"
-
-   [lint]
-   extend-select = ["B", "I"]
-   ```
-
-   In a synced downstream project, that produces:
-
-   ```text
-   .ruff.toml
-   ```
-
-3. **Declare the bundle in `.rhiza/template-bundles.yml`**
-
-   Add metadata for the new bundle and declare any dependencies it needs. Because this example extends the `core` bundle's Ruff config, it should require `core`.
-
-   ```yaml
-   linter:
-     description: "Optional Ruff overrides for stricter linting"
-     standalone: false
-     requires: [core]
-   ```
-
-4. **Add bundle content tests in `tests/bundles/`**
-
-   Add a focused sync test so the new bundle is exercised the same way downstream projects receive it. For this example, extending `tests/bundles/test_bundle_combinations.py` is enough:
-
-   ```python
-   class TestLinterBundleSync:
-       """Syncing core + linter adds the Ruff override file."""
-
-       @pytest.fixture(autouse=True)
-       def synced(self, tmp_path: Path, root: Path) -> None:
-           sync_bundles(root, ["core", "linter"], tmp_path)
-           self.project = tmp_path
-
-       def test_ruff_override_exists(self) -> None:
-           assert (self.project / ".ruff.toml").is_file()
-
-       def test_ruff_override_extends_core_config(self) -> None:
-           content = (self.project / ".ruff.toml").read_text(encoding="utf-8")
-           assert 'extend = "ruff.toml"' in content
-   ```
-
-   Existing tests in `tests/bundles/test_bundle_content_validity.py` will also pick up any new YAML or JSON files automatically.
-
-5. **Document the bundle in CLAUDE.md and README.md**
-
-   Mention the new bundle in CLAUDE.md's bundle overview (under "Template Bundles") and add a row to the
-   matching bundle table in README.md ("Feature bundles", "Platform overlay bundles", or "Meta-bundles").
-   The CLAUDE.md mention is test-enforced: `tests/docs/test_doc_consistency.py::TestBundleDocumentation`
-   fails for any bundle defined in `.rhiza/template-bundles.yml` that CLAUDE.md does not name.
-
-6. **Run `make rhiza-test`**
-
-   Before opening a PR, run the normal validation flow:
-
-   ```bash
-   make rhiza-test
-   ```
-
-   In this repository, `make rhiza-test` runs the conformance checks that do not need a `.rhiza/template.yml`, because Rhiza itself has none. When you add a bundle here, also run the repository test suite so the new `tests/bundles/` coverage actually executes.
-
-7. **Open a PR**
-
-   Include the new bundle directory, the `.rhiza/template-bundles.yml` entry, the documentation updates, and the matching `tests/bundles/` coverage in one PR so reviewers can validate the bundle end to end.
-
-### Quick Review Checklist
-
-Each step lists the gate that enforces it, so a miss is discovered here rather than as a surprise CI failure:
-
-- `.rhiza/template-bundles.yml` contains the bundle metadata with a `description`
-  (gate: `tests/bundles/test_template_bundles.py::TestTemplateBundles`)
-- `bundles/<name>/` exists, is non-empty, and owns no file claimed by another bundle
-  (gate: `tests/bundles/test_template_bundles.py::TestTemplateBundles`)
-- Dependencies are declared with `requires` and reference existing bundles
-  (gate: `tests/bundles/test_template_bundles.py::TestTemplateBundles`)
-- CLAUDE.md mentions the bundle in its overview
-  (gate: `tests/docs/test_doc_consistency.py::TestBundleDocumentation`)
-- README.md's bundle tables include the bundle (no gate — reviewer responsibility)
-- Bundle × platform compatibility coverage picks the bundle up automatically from
-  `.rhiza/template-bundles.yml` (gate: `tests/bundles/test_bundle_matrix.py` — nothing to add manually,
-  but a matrix failure for `<name>` points at a YAML, ownership, or dependency problem in the new bundle)
-- `tests/bundles/` covers the new bundle's synced output (focused test you write)
-- `make rhiza-test` and the full test suite have been run locally
+Never edit anything under `.rhiza/` either. The one exception is `.rhiza/.env`, which the
+template does not ship at all — it is yours to create, and gitignored, so it is for values that
+should not travel with the repository.
 
 ---
 
-## Extension Points
+## Extending a managed project
 
-### 1. Makefile Hooks
+### Add a target
 
-Hooks allow you to inject custom logic into standard workflows using double-colon syntax (`::`).
-
-#### Available Hooks
-
-| Hook | When It Runs | Common Use Cases |
-|------|--------------|------------------|
-| `pre-install` | Before `make install` | Install system dependencies, validate environment |
-| `post-install` | After `make install` | Additional setup, generate files, configure services |
-| `pre-sync` | Before template sync | Backup files, validate state |
-| `post-sync` | After template sync | Regenerate files, apply local patches |
-| `pre-validate` | Before project validation | Custom checks, pre-validation setup |
-| `post-validate` | After project validation | Additional validation steps |
-
-#### Hook Syntax
+Put it in `local.mk`. The `Makefile` `-include`s that file, and no sync touches it:
 
 ```makefile
-# In root Makefile (before include line)
+# local.mk
+train-model: ## Train the model
+	@uv run python scripts/train.py
 
-# Single-line hook
-post-install::
-	@echo "Running custom setup..."
-
-# Multi-line hook
-post-install::
-	@echo "Installing additional tools..."
-	@uv run pip install my-private-package
-	@echo "Setup complete!"
-
-# Multiple hooks (they accumulate)
-post-install::
-	@./scripts/setup-database.sh
-
-post-install::
-	@./scripts/configure-services.sh
+smoke: test ## Run the suite, then hit the deployed endpoint
+	@./scripts/smoke.sh
 ```
 
-### 2. Custom Make Targets
+Two properties worth knowing:
 
-Add new make targets in your root `Makefile` to create project-specific commands.
+- **A `##` comment puts the target in `make help`**, listed under *Repo-owned targets* —
+  `rhiza-task list` cannot know about them, so the `Makefile`'s `help` rule greps them out of
+  `MAKEFILE_LIST` and appends them.
+- **Template tasks work as prerequisites.** `smoke: test` above resolves `test` through the
+  catch-all, so ordering your work after a template task needs nothing special.
 
-#### Basic Target
+### Extend a template task
+
+The `pre-install::` / `post-install::` hooks are **gone**. They were anchors declared by the
+synced make layer, and the CLI that replaced it knows nothing about make targets. Nothing
+warns you about this: a `post-install::` rule in `local.mk` today is a target nobody invokes.
+
+Shadow the task instead. An explicit rule beats the `%:` catch-all, so the rule runs and can
+call the task itself wherever you want it in the sequence:
 
 ```makefile
-# In root Makefile (before include line)
+# local.mk
 
-##@ Custom Tasks
-my-task: ## Description shown in make help
-	@echo "Running my custom task..."
-	@uv run python scripts/my_script.py
+# The old `pre-install::` — extra work first, then the real task.
+install: $(UVX)
+	@command -v dot >/dev/null 2>&1 || sudo apt-get install -y graphviz
+	@$(UVX) $(RHIZA_TASK) install
+
+# The old `post-install::` — the real task first, then the extra work.
+test: $(UVX)
+	@$(UVX) $(RHIZA_TASK) test
+	@./scripts/publish-test-report.sh
 ```
 
-#### Target with Dependencies
+`UVX`, `UV` and `RHIZA_TASK` are all defined by the `Makefile` above the `-include`, so a
+shadowing rule always drives the same pinned CLI as everything else. Naming `$(UVX)` as a
+prerequisite keeps the bootstrap that installs `uv` on a runner that has none.
 
-```makefile
-##@ Custom Tasks
-deploy: test docs ## Deploy application (runs tests and docs first)
-	@echo "Deploying application..."
-	@./scripts/deploy.sh
-```
+This is strictly more capable than the hooks were: it works for **every** task rather than the
+six that happened to have anchors, and the order is written down rather than implied.
 
-#### Target with Variables
+### Change a setting
 
-```makefile
-##@ Custom Tasks
-train: ## Train ML model (use ENV=prod for production)
-	@echo "Training model in $(ENV) environment..."
-	@uv run python scripts/train.py --env=$(ENV)
-```
+Settings belong to the task runner, which resolves each one through a chain — later wins:
 
-### 3. Environment Variables
+1. `rhiza-task`'s own defaults
+2. `.rhiza/.env` (developer-local, `UPPER_SNAKE_CASE` keys)
+3. `rhiza.toml`
+4. `pyproject.toml`'s `[tool.rhiza-task]` table
+5. `RHIZA_*` environment variables
+6. CLI flags
 
-Override default variables or add new ones.
-
-#### In Root Makefile
-
-```makefile
-# In root Makefile (before include line)
-
-# Override default Python version
-PYTHON_VERSION = 3.12
-
-# Override coverage threshold
-COVERAGE_FAIL_UNDER = 80
-
-# Add custom variable
-MY_API_URL = https://api.example.com
-
-# Export for use in recipes
-export MY_API_URL
-
-# Include Rhiza
-include .rhiza/rhiza.mk
-```
-
-#### In pyproject.toml
-
-The documented home for Rhiza's own settings. TOML types the values, they sit beside the
-project's other tool config, and `rhiza-task` reads the table as layer 3 of its resolution
-order — above `.rhiza/.env`, below the environment.
+The documented home for a committed setting is the table:
 
 ```toml
 [tool.rhiza-task]
@@ -264,856 +127,182 @@ coverage-fail-under = 80
 ci-os-matrix = ["ubuntu-latest", "macos-latest"]
 ```
 
-Note that a repo still on the synced make layer resolves settings through `rhiza.mk`, which
-does not read this table — set those in its `Makefile` or `.rhiza/.env` until it syncs a
-template that has no make layer left. Once it has, the `Makefile` is template-owned and
-overwritten by every sync, so this table (or an exported `RHIZA_*` variable in `local.mk`) is
-where a committed setting belongs.
+A project with no Python manifest — a crate, a Go module — uses `rhiza.toml`, which takes the
+same keys either inside a `[tool.rhiza-task]` table or flat at the top level. Where both files
+exist, `pyproject.toml` wins.
 
-#### In .rhiza/.env
-
-For values `make` itself must see. Best kept to genuine environment variables rather than
-Rhiza settings, and remember that an assignment here outranks an exported variable — so
-pinning something CI expects to pass in silently discards it.
+For a one-off, an environment variable outranks both files:
 
 ```bash
-# .rhiza/.env
-DATABASE_URL=postgresql://localhost/mydb
-API_KEY=your-api-key
-LOG_LEVEL=DEBUG
+RHIZA_COVERAGE_FAIL_UNDER=80 make test
 ```
 
-These are automatically loaded by the Makefile.
+**Check rather than assume.** `uvx rhiza-task print coverage-fail-under` prints what a setting
+currently resolves to, which is the fastest way to find out that an override is not being read
+at all. That failure mode is worth taking seriously: a gate pointed at a folder that does not
+exist *skips* rather than fails, so a misresolved `source-folder` makes `typecheck`, `security`
+and `docs-coverage` all report success having measured nothing.
+
+### What not to do
+
+| Don't | Because | Do instead |
+|-------|---------|------------|
+| Append to the `Makefile` | Template-owned; the next sync overwrites it | `local.mk` |
+| Edit anything in `.rhiza/` (except `.env`) | Same | Upstream PR, or `exclude:` in `.rhiza/template.yml` |
+| Write `post-install::` anywhere | The anchors are gone; nothing invokes it | Shadow the task |
+| Set `SOURCE_FOLDER` or similar in a makefile | The CLI reads settings, not make variables | `[tool.rhiza-task]` |
+| Commit a fix to a template-owned workflow | It vanishes at the next sync | Upstream PR, or `exclude:` |
+
+If a template-owned file genuinely needs to differ in your repository, `exclude:` in
+`.rhiza/template.yml` stops the sync delivering it — you then own that file, and stop getting
+its improvements. Prefer an upstream PR where the change makes sense for everyone.
 
 ---
 
-## Common Patterns
-
-### Pattern 1: Installing System Dependencies
-
-Ensure system packages are available before running your application.
-
-```makefile
-# Root Makefile
-
-pre-install::
-	@echo "Checking system dependencies..."
-	@if ! command -v graphviz >/dev/null 2>&1; then \
-		echo "Installing graphviz..."; \
-		if command -v brew >/dev/null 2>&1; then \
-			brew install graphviz; \
-		elif command -v apt-get >/dev/null 2>&1; then \
-			sudo apt-get update && sudo apt-get install -y graphviz; \
-		else \
-			echo "Please install graphviz manually."; \
-			exit 1; \
-		fi \
-	fi
-```
-
-### Pattern 2: Database Setup
-
-Set up a database during installation.
-
-```makefile
-# Root Makefile
-
-post-install::
-	@echo "Setting up database..."
-	@uv run python scripts/init_db.py
-	@echo "Running migrations..."
-	@uv run alembic upgrade head
-
-##@ Database
-db-migrate: ## Create a new database migration
-	@uv run alembic revision --autogenerate -m "$(MSG)"
-
-db-upgrade: ## Apply database migrations
-	@uv run alembic upgrade head
-
-db-downgrade: ## Rollback last migration
-	@uv run alembic downgrade -1
-
-db-reset: ## Reset database (WARNING: destructive!)
-	@echo "Resetting database..."
-	@uv run python scripts/reset_db.py
-	@$(MAKE) db-upgrade
-```
-
-### Pattern 3: Configuration Files
-
-Generate configuration files from templates.
-
-```makefile
-# Root Makefile
-
-post-install::
-	@echo "Generating configuration files..."
-	@if [ ! -f config/local.yaml ]; then \
-		cp config/local.yaml.template config/local.yaml; \
-		echo "Created config/local.yaml - please customize it"; \
-	fi
-
-##@ Configuration
-config-validate: ## Validate configuration files
-	@uv run python scripts/validate_config.py
-
-config-show: ## Show current configuration
-	@uv run python -c "from myapp.config import settings; print(settings.model_dump_json(indent=2))"
-```
-
-### Pattern 4: Building Assets
-
-Compile frontend assets or other build artifacts.
-
-```makefile
-# Root Makefile
-
-post-install::
-	@echo "Building frontend assets..."
-	@npm install
-	@npm run build
-
-##@ Build
-build-assets: ## Build frontend assets
-	@echo "Building assets..."
-	@npm run build
-
-watch-assets: ## Watch and rebuild assets on change
-	@npm run watch
-
-clean-assets: ## Clean built assets
-	@rm -rf static/dist/
-```
-
-### Pattern 5: Multi-Environment Support
-
-Support different environments (dev, staging, production).
-
-```makefile
-# Root Makefile
-
-# Default environment
-ENV ?= dev
-
-##@ Deployment
-deploy-dev: ## Deploy to development
-	@$(MAKE) deploy ENV=dev
-
-deploy-staging: ## Deploy to staging
-	@$(MAKE) deploy ENV=staging
-
-deploy-prod: ## Deploy to production
-	@$(MAKE) deploy ENV=prod
-
-deploy: test ## Deploy to $(ENV) environment
-	@echo "Deploying to $(ENV) environment..."
-	@uv run python scripts/deploy.py --env=$(ENV)
-```
-
-### Pattern 6: Development Servers
-
-Run development servers with auto-reload.
-
-```makefile
-# Root Makefile
-
-##@ Development
-dev: ## Start development server with auto-reload
-	@echo "Starting development server..."
-	@uv run uvicorn myapp.main:app --reload --host 0.0.0.0 --port 8000
-
-dev-worker: ## Start background worker
-	@echo "Starting background worker..."
-	@uv run celery -A myapp.worker worker --loglevel=info
-
-dev-all: ## Start all development services
-	@echo "Starting all services..."
-	@$(MAKE) -j dev dev-worker
-```
-
-### Pattern 7: Data Management
-
-Tasks for managing data, seeds, fixtures.
-
-```makefile
-# Root Makefile
-
-##@ Data Management
-seed-db: ## Seed database with sample data
-	@echo "Seeding database..."
-	@uv run python scripts/seed_data.py
-
-import-data: ## Import data from file (use FILE=path/to/file)
-	@echo "Importing data from $(FILE)..."
-	@uv run python scripts/import_data.py $(FILE)
-
-export-data: ## Export data to file (use FILE=path/to/file)
-	@echo "Exporting data to $(FILE)..."
-	@uv run python scripts/export_data.py $(FILE)
-
-backup-db: ## Backup database
-	@echo "Creating backup..."
-	@mkdir -p backups
-	@uv run python scripts/backup_db.py backups/backup-$$(date +%Y%m%d-%H%M%S).sql
-```
-
-### Pattern 8: Code Generation
-
-Generate boilerplate code from templates.
-
-```makefile
-# Root Makefile
-
-##@ Code Generation
-new-model: ## Create new model (use NAME=ModelName)
-	@echo "Generating model $(NAME)..."
-	@uv run python scripts/generate_model.py $(NAME)
-
-new-api: ## Create new API endpoint (use NAME=endpoint_name)
-	@echo "Generating API endpoint $(NAME)..."
-	@uv run python scripts/generate_api.py $(NAME)
-
-new-test: ## Create test file (use NAME=test_name)
-	@echo "Generating test file $(NAME)..."
-	@uv run python scripts/generate_test.py $(NAME)
-```
-
----
-
-## Advanced Techniques
-
-### Conditional Logic
-
-Execute different logic based on environment or system.
-
-```makefile
-# Root Makefile
-
-# Detect operating system
-UNAME_S := $(shell uname -s)
-
-pre-install::
-ifeq ($(UNAME_S),Darwin)
-	@echo "Installing macOS dependencies..."
-	@brew install graphviz
-else ifeq ($(UNAME_S),Linux)
-	@echo "Installing Linux dependencies..."
-	@sudo apt-get install -y graphviz
-else
-	@echo "Unsupported OS: $(UNAME_S)"
-	@exit 1
-endif
-
-# Conditional based on environment variable
-post-install::
-ifdef CI
-	@echo "Running in CI environment, skipping interactive setup"
-else
-	@echo "Running local setup..."
-	@./scripts/interactive_setup.sh
-endif
-```
-
-### Parallel Execution
-
-Run multiple tasks in parallel.
-
-```makefile
-# Root Makefile
-
-##@ Development
-dev-all: ## Start all services in parallel
-	@$(MAKE) -j4 dev-api dev-worker dev-frontend dev-db
-
-dev-api:
-	@uv run uvicorn myapp.api:app --reload
-
-dev-worker:
-	@uv run celery -A myapp.worker worker
-
-dev-frontend:
-	@npm run dev
-
-dev-db:
-	@docker-compose up postgres
-```
-
-### Dynamic Targets
-
-Generate targets dynamically.
-
-```makefile
-# Root Makefile
-
-# Define environments
-ENVIRONMENTS := dev staging prod
-
-# Generate deploy target for each environment
-$(foreach env,$(ENVIRONMENTS),\
-	$(eval deploy-$(env): ;\
-		@echo "Deploying to $(env)..." ;\
-		@./scripts/deploy.sh $(env)))
-
-# Now you can run: make deploy-dev, make deploy-staging, make deploy-prod
-```
-
-### Function Calls
-
-Use make functions for reusable logic.
-
-```makefile
-# Root Makefile
-
-# Function to check if command exists
-define check_command
-	@command -v $(1) >/dev/null 2>&1 || { \
-		echo "Error: $(1) is not installed"; \
-		exit 1; \
-	}
-endef
-
-##@ Validation
-check-tools: ## Verify required tools are installed
-	$(call check_command,docker)
-	$(call check_command,kubectl)
-	$(call check_command,helm)
-	@echo "All required tools are installed ✓"
-```
-
-### Including External Makefiles
-
-Modularize large Makefiles.
-
-```makefile
-# Root Makefile
-
-# Include custom modules
--include makefiles/docker.mk
--include makefiles/kubernetes.mk
--include makefiles/terraform.mk
-
-# Include Rhiza
-include .rhiza/rhiza.mk
-```
-
-Then create `makefiles/docker.mk`:
-
-```makefile
-# makefiles/docker.mk
-
-##@ Docker
-docker-dev: ## Run development environment in Docker
-	@docker-compose -f docker-compose.dev.yml up
-
-docker-prod: ## Build production Docker image
-	@docker build -t myapp:$(VERSION) .
-```
-
----
-
-## Real-World Examples
-
-### Example 1: Machine Learning Project
-
-```makefile
-# Root Makefile for ML project
-
-# ML-specific variables
-DATA_DIR := data
-MODELS_DIR := models
-EXPERIMENT_NAME ?= default
-
-post-install::
-	@echo "Downloading datasets..."
-	@uv run python scripts/download_data.py
-
-##@ Machine Learning
-train: ## Train model (use MODEL=model_name EXPERIMENT=name)
-	@echo "Training $(MODEL) model..."
-	@uv run python scripts/train.py \
-		--model $(MODEL) \
-		--experiment $(EXPERIMENT_NAME) \
-		--data-dir $(DATA_DIR) \
-		--output-dir $(MODELS_DIR)
-
-evaluate: ## Evaluate model (use MODEL=model_name)
-	@echo "Evaluating $(MODEL) model..."
-	@uv run python scripts/evaluate.py \
-		--model $(MODEL) \
-		--data-dir $(DATA_DIR)/test
-
-predict: ## Run inference (use MODEL=model_name INPUT=file)
-	@uv run python scripts/predict.py \
-		--model $(MODELS_DIR)/$(MODEL) \
-		--input $(INPUT)
-
-tune: ## Hyperparameter tuning (use MODEL=model_name)
-	@echo "Tuning hyperparameters for $(MODEL)..."
-	@uv run python scripts/tune.py --model $(MODEL)
-
-experiment-track: ## Start MLflow tracking server
-	@uv run mlflow server --host 0.0.0.0 --port 5000
-
-##@ Data
-download-data: ## Download datasets
-	@uv run python scripts/download_data.py
-
-preprocess-data: ## Preprocess raw data
-	@uv run python scripts/preprocess.py \
-		--input $(DATA_DIR)/raw \
-		--output $(DATA_DIR)/processed
-
-validate-data: ## Validate data quality
-	@uv run python scripts/validate_data.py
-
-# Include Rhiza
-include .rhiza/rhiza.mk
-```
-
-### Example 2: Web API Project
-
-```makefile
-# Root Makefile for Web API project
-
-# API configuration
-API_HOST ?= 0.0.0.0
-API_PORT ?= 8000
-WORKERS ?= 4
-
-post-install::
-	@echo "Setting up database..."
-	@uv run alembic upgrade head
-	@echo "Loading fixtures..."
-	@uv run python scripts/load_fixtures.py
-
-##@ Development
-dev: ## Start development server
-	@uv run uvicorn myapi.main:app \
-		--reload \
-		--host $(API_HOST) \
-		--port $(API_PORT)
-
-dev-debug: ## Start development server with debugging
-	@uv run python -m debugpy --listen 5678 \
-		-m uvicorn myapi.main:app \
-		--reload \
-		--host $(API_HOST) \
-		--port $(API_PORT)
-
-shell: ## Open interactive Python shell with app context
-	@uv run python scripts/shell.py
-
-##@ Database
-db-create: ## Create database
-	@uv run python scripts/create_db.py
-
-db-drop: ## Drop database (WARNING: destructive!)
-	@echo "Are you sure? [y/N] " && read ans && [ $${ans:-N} = y ]
-	@uv run python scripts/drop_db.py
-
-db-migrate: ## Create new migration (use MSG="message")
-	@uv run alembic revision --autogenerate -m "$(MSG)"
-
-db-upgrade: ## Apply migrations
-	@uv run alembic upgrade head
-
-db-downgrade: ## Rollback migration
-	@uv run alembic downgrade -1
-
-db-seed: ## Seed database with test data
-	@uv run python scripts/seed_db.py
-
-##@ Production
-start: ## Start production server
-	@uv run gunicorn myapi.main:app \
-		--workers $(WORKERS) \
-		--worker-class uvicorn.workers.UvicornWorker \
-		--bind $(API_HOST):$(API_PORT)
-
-##@ API Testing
-api-test: ## Run API tests
-	@uv run pytest tests/api/ -v
-
-api-load-test: ## Run load tests (use USERS=100 DURATION=60)
-	@uv run locust \
-		-f tests/load/locustfile.py \
-		--users $(USERS) \
-		--spawn-rate 10 \
-		--run-time $(DURATION)s \
-		--headless \
-		--host http://localhost:$(API_PORT)
-
-# Include Rhiza
-include .rhiza/rhiza.mk
-```
-
-### Example 3: Data Pipeline Project
-
-```makefile
-# Root Makefile for data pipeline project
-
-# Pipeline configuration
-AIRFLOW_HOME := $(CURDIR)/airflow
-export AIRFLOW_HOME
-
-post-install::
-	@echo "Initializing Airflow..."
-	@uv run airflow db init
-	@uv run airflow users create \
-		--username admin \
-		--password admin \
-		--firstname Admin \
-		--lastname User \
-		--role Admin \
-		--email admin@example.com
-
-##@ Airflow
-airflow-webserver: ## Start Airflow webserver
-	@uv run airflow webserver --port 8080
-
-airflow-scheduler: ## Start Airflow scheduler
-	@uv run airflow scheduler
-
-airflow-worker: ## Start Airflow worker
-	@uv run airflow celery worker
-
-airflow: ## Start all Airflow components
-	@$(MAKE) -j3 airflow-webserver airflow-scheduler airflow-worker
-
-##@ Pipelines
-list-dags: ## List all DAGs
-	@uv run airflow dags list
-
-trigger-dag: ## Trigger DAG (use DAG=dag_id)
-	@uv run airflow dags trigger $(DAG)
-
-test-dag: ## Test DAG (use DAG=dag_id)
-	@uv run airflow dags test $(DAG) $$(date +%Y-%m-%d)
-
-backfill: ## Backfill DAG (use DAG=dag_id START=YYYY-MM-DD END=YYYY-MM-DD)
-	@uv run airflow dags backfill $(DAG) \
-		--start-date $(START) \
-		--end-date $(END)
-
-##@ Data
-validate-schema: ## Validate data schemas
-	@uv run python scripts/validate_schemas.py
-
-check-data-quality: ## Run data quality checks
-	@uv run python scripts/check_quality.py
-
-# Include Rhiza
-include .rhiza/rhiza.mk
-```
-
----
-
-## Best Practices
-
-### 1. Documentation
-
-- **Add comments** to explain complex logic
-- **Use `##` syntax** for target descriptions (they appear in `make help`)
-- **Group related targets** with `##@` section headers
-- **Document variables** at the top of your Makefile
-
-```makefile
-# Root Makefile
-
-# Configuration variables
-API_HOST ?= 0.0.0.0  # Host for API server
-API_PORT ?= 8000     # Port for API server
-LOG_LEVEL ?= info    # Logging level (debug, info, warning, error)
-
-##@ API Server
-dev: ## Start development server (use API_PORT=8080 to override port)
-	@echo "Starting API on $(API_HOST):$(API_PORT)..."
-	@uv run uvicorn app.main:app --host $(API_HOST) --port $(API_PORT) --log-level $(LOG_LEVEL)
-```
-
-### 2. Error Handling
-
-- **Check for required variables**
-- **Validate prerequisites**
-- **Provide helpful error messages**
-
-```makefile
-##@ Deployment
-deploy: ## Deploy to server (requires SERVER and ENV variables)
-ifndef SERVER
-	$(error SERVER is not set. Use: make deploy SERVER=prod-01 ENV=production)
-endif
-ifndef ENV
-	$(error ENV is not set. Use: make deploy SERVER=prod-01 ENV=production)
-endif
-	@echo "Deploying to $(SERVER) in $(ENV) environment..."
-	@./scripts/deploy.sh $(SERVER) $(ENV)
-
-check-docker:
-	@command -v docker >/dev/null 2>&1 || { \
-		echo "Error: docker is not installed"; \
-		echo "Install from: https://docs.docker.com/get-docker/"; \
-		exit 1; \
-	}
-```
-
-### 3. Idempotency
-
-Make targets idempotent (safe to run multiple times).
-
-```makefile
-post-install::
-	@echo "Creating config file..."
-	@if [ ! -f config/local.yaml ]; then \
-		cp config/local.yaml.template config/local.yaml; \
-	else \
-		echo "Config already exists, skipping..."; \
-	fi
-
-db-create:
-	@echo "Creating database..."
-	@uv run python -c "from myapp.db import create_db; create_db(if_not_exists=True)"
-```
-
-### 4. DRY Principle
-
-Avoid repetition by using variables and functions.
-
-```makefile
-# Bad: Repetitive
-deploy-dev:
-	@echo "Deploying to dev..."
-	@./scripts/deploy.sh dev
-	@./scripts/notify.sh dev
-
-deploy-staging:
-	@echo "Deploying to staging..."
-	@./scripts/deploy.sh staging
-	@./scripts/notify.sh staging
-
-# Good: DRY
-ENV ?= dev
-
-deploy: ## Deploy to $(ENV) environment
-	@echo "Deploying to $(ENV)..."
-	@./scripts/deploy.sh $(ENV)
-	@./scripts/notify.sh $(ENV)
-
-deploy-dev: ENV=dev
-deploy-dev: deploy
-
-deploy-staging: ENV=staging
-deploy-staging: deploy
-```
-
-### 5. Testing Custom Targets
-
-Test your custom targets work correctly.
-
-```makefile
-##@ Testing
-test-makefile: ## Test custom make targets
-	@echo "Testing custom targets..."
-	@$(MAKE) print-API_HOST
-	@$(MAKE) print-API_PORT
-	@echo "Targets exist: deploy, dev, db-migrate"
-	@echo "All tests passed ✓"
-```
-
-### 6. Use Silent Prefix
-
-Use `@` to suppress command echoing for cleaner output.
-
-```makefile
-# Bad: Noisy output
-deploy:
-	echo "Starting deployment..."
-	./scripts/deploy.sh
-	echo "Deployment complete!"
-
-# Good: Clean output
-deploy:
-	@echo "Starting deployment..."
-	@./scripts/deploy.sh
-	@echo "Deployment complete!"
-```
-
-### 7. Provide Defaults
-
-Provide sensible defaults for variables.
-
-```makefile
-# Defaults with override capability
-HOST ?= localhost
-PORT ?= 8000
-ENV ?= dev
-LOG_LEVEL ?= info
-
-##@ Development
-dev: ## Start development server
-	@uv run uvicorn app:main --host $(HOST) --port $(PORT) --log-level $(LOG_LEVEL)
-```
+## Adding a bundle to Rhiza
+
+This half is for work in **this** repository. A bundle is a named group of files plus an entry
+in `.rhiza/template-bundles.yml`; the filesystem expresses ownership, so `bundles/<name>/`
+holds exactly what a consumer selecting `<name>` receives, at the paths they receive it.
+
+### Worked example: `linter`
+
+1. **Create the bundle directory**
+
+   ```text
+   bundles/
+   └── linter/
+       └── .ruff.toml
+   ```
+
+2. **Add the bundle files.** Files under `bundles/linter/` land in the downstream project at
+   the same relative path. A Ruff override extending the layer's own config:
+
+   ```toml
+   # bundles/linter/.ruff.toml
+   extend = "ruff.toml"
+
+   [lint]
+   extend-select = ["B", "I"]
+   ```
+
+3. **Declare it in `.rhiza/template-bundles.yml`**, with any dependencies. This one extends
+   `python-core`'s `ruff.toml`, so it requires that layer:
+
+   ```yaml
+   linter:
+     description: "Optional Ruff overrides for stricter linting"
+     standalone: false
+     requires: [python-core]
+   ```
+
+4. **Add a sync test in `tests/bundles/`** so the bundle is exercised the way a consumer
+   receives it. Extending `test_bundle_combinations.py` is usually enough:
+
+   ```python
+   class TestLinterBundleSync:
+       """Syncing python-core + linter adds the Ruff override file."""
+
+       @pytest.fixture(autouse=True)
+       def synced(self, tmp_path: Path, root: Path) -> None:
+           sync_bundles(root, ["core", "python-core", "linter"], tmp_path)
+           self.project = tmp_path
+
+       def test_ruff_override_exists(self) -> None:
+           assert (self.project / ".ruff.toml").is_file()
+
+       def test_ruff_override_extends_the_layer_config(self) -> None:
+           content = (self.project / ".ruff.toml").read_text(encoding="utf-8")
+           assert 'extend = "ruff.toml"' in content
+   ```
+
+   `test_bundle_content_validity.py` picks up any new YAML or JSON automatically.
+
+5. **Document it** in CLAUDE.md's bundle overview, README.md's bundle tables, and
+   `docs/reference/BUNDLE_TAXONOMY.md`. All three are gated — see the checklist.
+
+6. **Run the suite.** `make test` covers the bundle and documentation gates; `make rhiza-test`
+   runs the conformance checks. If the bundle belongs to a language layer, `make e2e` is what
+   actually executes its gates against a real toolchain.
+
+7. **Open one PR** with the directory, the YAML entry, the tests and the documentation
+   together, so a reviewer can see the whole bundle.
+
+### Review checklist
+
+Each item names the gate that enforces it, so a miss shows up locally rather than as a
+surprise in CI:
+
+- Bundle metadata with a `description`, and `requires` referencing existing bundles
+  (gate: `tests/bundles/test_template_bundles.py::TestTemplateBundles`)
+- `bundles/<name>/` exists, is non-empty, and claims no file another bundle owns — except
+  within a language layer, where overlap is the design
+  (gate: `tests/bundles/test_template_bundles.py::TestTemplateBundles`)
+- The bundle is named in CLAUDE.md
+  (gate: `tests/docs/test_doc_consistency.py::TestBundleDocumentation`)
+- The bundle is listed in README.md's bundle tables
+  (gate: `tests/docs/test_doc_consistency.py::TestReadmeBundleList` — which also fails on a
+  table row for a bundle that does *not* exist)
+- The bundle appears in `docs/reference/BUNDLE_TAXONOMY.md`
+  (gate: `tests/docs/test_doc_consistency.py::TestBundleTaxonomyDoc`)
+- Platform compatibility is picked up automatically from the YAML
+  (gate: `tests/bundles/test_bundle_matrix.py` — nothing to write, but a failure for
+  `<name>` points at a YAML, ownership or dependency problem)
+- The synced output has a focused test (the one you wrote in step 4)
 
 ---
 
 ## Troubleshooting
 
-For sync-specific failure modes and recovery commands, see
-[docs/troubleshooting.md](../troubleshooting.md).
+For sync failures and recovery commands, see [docs/troubleshooting.md](../troubleshooting.md).
 
-### Issue: Hook Not Running
+### A target does not appear in `make help`
 
-**Problem**: Your `post-install` hook doesn't seem to execute.
+`make help` lists the CLI's tasks and then greps `MAKEFILE_LIST` for repo-owned rules carrying
+a `##` comment. No comment, no listing — and a target defined anywhere other than `local.mk`
+(or a file it includes) is not in `MAKEFILE_LIST` at all.
 
-**Solution**: Ensure you're using double-colon syntax and it's defined before the `include` line:
+### A `post-install::` rule never runs
 
-```makefile
-# Root Makefile
+It never will: the anchors retired with the synced make layer. See
+[Extend a template task](#extend-a-template-task).
 
-# ✅ Correct
-post-install::
-	@echo "Running custom setup..."
+### A shadowing rule is ignored
 
-include .rhiza/rhiza.mk
-```
+An explicit rule beats the pattern rule, so this is almost always a name mismatch — check
+`uvx rhiza-task list` for the exact task name. Note also that the shadow *replaces* the task:
+if the rule does not call `$(UVX) $(RHIZA_TASK) <task>`, the template's work simply does not
+happen.
 
-### Issue: Variable Not Recognized
+### A setting has no effect
 
-**Problem**: Variable defined in Makefile not available in target.
+Run `uvx rhiza-task print <setting>` to see what resolves. The usual causes are a key in the
+wrong case (`.rhiza/.env` takes `UPPER_SNAKE_CASE`, the TOML tables take `kebab-case`), a
+`[tool.rhiza-task]` table shadowing the `rhiza.toml` you were editing, or an assignment in a
+`Makefile`, which the CLI does not read.
 
-**Solution**: Define variables before the `include` line and use `export` if needed:
+### A gate passes but measures nothing
 
-```makefile
-# Root Makefile
+Almost always a path setting pointing somewhere that does not exist — the gates skip a missing
+folder rather than failing. `uvx rhiza-task print source_folder` and confirm the folder holds
+the code you expect.
 
-# Define before include
-MY_VAR = value
-export MY_VAR  # Export if needed in sub-shells
+### An edit to a workflow keeps disappearing
 
-include .rhiza/rhiza.mk
-
-target:
-	@echo "Variable: $(MY_VAR)"
-```
-
-### Issue: Target Not in Help
-
-**Problem**: Custom target doesn't appear in `make help`.
-
-**Solution**: Add `##` comment and ensure it comes after the target name and colon:
-
-```makefile
-##@ Custom Tasks
-my-target: ## This description will appear in help
-	@echo "Running target..."
-```
-
-### Issue: Circular Dependency
-
-**Problem**: Get error about circular dependency.
-
-**Solution**: Check for dependency loops:
-
-```makefile
-# ❌ Bad: Circular dependency
-a: b
-b: a
-
-# ✅ Good: Linear dependency
-a: b
-b: c
-c:
-	@echo "Base target"
-```
-
-### Issue: Command Not Found in CI
-
-**Problem**: Command works locally but fails in CI.
-
-**Solution**: Check if command is available and install if needed:
-
-```makefile
-pre-install::
-ifdef CI
-	@echo "Installing CI dependencies..."
-	@apt-get update && apt-get install -y build-essential
-endif
-```
-
----
-
-## CodeQL Configuration
-
-The CodeQL workflow (`.github/workflows/rhiza_codeql.yml`) performs security analysis on your code. However, **CodeQL requires GitHub Advanced Security**, which is:
-
-- ✅ **Available for free** on public repositories
-- ⚠️ **Requires GitHub Enterprise license** for private repositories
-
-### Automatic Behavior
-
-By default, the CodeQL workflow:
-
-- **Runs automatically** on public repositories
-- **Skips automatically** on private repositories (unless you have Advanced Security)
-
-### Controlling CodeQL
-
-You can override the default behavior using a repository variable:
-
-1. Go to your repository → **Settings** → **Secrets and variables** → **Actions** → **Variables** tab
-2. Create a new repository variable named `CODEQL_ENABLED`
-3. Set the value:
-   - `true` - Force CodeQL to run (use if you have Advanced Security on a private repo)
-   - `false` - Disable CodeQL entirely (e.g., if it's causing issues)
-
-For private repositories with Advanced Security enabled:
-
-```bash
-gh variable set CODEQL_ENABLED --body "true"
-```
-
-For users without Advanced Security, no action is needed. To disable it completely:
-
-```bash
-gh variable set CODEQL_ENABLED --body "false"
-```
-
-Or remove the workflow file entirely:
-
-```bash
-git rm .github/workflows/rhiza_codeql.yml
-git commit -m "Remove CodeQL workflow"
-```
-
----
-
-## Documentation Customization
-
-### Project Logo
-
-The API documentation can show a logo in the sidebar. Set it in `mkdocs.yml`:
-
-```yaml
-theme:
-  logo: assets/my-custom-logo.png
-```
-
-### Custom pdoc Templates
-
-Customize the look and feel of the API documentation by providing your own Jinja2 templates. Place custom templates in the `book/pdoc-templates` directory.
-
-For example, to override the main module template, create `book/pdoc-templates/module.html.jinja2`.
-
-See the [pdoc documentation on templates](https://pdoc.dev/docs/pdoc.html#edit-pdocs-html-template) for full details on overriding specific parts of the documentation.
-
-For more details on customizing the documentation book, see [BOOK.md](BOOK.md).
+The file is template-owned. `check-managed-files` should have refused the commit; if it did not
+run, the sync silently reverted the edit. Send the change upstream, or `exclude:` the file and
+own it.
 
 ---
 
 ## See Also
 
-- [Quick Reference](QUICK_REFERENCE.md) - Command quick reference
-- [Tools Reference](../reference/TOOLS_REFERENCE.md) - Comprehensive tool documentation
-- [Makefile Customisation](../../README.md#makefile-customisation) - Adding targets and shadowing tasks
-- [rhiza-education Lesson 10: Customising Safely](https://github.com/Jebel-Quant/rhiza-education/blob/main/lessons/10-customizing-safely.md) - Tutorial overview of extension mechanisms and the template-managed file rule
+- [Customization Guide](CUSTOMIZATION.md) — the same extension points with more worked
+  examples, plus CodeQL and documentation configuration
+- [Quick Reference](QUICK_REFERENCE.md) — command and file cheat sheet
+- [Tools Reference](../reference/TOOLS_REFERENCE.md) — what each tool in the stack does
+- [Bundle Taxonomy](../reference/BUNDLE_TAXONOMY.md) — every bundle and profile
+- [Makefile Customisation](../../README.md#makefile-customisation) — the shim, the pin, and
+  where settings live
+- [rhiza-education Lesson 10: Customising Safely](https://github.com/Jebel-Quant/rhiza-education/blob/main/lessons/10-customizing-safely.md)
+  — tutorial walkthrough of these mechanisms

--- a/docs/guides/QUICK_REFERENCE.md
+++ b/docs/guides/QUICK_REFERENCE.md
@@ -110,7 +110,7 @@ advance.
 | `.python-version` | Default Python version — single line, e.g. `3.13` |
 | `.rhiza/template.yml` | Sync configuration (repository, ref, profiles/bundles) |
 | `ruff.toml` | Linter/formatter configuration |
-| `local.mk` | Local Makefile customizations (not synced, auto-loaded) |
+| `local.mk` | This repo's own make targets — `-include`d by the `Makefile`, never synced, and committed (not gitignored) |
 
 ## Python Execution
 
@@ -135,34 +135,38 @@ uv build                   # Build distribution packages
 | CI | Push, Pull Request |
 | Release | Tag `v*` |
 | Security | Schedule, Push |
-| Sync | Manual |
+| Weekly maintenance | Schedule |
 
 ## Common Patterns
 
 ### Add a custom make target
 
-Add to your root `Makefile` (above the `include .rhiza/rhiza.mk` line):
+Add it to `local.mk` — the `Makefile` is template-owned, so anything appended there is
+overwritten by the next sync:
 ```makefile
-##@ Custom Tasks
 my-target: ## My custom task
 	@echo "Custom target"
 ```
+The `##` comment is what puts it in `make help`, under *Repo-owned targets*.
 
-### Extend a hook (root Makefile)
+### Extend a template task
 
-Add above the `include` line in your root `Makefile`:
+Shadow it in `local.mk` (see **Extending a Task** above) — there are no hook targets:
 ```makefile
-post-install::
+install: $(UVX)
+	@$(UVX) $(RHIZA_TASK) install
 	@echo "Additional setup after install"
 ```
 
-### Extend a hook (local only)
+### Change a setting
 
-Add to `local.mk` (not committed, not synced):
-```makefile
-post-install::
-	@echo "Local developer setup"
+```toml
+# pyproject.toml
+[tool.rhiza-task]
+coverage-fail-under = 80
 ```
+Or `RHIZA_COVERAGE_FAIL_UNDER=80 make test` for one run; `uvx rhiza-task print
+coverage-fail-under` shows what currently resolves.
 
 ### Skip CI on commit
 

--- a/docs/ops/TECHNICAL_DEBT.md
+++ b/docs/ops/TECHNICAL_DEBT.md
@@ -24,14 +24,18 @@ So: **file an issue.** Use this page only for context that has nowhere else to l
 
 ## Scope — what belongs here, and what does not
 
-Rhiza is a collection of configuration templates. The tool that *syncs* them into
-downstream projects is [`rhiza-cli`](https://github.com/Jebel-Quant/rhiza-cli), a
-separate repository ([ADR 0005](../adr/0005-separate-rhiza-template-from-cli.md)).
+Rhiza is a collection of configuration templates. Nothing here *acts* on them: the sync
+lives in [rhiza-claude](https://github.com/Jebel-Quant/rhiza-claude), the gates in
+[rhiza-task](https://github.com/Jebel-Quant/rhiza-task), the conformance checks in
+[pytest-rhiza](https://github.com/jebel-quant/pytest-rhiza), and the hooks in
+[rhiza-hooks](https://github.com/Jebel-Quant/rhiza-hooks) — the content/engine split of
+[ADR 0005](../adr/0005-separate-rhiza-template-from-cli.md), which outlived the `rhiza-cli`
+package that first implemented the engine half.
 
-Debt in sync behaviour — conflict resolution when a template update collides with local
-changes, sync performance on large repositories, pre-sync validation of a custom
-template — belongs to `rhiza-cli` and should be filed there. The previous version of
-this document tracked three such items against this repository, where no code
+So debt in sync behaviour — conflict resolution when a template update collides with local
+changes, sync performance on large repositories, pre-sync validation of a custom template —
+belongs to rhiza-claude, and debt in a gate's recipe belongs to rhiza-task. The previous
+version of this document tracked three such items against this repository, where no code
 implementing them exists.
 
 ## Current items
@@ -74,6 +78,6 @@ speculative work is a roadmap question, not debt.
 1. Open a GitHub issue describing the limitation and its impact.
 2. Label it `technical-debt`.
 3. If it concerns syncing rather than the templates themselves, file it against
-   `rhiza-cli` instead.
+   rhiza-claude instead — and a gate's behaviour against rhiza-task.
 4. Add a note here **only** if the item needs context that does not fit an issue — and
    link the issue, so the two cannot drift apart.

--- a/docs/reference/GLOSSARY.md
+++ b/docs/reference/GLOSSARY.md
@@ -5,10 +5,13 @@ A comprehensive glossary of terms used in the Rhiza template system.
 ## Core Concepts
 
 ### rhiza (template repository)
-The GitHub repository (`jebel-quant/rhiza`) that contains the curated set of configuration files, Makefile modules, CI/CD workflows, and other tooling files that downstream projects sync from. This is the *content* — the files you receive. See also: [rhiza-cli](#rhiza-cli).
+The GitHub repository (`jebel-quant/rhiza`) that contains the curated set of configuration files, CI/CD workflow stubs, and other tooling files that downstream projects sync from. This is the *content* — the files you receive. See also: [rhiza-claude](#rhiza-claude), [rhiza-task](#rhiza-task).
 
-### rhiza-cli
-A standalone Python package (published on PyPI as `rhiza-cli`) that provides the `rhiza` command-line interface. It is the *engine* that reads `.rhiza/template.yml` and performs operations such as `init`, `sync`, `bump`, and `release`. Invoked via `uvx rhiza ...` without requiring a permanent installation. Versioned independently from the template repository. See also: [rhiza (template repository)](#rhiza-template-repository).
+### rhiza-claude
+The Claude Code plugin marketplace providing the `rhiza` plugin — the slash commands that drive a managed repo: `/rhiza:init`, `/rhiza:update`, `/rhiza:status`, `/rhiza:quality`, `/rhiza:docs`, `/rhiza:release`, `/rhiza:detach`. It is the *engine*: it reads `.rhiza/template.yml`, fetches the selected bundles and three-way merges them into the working tree, recording what arrived in `.rhiza/template.lock`. Its scripts are stdlib-only Python, so nothing is installed beyond the plugin itself. Versioned independently from the template repository. See also: [rhiza (template repository)](#rhiza-template-repository), [Template Sync](#template-sync).
+
+### rhiza-cli (retired)
+The former PyPI package that provided a `rhiza` command — `init`, `sync`, `bump`, `release` — invoked as `uvx rhiza ...`. The package is unpublished and [its repository](https://github.com/Jebel-Quant/rhiza-cli) is archived; the sync it performed now ships inside [rhiza-claude](#rhiza-claude). The separation of content from engine that [ADR-0005](../adr/0005-separate-rhiza-template-from-cli.md) chose is unchanged — only the engine moved. Listed here because the name still appears in older documents and changelog entries.
 
 ### Living Templates
 A template approach where configuration files remain synchronized with an upstream source over time, as opposed to traditional "one-shot" template generators (like cookiecutter or copier) that generate files once and then disconnect from the source.
@@ -84,6 +87,7 @@ flowchart LR
 
     python_core --> core
     rust_core --> core
+    go_core --> core
     github --> core
     gitlab --> core
     book --> core
@@ -125,7 +129,7 @@ flowchart LR
 ## Directory Structure
 
 ### `.rhiza/`
-The core directory containing Rhiza's template system files. This directory is synced from upstream and should generally not be modified directly.
+The core directory containing Rhiza's template system files. Synced from upstream, so its contents are overwritten by the next sync and should not be edited — with one exception: `.rhiza/.env` is repo-owned, read by [rhiza-task](#rhiza-task) as layer 2 of its settings order, and gitignored, so it holds developer-local values only.
 
 ### `rhiza-task`
 The pinned CLI that provides Rhiza's developer tasks — `install`, `test`, `typecheck`, `book`,
@@ -141,24 +145,21 @@ targets go in `local.mk`, which the shim `-include`s. It was repo-owned for one 
 by `uvx rhiza-task shim`; that subcommand was removed in rhiza-task 1.0.0.
 
 ### `.rhiza/template.yml`
-Configuration file defining which files to sync from upstream, include/exclude patterns, and sync behavior.
+The *pointer*: which template repository this project follows, at which `ref`, and which bundles or profiles it selects (plus any `include`/`exclude` patterns). Written by `/rhiza:init`, and the file Renovate bumps.
+
+### `.rhiza/template.lock`
+The *record*: what a sync actually delivered — repository, ref, commit SHA, timestamp, strategy, and every managed file. The pointer and the record answer different questions and can disagree, which is why `/rhiza:status` reports both, and why `/rhiza:update` stages precisely the recorded file list rather than everything that changed.
 
 ### `local.mk`
-Optional file for project-specific Makefile extensions. Not synced from upstream, allowing local customization without conflicts.
+The project's own make targets, `-include`d by the [shim](#makefile-the-shim) and never synced. Deliberately **not** gitignored: anything CI invokes has to be committed. This is where a repo's targets live now that the `Makefile` is template-owned.
 
 ## Makefile System
 
-### Double-Colon Targets (`::`)
-Make targets defined with `::` instead of `:`. These are "hook" targets that can be extended by downstream projects without overriding the original implementation.
-
-### Hook Targets
-Extension points in the Makefile system. Available hooks:
-- `pre-install::` / `post-install::` - Before/after dependency installation
-- `pre-sync::` / `post-sync::` - Before/after template sync
-- `pre-validate::` / `post-validate::` - Before/after project validation
-
 ### Make Target
-A named command in the Makefile (e.g., `make test`, `make fmt`). Rhiza provides 40+ targets out of the box.
+A named command reached through `make` (e.g., `make test`, `make fmt`). Rhiza provides 40+ of them out of the box, and nearly all are tasks of [rhiza-task](#rhiza-task) rather than rules in a file: the [shim](#makefile-the-shim) forwards every unmatched target to the pinned CLI.
+
+### Hook Targets (retired)
+The synced make layer anchored `pre-install::` / `post-install::` and similar double-colon no-ops, so a project could chain work onto a template target without overriding it. The CLI knows nothing about make targets, so those hooks are gone. The replacement is to **shadow** the target: an explicit rule in `local.mk` beats the shim's `%:` catch-all, so an `install:` rule there can call `uvx $(RHIZA_TASK) install` and then the extra step.
 
 ### `make doctor`
 A diagnostic target that validates required tools, checks versions, and reports environment issues. Run this first when something is wrong with your setup.
@@ -221,7 +222,7 @@ A security linter for Python code. Finds common security issues. Integrated in p
 GitHub's semantic code analysis engine. Scans for security vulnerabilities in Python code and GitHub Actions workflows.
 
 ### Marimo
-A reactive Python notebook format. Rhiza includes support for marimo notebooks in the `book/` directory.
+A reactive Python notebook format. Rhiza includes support for marimo notebooks; the `marimo` bundle keeps them in `docs/notebooks` (the `marimo-folder` setting), inside the docs tree so the book can publish them.
 
 ## Configuration Files
 
@@ -263,8 +264,8 @@ Continuous Integration workflow that runs tests on every push and pull request.
 ### Release Workflow
 Multi-phase workflow triggered by version tags. Builds packages, creates GitHub releases, publishes to PyPI, optionally generates a conda recipe with grayskull, and can publish devcontainer images.
 
-### Sync Workflow
-Workflow that synchronizes template files from upstream Rhiza repository.
+### Sync Workflow (retired)
+Syncing is no longer a CI job in either platform's bundle: `/rhiza:update` runs it from a developer's machine and opens the pull request, so nothing needs a write-scoped token on a schedule.
 
 ### Security Workflow
 Workflow running security scans (bandit, semgrep, CodeQL) on the codebase.

--- a/docs/reference/WHY_NOT_COPIER_CRUFT.md
+++ b/docs/reference/WHY_NOT_COPIER_CRUFT.md
@@ -129,7 +129,8 @@ are routine, because editing generated files is the expected workflow.
 ### 7. Fork-friendly without forking an engine
 
 Rhiza separates the template content from the sync engine
-([ADR-0005](../adr/0005-separate-rhiza-template-from-cli.md)): `rhiza-cli` is generic, and
+([ADR-0005](../adr/0005-separate-rhiza-template-from-cli.md)): the engine — the `rhiza`
+Claude Code plugin, since the `rhiza-cli` package retired — is generic, and
 `.rhiza/template.yml` can point at any repository. An organisation that wants its own variant
 forks this repository, adjusts files, and keeps pulling upstream improvements with ordinary
 `git merge` — because the files are verbatim, fork maintenance is plain git work, not Jinja

--- a/tests/bundles/test_bundle_dogfood_symlinks.py
+++ b/tests/bundles/test_bundle_dogfood_symlinks.py
@@ -16,7 +16,7 @@ a same-path bundle counterpart it asserts one of two states holds, and fails oth
 
 The failure that matters most is a byte-identical *plain-file duplicate* that is neither a
 carve-out nor a symlink: that means someone added a bundle file without running
-``make sync-self``, or a ``rhiza sync .`` re-materialised a copy — silently breaking the
+``make sync-self``, or a ``/rhiza:update`` re-materialised a copy — silently breaking the
 single-source-of-truth guarantee. The check is driven by the very same helpers the linker
 uses (:mod:`link_dogfood`), so the guard and the linker can never disagree about the rules.
 """
@@ -101,7 +101,7 @@ class TestDogfoodSymlinks:
         """Each non-carve-out dogfood path must be a symlink into a byte-identical bundle source.
 
         This is the drift catch: a real file here means a bundle twin was left un-linked
-        (add a file then forget ``make sync-self``, or a ``rhiza sync`` re-materialised a
+        (add a file then forget ``make sync-self``, or a ``/rhiza:update`` re-materialised a
         copy), silently forking the single source of truth.
         """
         link = _ROOT / rel

--- a/tests/docs/test_doc_consistency.py
+++ b/tests/docs/test_doc_consistency.py
@@ -273,13 +273,17 @@ _PROSE_GATE_EXEMPT = {"CHANGELOG.md"}
 
 # Words that follow a literal `make` without naming a target of this repository, and so
 # cannot be checked against the CLI. Each is a documented category, not a leak:
-#   - metasyntax: `make <target>` rendered without the angle brackets, and the mermaid node
-#     label `make commands`
+#   - metasyntax: `make <target>`/`make <targets>` rendered without the angle brackets, and
+#     the mermaid node label `make commands`
 #   - a package list: `apt-get install -y make git curl`
-#   - worked examples of a *consumer's* own targets, in the guide about adding them
-_MAKE_MENTION_EXEMPT = frozenset(
-    {"target", "targets", "variables", "commands", "git", "deploy", "deploy-dev", "deploy-prod", "deploy-staging"}
-)
+#
+# The `deploy`/`deploy-dev`/`deploy-staging`/`deploy-prod` and `variables` entries went when
+# EXTENDING_RHIZA.md was rewritten: they existed for that guide's worked examples of a
+# *consumer's* own targets, which is a category an exemption cannot distinguish from a stale
+# mention of a real target. The guide now shows such targets as makefile rules rather than as
+# `make <name>` invocations, so nothing needs excusing.
+# ``test_every_make_mention_exemption_is_still_needed`` keeps the list from re-accumulating.
+_MAKE_MENTION_EXEMPT = frozenset({"target", "targets", "commands", "git"})
 
 
 @functools.lru_cache(maxsize=1)
@@ -396,6 +400,27 @@ class TestProseDrift:
     def test_make_mentions_were_collected(self) -> None:
         """Guard against the make-mention scanner silently collecting nothing."""
         assert len(_make_mention_cases()) > 10, "expected CLAUDE.md/README.md to mention make targets"
+
+    @pytest.mark.parametrize("word", sorted(_MAKE_MENTION_EXEMPT))
+    def test_every_make_mention_exemption_is_still_needed(self, word: str) -> None:
+        """Each exempt word must actually appear after `make` in some doc's code region.
+
+        An exemption outlives the text it was written for -- five of them did, for worked
+        examples that a rewrite removed -- and each one that lingers is a real target name the
+        drift check can no longer see. `make deploy` was excused here while `deploy` was also
+        a plausible task name, so a doc promising it would have passed.
+        """
+        found = {
+            match.group(1)
+            for doc in _markdown_files()
+            if doc.name not in _PROSE_GATE_EXEMPT
+            for region in _CODE_REGION_RE.findall(doc.read_text(encoding="utf-8", errors="replace"))
+            for match in _MAKE_MENTION_RE.finditer(region)
+        }
+        assert word in found, (
+            f"'{word}' is exempt from the make-mention check but no document uses it -- "
+            "remove it from _MAKE_MENTION_EXEMPT rather than leaving a real target name unchecked"
+        )
 
     def test_the_cli_half_of_the_target_set_was_collected(self) -> None:
         """The other side of the comparison needs a control too (#1584).

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -10,7 +10,7 @@ test for it could only be written *after* someone ran the gate on a real project
 and watched it fail on the project's own module.
 
 This module closes that gap. For each layer it copies the bundles into a temp
-directory (standing in for a `rhiza-cli` sync), writes the smallest project the
+directory (standing in for a `/rhiza:update` sync), writes the smallest project the
 layer should be green on (see `scaffolds.py`), commits it, and runs `make install`.
 The test modules then drive one gate per test against that project, for real.
 
@@ -209,7 +209,7 @@ def _init_repo(project: Path, version: str) -> None:
 def _sync(root: Path, layer: Layer, project: Path) -> None:
     """Copy the layer's bundles into the project, dereferencing symlinks.
 
-    Mirrors what `rhiza-cli` does on a sync: bundle files land at the paths they
+    Mirrors what a sync does: bundle files land at the paths they
     declare, with dogfood symlinks resolved to real content.
 
     Args:

--- a/utils/link_dogfood.py
+++ b/utils/link_dogfood.py
@@ -14,9 +14,9 @@ Only root files that are byte-identical to exactly one bundle source are linked.
 Intentional mother-repo overrides (files that deliberately diverge from their bundle
 source) and root-only files are listed in ``_EXCLUDE`` and left untouched. The script
 is idempotent: correct symlinks are left as-is, and a copy that reappears (e.g. after
-a local ``rhiza sync .``) is re-linked.
+a local ``/rhiza:update``) is re-linked.
 
-It is mother-repo-only tooling. Downstream consumers never run it — ``rhiza sync``
+It is mother-repo-only tooling. Downstream consumers never run it — the sync
 resolves symlinks to real content, so synced projects only ever receive real files.
 
 Example:


### PR DESCRIPTION
`rhiza-cli` is unpublished and [its repository](https://github.com/Jebel-Quant/rhiza-cli) is archived, so every `uvx rhiza init` / `uvx rhiza sync` instruction in these docs was advice that cannot work. The sync belongs to the `rhiza` Claude Code plugin now, and ADR 0005's content/engine split outlived the package that first implemented the engine half.

Two commits: the sweep, then the README shortening.

## rhiza-cli, retired properly

- **README.md** — the onboarding path, the "two components" section (five now, as a table), the GitLab "quick setup" that copied a `.gitlab/` this repo does not have at root, and the GitHub workflow list that still advertised *template synchronization* — no sync workflow ships in either platform bundle.
- **GLOSSARY.md** — the `rhiza-cli` entry becomes rhiza-claude plus a retired stub (the name survives in the changelog); `Hook Targets` and `Sync Workflow` are marked retired with their replacements; `template.yml`/`template.lock` are described as pointer-vs-record; the dependency map was missing its `go_core --> core` edge.
- **ADRs 0005 and 0010** — amended rather than rewritten, in the style ADR 0009 set. 0005 records which of its stated benefits survive the substitution and which do not (PyPI discoverability is simply gone; "two repositories to follow" is now five). 0010 records that its *CLI changes required* negative is discharged: `/rhiza:init` writes a `profiles:` key and `/rhiza:update` expands it.
- **CLAUDE.md, TECHNICAL_DEBT.md, WHY_NOT_COPIER_CRUFT.md, COMPARISON.md** and three code comments.

## Two guides that still taught the retired make layer

- **CUSTOMIZATION.md** and **QUICK_REFERENCE.md** told readers to put hooks and variables above `include .rhiza/rhiza.mk`, and called `local.mk` gitignored. README links the first as its worked examples, so it contradicted the file it supports; the second contradicted itself, one section saying the hooks were gone while a later one demonstrated them.
- **EXTENDING_RHIZA.md, 1119 → 308 lines.** The bundle-authoring half is kept, with three gate claims corrected — README's bundle tables *are* gated now, by `TestReadmeBundleList`. The extension-points half is rewritten around `local.mk`, shadowing and the settings chain. What went is ~700 lines of generic GNU make tutorial (Airflow, Alembic and Locust Makefiles; "use `@` to suppress echoing"; circular-dependency troubleshooting), all written against the `include` model. Its bulk is why the rot went unnoticed.

Documenting the settings chain from the pinned CLI rather than transcribing it turned up a stale claim in CLAUDE.md: the `[tool.rhiza-task]` table is **no longer Python-only**. rhiza-task 1.1.0 reads a root `rhiza.toml` too, in table or flat form, with `pyproject.toml` winning where both exist — the language-neutral source CLAUDE.md said was missing.

## One knock-on in the guard

The drift check exempted `deploy`, `deploy-dev`, `deploy-staging`, `deploy-prod` and `variables` from its `make <target>` scan, for EXTENDING_RHIZA's worked examples. The rewrite shows those as makefile rules instead, so all five are pruned and `test_every_make_mention_exemption_is_still_needed` keeps the list from re-accumulating. That mattered: `deploy` was excused while also being a plausible task name, so a document promising `make deploy` would have passed the check written to catch exactly that.

## README: 730 → 529 lines

The README had grown into a tutorial it cannot keep current, duplicating rhiza-education's lessons — which is how the `uvx rhiza init` advice survived so long, since the education repo had already moved to the plugin flow. The split is now by role: this file says what Rhiza is, what you get, which bundles exist, and how to keep your own additions out of the sync's way; the tutorial says how to learn it, and Lessons 6, 7–9 and 10 are named at the three points a reader would otherwise want a walkthrough.

Removed rather than reworded: *Advanced Topics* (eleven subsections, mostly a link with a heading around it) becomes a documentation-map table that also absorbs *Project Maintainability*; the ADR list, which had been missing 0010 and 0011 since they landed; the Integration Guide's reference tables, which QUICK_REFERENCE/GLOSSARY/CUSTOMIZATION cover in more detail; and two of the three copies of the tool-prerequisites table.

Kept deliberately: the bundle and profile tables (gated against `template-bundles.yml` in both directions) and the generated make-help fence — deleting its markers would silently disable the `update-readme-help` hook, which was inert once already (#1581).

## Also

The `presentation` bundle ships its deck to consumers, and it pointed at `.github/template.yml`, `.rhiza/scripts/sync.sh`, a `sync.yml` workflow and a `.rhiza/scripts/customisations/` mechanism — none of which exist — plus pdoc and minibook for a docs stack that is MkDocs + zensical.

## Verification

`make fmt`, `make test` (1628 passed) and `make rhiza-test` are green. `make book-nav` fails locally on a stale `_book` from 19 August and a missing paper PDF; no doc files were added or removed, so the nav is unchanged.

Not included: **`docs/reference/ARCHITECTURE.md`** is in the same state — it diagrams a `requirements/` directory that no longer exists, names pdoc, and hard-codes file counts. Same rewrite shape, separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)