### PR TITLE
chore: SHA-pin the shipped workflows, and give their pins a bot that watches them

### DIFF
--- a/bundles/github/.github/CONFIG.md
+++ b/bundles/github/.github/CONFIG.md
@@ -61,3 +61,44 @@ optional depending on which release features you use:
 | `UV_EXTRA_INDEX_URL` | Extra package index URL (with credentials) for private dependencies. |
 
 `GITHUB_TOKEN` is provided automatically by GitHub Actions and needs no configuration.
+
+## How the workflows are pinned
+
+Every third-party action in these workflows is pinned to a **commit SHA**, with the tag it
+corresponds to in a trailing comment:
+
+```yaml
+- uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+```
+
+A tag is a moving reference: whoever owns the action can repoint `v6.1.0` at a different
+commit, and every repository using it runs the new code without a diff anywhere. A SHA cannot
+move. This is also what OpenSSF Scorecard's Pinned-Dependencies check looks for, so a synced
+repository scores on it without doing anything.
+
+Keeping them current is a bot's job. Rhiza itself uses Renovate and Dependabot; the `renovate`
+bundle ships a config with the `github-actions` manager enabled, and the `github` bundle ships
+a `dependabot.yml` that covers `.github/workflows`. Either updates the SHA and the comment
+together — you need only review and merge.
+
+References to rhiza's own reusable workflows are the deliberate exception:
+
+```yaml
+uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.5.1
+```
+
+That tag is the *template version* this repository is synced to, not a dependency to bump.
+`/rhiza:update` rewrites it when you move to a new release, so a bot bumping it would put
+your workflows ahead of the template they came from.
+
+## What these workflows deliberately do not do
+
+They contain no runner-hardening or egress-monitoring step, even though rhiza's own workflows
+open every job with `step-security/harden-runner`. Adding a third-party agent that watches a
+runner and reports its network activity to a third-party service is a decision for the people
+who own the repository and answer for its compliance — not one a configuration template makes
+on their behalf. Nothing in the release pipeline needs it to cut a release.
+
+If you want it, add the step to each job; `exclude:` in `.rhiza/template.yml` keeps your copy
+across syncs. Note that the workflows delegating to rhiza's reusable workflows — CI, book,
+docker, marimo, paper — already run hardened jobs, because those jobs are rhiza's.

--- a/bundles/github/.github/workflows/rhiza_release.yml
+++ b/bundles/github/.github/workflows/rhiza_release.yml
@@ -127,7 +127,7 @@ jobs:
       tag: ${{ steps.set_tag.outputs.tag }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
 
@@ -199,7 +199,7 @@ jobs:
           exit 1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7.6.0
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Ensure release version is newer than latest published
         env:
@@ -254,12 +254,12 @@ jobs:
       attestations: write   # SLSA provenance + SBOM attestations (public repos only)
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7.6.0
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: "0.11.16"
 
@@ -303,7 +303,7 @@ jobs:
 
       - name: Install Python for SBOM generation
         if: hashFiles('pyproject.toml') != ''
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version-file: .python-version
 
@@ -329,7 +329,7 @@ jobs:
         # The XML format is provided for compatibility but doesn't need separate attestation.
         id: attest-sbom
         if: hashFiles('pyproject.toml') != '' && github.event.repository.private == false
-        uses: actions/attest@v4.1.0
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-path: sbom.cdx.json
           sbom-path: sbom.cdx.json
@@ -345,7 +345,7 @@ jobs:
 
       - name: Upload SBOM artifacts
         if: hashFiles('pyproject.toml') != ''
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom
           path: |
@@ -356,7 +356,7 @@ jobs:
       - name: Generate SLSA provenance attestations
         id: provenance
         if: steps.buildable.outputs.buildable == 'true' && github.event.repository.private == false
-        uses: actions/attest-build-provenance@v4.1.0
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: dist/*
 
@@ -369,7 +369,7 @@ jobs:
 
       - name: Upload dist artifact
         if: steps.buildable.outputs.buildable == 'true'
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
           path: dist
@@ -384,19 +384,19 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7.6.0
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Generate release notes with git-cliff
         run: uvx git-cliff --latest --output RELEASE_NOTES.md
 
       - name: Download SBOM artifact
         # Downloads sbom.cdx.json and sbom.cdx.xml into sbom/ directory
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: sbom
           path: sbom
@@ -405,14 +405,14 @@ jobs:
       - name: Download dist artifact
         # Brings in provenance.intoto.jsonl (and the built distributions) staged
         # by the build job, so the SLSA provenance ships as a release asset.
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: dist
         continue-on-error: true
 
       - name: Create GitHub Release with artifacts
-        uses: ncipollo/release-action@v1.21.0
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           tag: ${{ needs.tag.outputs.tag }}
           name: ${{ needs.tag.outputs.tag }}
@@ -435,12 +435,12 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
 
       - name: Download dist artifact
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: dist
@@ -473,7 +473,7 @@ jobs:
       # repository-url and password only used for custom feeds, not for PyPI with OIDC
       - name: Publish to PyPI
         if: ${{ steps.check_dist.outputs.should_publish == 'true' }}
-        uses: pypa/gh-action-pypi-publish@v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: dist/
           skip-existing: true
@@ -492,7 +492,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
 
@@ -511,7 +511,7 @@ jobs:
 
       - name: Set up Python
         if: steps.check_conda.outputs.should_generate == 'true'
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version-file: .python-version
 
@@ -553,7 +553,7 @@ jobs:
 
       - name: Upload conda recipe artifact
         if: steps.check_conda.outputs.should_generate == 'true'
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: conda-recipe
           path: conda-recipe/meta.yaml
@@ -571,7 +571,7 @@ jobs:
       image_name: ${{ steps.image_name.outputs.image_name }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
 
@@ -600,7 +600,7 @@ jobs:
 
       - name: Login to Container Registry
         if: steps.check_publish.outputs.should_publish == 'true'
-        uses: docker/login-action@v4.2.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ steps.registry.outputs.registry }}
           username: ${{ github.repository_owner }}
@@ -642,7 +642,7 @@ jobs:
 
       - name: Build and Publish Devcontainer Image
         if: steps.check_publish.outputs.should_publish == 'true'
-        uses: devcontainers/ci@v0.3.1900000450
+        uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3.1900000450
         with:
           configFile: .devcontainer/devcontainer.json
           push: always
@@ -675,12 +675,12 @@ jobs:
       contents: write   # Needed to undraft/publish the GitHub release
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7.6.0
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: "0.11.16"
 
@@ -692,7 +692,7 @@ jobs:
           uv sync --all-extras --all-groups --frozen
 
       - name: Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
 
       - name: Generate Devcontainer Link
         id: devcontainer_link

--- a/docs/ops/CII_BEST_PRACTICES.md
+++ b/docs/ops/CII_BEST_PRACTICES.md
@@ -45,7 +45,7 @@ to the evidence that already exists in rhiza, so the questionnaire is mostly cop
 | Contribution guide | `CONTRIBUTING.md` |
 | Code review of changes | Branch-protection ruleset (`docs/ops/BRANCH_PROTECTION.md`) |
 | Continuous integration | GitHub Actions + GitLab CI |
-| Supply-chain hardening | SHA-pinned actions, OpenSSF Scorecard workflow |
+| Supply-chain hardening | SHA-pinned actions — in the workflows rhiza runs *and* the ones it ships (#1611) — plus runner hardening (`step-security/harden-runner`, audit mode) on every job here, and the OpenSSF Scorecard workflow |
 
 ## Related
 

--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,7 @@
   "enabledManagers": [
     "pep621",
     "pre-commit",
+    "github-actions",
     "gitlabci",
     "devcontainer",
     "dockerfile",
@@ -39,6 +40,26 @@
         "jebel-quant/rhiza"
       ],
       "automerge": false
+    },
+    {
+      "description": "The live workflows stay Dependabot's, so Renovate does not open a second PR for the same bump. `managerFilePatterns` above is merged with the manager's defaults rather than replacing them, so this is the half that actually draws the line.",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchFileNames": [
+        ".github/workflows/**"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "rhiza's own reusable workflows are not a dependency to bump: `[[tool.bumpversion.files]]` rewrites `@vX.Y.Z` across the bundle stubs on every release, so a Renovate PR here would fight the release and pin consumers to a tag ahead of the template they synced.",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchPackageNames": [
+        "jebel-quant/rhiza"
+      ],
+      "enabled": false
     }
   ],
   "customManagers": [
@@ -78,5 +99,11 @@
       "depNameTemplate": "rhiza-task",
       "datasourceTemplate": "pypi"
     }
-  ]
+  ],
+  "github-actions": {
+    "description": "The action pins in the workflows rhiza *ships*. The manager's default file patterns are anchored at the repository root (`^\\.github/workflows/`), so nothing matched `bundles/*/.github/workflows/*.yml` and those pins only aged -- `actions/checkout` sat at v6.0.2 while the live copies were three releases ahead (#1610). Dependabot could not cover them either: its `github-actions` ecosystem reads `.github/workflows` under the configured directory and nothing else.",
+    "managerFilePatterns": [
+      "/^bundles/[^/]+/\\.github/workflows/[^/]+\\.ya?ml$/"
+    ]
+  }
 }

--- a/tests/api/test_renovate_managers.py
+++ b/tests/api/test_renovate_managers.py
@@ -35,6 +35,7 @@ import subprocess  # nosec B404 - fixed argument vectors
 from pathlib import Path
 
 import pytest
+import yaml
 
 _ROOT = Path(__file__).resolve().parents[2]
 _RENOVATE = _ROOT / "renovate.json"
@@ -228,4 +229,174 @@ def test_every_pin_names_the_same_version() -> None:
         f"the rhiza-task pin disagrees with itself across files: "
         f"{ {v: sorted(p) for v, p in versions.items()} }. Every literal must name one "
         f"version, or the shim and CI run different gates."
+    )
+
+
+# --------------------------------------------------------------------------------------
+# Action pins: the same question as above, asked of `uses:` rather than of `rhiza-task@`.
+# --------------------------------------------------------------------------------------
+
+# `uses: owner/repo[/path]@ref`, which is every action reference that resolves to another
+# repository. `./`-relative refs are local and have no version to bump.
+_USES_RE = re.compile(r"^\s*(?:-\s+)?uses:\s*([A-Za-z0-9][\w.-]*/[\w./-]+)@\S+", re.MULTILINE)
+
+# rhiza's own reusable workflows. Deliberately unwatched: the release rewrites the tag.
+_FIRST_PARTY = "jebel-quant/rhiza/"
+
+# What Renovate's `github-actions` manager matches without configuration. Anchored at the
+# repository root -- which is the whole of #1610: `bundles/github/.github/workflows/` is not
+# under `^.github/`, so the shipped pins were matched by nothing and only aged.
+_RENOVATE_DEFAULT_PATTERNS = (
+    re.compile(r"^(?:workflow-templates|\.(?:github|gitea|forgejo)/(?:workflows|actions))/.+\.ya?ml$"),
+    re.compile(r"(^|/)action\.ya?ml$"),
+)
+
+# Dependabot's `github-actions` ecosystem reads `<directory>/.github/workflows` and nothing
+# else -- it has no globbing over the tree, which is why it cannot cover the bundles either.
+_DEPENDABOT = _ROOT / ".github" / "dependabot.yml"
+
+
+def _third_party_action_files() -> list[str]:
+    """Return every tracked workflow that references a third-party action.
+
+    Returns:
+        Repo-relative paths, sorted; first-party reusable-workflow callers excluded.
+    """
+    out = []
+    for path in _tracked_files():
+        if not (path.startswith(".github/workflows/") or ".github/workflows/" in path):
+            continue
+        text = (_ROOT / path).read_text(encoding="utf-8", errors="replace")
+        if any(not ref.startswith(_FIRST_PARTY) for ref in _USES_RE.findall(text)):
+            out.append(path)
+    return sorted(out)
+
+
+@functools.lru_cache(maxsize=1)
+def _renovate_action_scope() -> tuple[list[re.Pattern[str]], list[str]]:
+    """Return Renovate's github-actions file patterns and the paths it is switched off for.
+
+    Returns:
+        ``(patterns, disabled_prefixes)`` -- the configured patterns plus the manager's own
+        defaults, and the ``matchFileNames`` globs of every rule disabling the manager.
+    """
+    config = json.loads(_RENOVATE.read_text(encoding="utf-8"))
+    assert "github-actions" in config["enabledManagers"], (
+        "the github-actions manager is not enabled, so nothing Renovate does covers the shipped workflows (#1610)"
+    )
+    configured = [_as_regex(p) for p in config.get("github-actions", {}).get("managerFilePatterns", [])]
+    disabled = [
+        glob.removesuffix("/**")
+        for rule in config.get("packageRules", [])
+        if rule.get("enabled") is False and "github-actions" in (rule.get("matchManagers") or [])
+        for glob in (rule.get("matchFileNames") or [])
+    ]
+    return [*configured, *_RENOVATE_DEFAULT_PATTERNS], disabled
+
+
+@functools.lru_cache(maxsize=1)
+def _dependabot_action_dirs() -> tuple[str, ...]:
+    """Return the workflow directories Dependabot's github-actions ecosystem covers."""
+    config = yaml.safe_load(_DEPENDABOT.read_text(encoding="utf-8"))
+    return tuple(
+        f"{entry['directory'].strip('/')}/.github/workflows".lstrip("/")
+        for entry in config.get("updates", [])
+        if entry.get("package-ecosystem") == "github-actions"
+    )
+
+
+def _watchers(path: str) -> list[str]:
+    """Return the names of every bot configured to bump the action pins in ``path``."""
+    patterns, disabled = _renovate_action_scope()
+    watchers = []
+    if any(p.search(path) for p in patterns) and not any(path.startswith(d) for d in disabled):
+        watchers.append("Renovate")
+    if any(path.startswith(d) for d in _dependabot_action_dirs()):
+        watchers.append("Dependabot")
+    return watchers
+
+
+def test_the_action_scan_finds_the_workflows() -> None:
+    """Positive control: an empty file list makes every assertion below vacuous."""
+    found = _third_party_action_files()
+    assert len(found) >= 10, f"found only {len(found)} workflow(s) with a third-party action: {found}"
+    assert "bundles/github/.github/workflows/rhiza_release.yml" in found, (
+        "the shipped release workflow is the one bundle file with third-party actions; a scan "
+        "that misses it proves nothing about #1610"
+    )
+
+
+@pytest.mark.parametrize("path", _third_party_action_files())
+def test_every_third_party_action_pin_is_watched(path: str) -> None:
+    """Exactly one bot must be configured to bump each file's action pins.
+
+    Zero is #1610: `bundles/github/.github/workflows/rhiza_release.yml` carried 26 pins that
+    Renovate's root-anchored defaults did not match and Dependabot's directory-scoped
+    ecosystem could not reach, so `actions/checkout` sat at v6.0.2 while the live copies had
+    moved three releases on. A manager matching nothing is not an error to Renovate -- it
+    opens no PR and reports no failure.
+
+    Two is the opposite failure and just as real: both bots would open a PR for the same bump,
+    and the loser of the race rebases forever.
+    """
+    watchers = _watchers(path)
+    assert watchers, (
+        f"no dependency bot is configured to bump the action pins in {path}. Renovate's "
+        f"github-actions defaults are anchored at the repository root and Dependabot reads "
+        f"`<directory>/.github/workflows` only, so a file outside both is watched by nothing "
+        f"and its pins simply age (#1610)."
+    )
+    assert len(watchers) == 1, (
+        f"{path} is watched by {watchers} — two bots bumping one file means two PRs per bump. "
+        f"Give the file to one of them."
+    )
+
+
+def test_the_bundle_and_live_pins_agree() -> None:
+    """The same action must be pinned to the same commit everywhere it appears.
+
+    The action-pin twin of `test_every_pin_names_the_same_version`, and the state this
+    repository was actually in: the live workflows and the shipped one named different
+    commits for six of the eleven actions they share, which is drift with a security edge —
+    a consumer's release pipeline ran older code than the mother repo's did.
+    """
+    pins: dict[str, dict[str, set[str]]] = {}
+    for path in _third_party_action_files():
+        text = (_ROOT / path).read_text(encoding="utf-8")
+        for match in re.finditer(r"uses:\s*([A-Za-z0-9][\w.-]*/[\w./-]+)@(\S+)", text):
+            action, ref = match.group(1), match.group(2)
+            if action.startswith(_FIRST_PARTY):
+                continue
+            pins.setdefault(action, {}).setdefault(ref, set()).add(path)
+    split = {
+        action: {ref: sorted(paths) for ref, paths in refs.items()} for action, refs in pins.items() if len(refs) > 1
+    }
+    assert not split, f"actions pinned to more than one ref across the tree: {split}"
+
+
+def test_a_synced_repository_gets_a_bot_for_its_action_pins() -> None:
+    """The consumer half of #1610: a SHA pin nobody bumps is a pin that rots.
+
+    SHA-pinning the shipped workflows (#1611) makes this load-bearing rather than tidy. A tag
+    pin at least follows patch releases of the action; a SHA follows nothing at all, so a
+    synced repository with no bot configured freezes on the commit it was synced with — and
+    reads as hardened while it does.
+
+    Both halves are asserted because a consumer may adopt either bundle: `renovate` ships the
+    Renovate config, `github` ships `dependabot.yml`. `bundles/github/.github/CONFIG.md`
+    promises exactly this to the reader, which is the claim under test.
+    """
+    renovate = json.loads((_ROOT / "bundles" / "renovate" / "renovate.json").read_text(encoding="utf-8"))
+    assert "github-actions" in renovate["enabledManagers"], (
+        "the renovate bundle does not enable the github-actions manager, so a consumer's "
+        "SHA-pinned workflows would never be bumped"
+    )
+
+    dependabot = yaml.safe_load(
+        (_ROOT / "bundles" / "github" / ".github" / "dependabot.yml").read_text(encoding="utf-8")
+    )
+    ecosystems = {entry.get("package-ecosystem") for entry in dependabot.get("updates", [])}
+    assert "github-actions" in ecosystems, (
+        "the github bundle's dependabot.yml declares no github-actions ecosystem, so a "
+        "consumer relying on Dependabot alone would never see an action bump"
     )

--- a/tests/api/test_workflow_hygiene.py
+++ b/tests/api/test_workflow_hygiene.py
@@ -19,6 +19,19 @@ Two invariants:
    ``vX.Y.Z``-style tag or a 40-character commit SHA — so upgrades only
    happen through reviewed dependency-update PRs. Local actions (``./...``)
    are exempt.
+3. Every **third-party** action is pinned to a commit SHA, in the workflows rhiza
+   ships as well as the ones it runs. A tag is a moving target: whoever owns the
+   action can repoint ``v6`` — or ``v6.0.2`` — at a different commit, and every
+   consumer runs it on the next release. Only ``jebel-quant/rhiza`` reusable-workflow
+   refs may be tags, and they must be: ``[[tool.bumpversion.files]]`` rewrites
+   ``@vX.Y.Z`` on every release, which is how a stub keeps pointing at the template
+   version it was synced from.
+
+   This was one population until #1611. The live workflows were SHA-pinned and
+   ``bundles/github/.github/workflows/rhiza_release.yml`` — the one shipped workflow
+   with steps of its own, and the most privileged one a consumer runs — carried 26 tag
+   pins, several already behind their live twin. Nothing noticed, because invariant 2
+   accepts either form and asked no further questions.
 """
 
 from __future__ import annotations
@@ -36,6 +49,13 @@ _QUEUE_WORKFLOWS = {"rhiza_release.yml"}
 
 # Exact tag (v1.2.3, optionally deeper like v0.3.1900000450) or full commit SHA.
 _PRECISE_REF_RE = re.compile(r"@(v?\d+(\.\d+){2,}|[0-9a-f]{40})$")
+
+# A 40-character commit SHA, the only acceptable pin for a third-party action.
+_SHA_REF_RE = re.compile(r"@[0-9a-f]{40}$")
+
+# Refs that may carry a tag: rhiza's own reusable workflows, whose tag *is* the template
+# version and is rewritten by bump-my-version on every release.
+_FIRST_PARTY_PREFIX = "jebel-quant/rhiza/"
 
 
 # Names of compiler-generated workflows to exclude from hygiene checks (their
@@ -142,6 +162,62 @@ class TestWorkflowConcurrency:
         )
 
 
+class TestRunnerHardening:
+    """Where `step-security/harden-runner` runs, and — deliberately — where it does not.
+
+    Every job with steps of its own in `.github/workflows/` opens with it in
+    `egress-policy: audit` mode. That is 36 jobs across 13 workflows, and pinning it here
+    is what keeps a new workflow (or a new job in an old one) from quietly opting out.
+
+    **It is deliberately not in the shipped release workflow, and that is a decision rather
+    than the drift it looks like (#1611).** harden-runner is a third-party agent that
+    monitors the runner and reports egress to a third-party service. Adding one to rhiza's
+    own CI is rhiza's call; adding one to a *consumer's* release pipeline, on their runners
+    and under their compliance regime, is theirs — and none of the shipped stub's steps needs
+    it to do the release. Consumers are not left without it either way: every other stub
+    delegates to a reusable workflow in this repository, so their CI, book, docker and paper
+    jobs run these hardened jobs already.
+
+    A consumer who wants it in their release pipeline adds the step; that is a two-line
+    diff, and `exclude:` in `.rhiza/template.yml` keeps it across syncs.
+    """
+
+    @pytest.mark.parametrize(
+        "workflow_file",
+        [p for p in _WORKFLOWS if p.parent.parent.parent == _ROOT],
+        ids=[str(p.relative_to(_ROOT)) for p in _WORKFLOWS if p.parent.parent.parent == _ROOT],
+    )
+    def test_every_live_job_hardens_the_runner_first(self, workflow_file: Path) -> None:
+        """A job that runs steps must harden the runner before it runs any of them."""
+        unhardened = [
+            job_id
+            for job_id, job in (_load(workflow_file).get("jobs") or {}).items()
+            if (job.get("steps") or []) and "harden-runner" not in (job["steps"][0].get("uses") or "")
+        ]
+        assert not unhardened, (
+            f"{workflow_file.name}: jobs {unhardened} run steps without hardening the runner "
+            f"first — every other job in .github/workflows/ opens with step-security/"
+            f"harden-runner in audit mode"
+        )
+
+    def test_the_shipped_workflows_harden_nothing(self) -> None:
+        """The bundles must ship no harden-runner step — see this class's docstring.
+
+        Asserted so the decision is visible where the divergence is, rather than being
+        rediscovered as drift by the next person to diff a bundle against its live twin.
+        Flipping this decision means deleting this test, which is the point.
+        """
+        shipping = [
+            str(path.relative_to(_ROOT))
+            for path in _WORKFLOWS
+            if path.parent.parent.parent != _ROOT and "harden-runner" in path.read_text(encoding="utf-8")
+        ]
+        assert not shipping, (
+            f"{shipping} ship a harden-runner step. Adding a third-party runner-monitoring "
+            f"agent to a consumer's repository is their decision, not the template's (#1611)."
+        )
+
+
 class TestActionPinning:
     """Every action reference must be pinned to an exact version."""
 
@@ -156,6 +232,49 @@ class TestActionPinning:
         assert not imprecise, (
             f"{workflow_file.name}: imprecisely pinned actions {imprecise} — "
             f"pin to an exact vX.Y.Z tag or full commit SHA"
+        )
+
+    @pytest.mark.parametrize("workflow_file", _WORKFLOWS, ids=_IDS)
+    def test_third_party_actions_are_pinned_by_sha(self, workflow_file: Path) -> None:
+        """Third-party actions must carry a commit SHA, shipped stubs included (#1611).
+
+        A tag pin is only as trustworthy as the action's owner: `v6.0.2` is a ref, and a ref
+        can be moved. That is the whole argument for SHA pinning, and it applies with more
+        force to a workflow rhiza *ships* than to one it runs, because a consumer inherits the
+        pin without choosing it.
+
+        rhiza's own workflows have been SHA-pinned throughout. What this adds is the shipped
+        half — in practice `bundles/github/.github/workflows/rhiza_release.yml`, the only
+        shipped workflow with steps of its own; every other stub delegates to a reusable
+        workflow, so its consumers already run the mother repo's SHA-pinned steps.
+        """
+        loose = [
+            ref
+            for ref in _uses_refs(_load(workflow_file))
+            if not ref.startswith("./") and not ref.startswith(_FIRST_PARTY_PREFIX) and not _SHA_REF_RE.search(ref)
+        ]
+        assert not loose, (
+            f"{workflow_file.name}: {loose} pinned by tag — pin third-party actions to a "
+            f"commit SHA with a `# vX.Y.Z` comment, which is what Renovate maintains"
+        )
+
+    @pytest.mark.parametrize("workflow_file", _WORKFLOWS, ids=_IDS)
+    def test_first_party_reusable_workflows_are_pinned_by_tag(self, workflow_file: Path) -> None:
+        """`jebel-quant/rhiza` refs must stay tags, which is the other half of the rule above.
+
+        The exemption is not a weaker standard, it is a different mechanism: the tag names the
+        template release a repository is synced to, and `[[tool.bumpversion.files]]` rewrites
+        it across `bundles/**/.github/workflows/*.yml` on every release. A SHA there would
+        pin a consumer to a commit no release names, and the rewrite would stop finding it.
+        """
+        wrong = [
+            ref
+            for ref in _uses_refs(_load(workflow_file))
+            if ref.startswith(_FIRST_PARTY_PREFIX) and _SHA_REF_RE.search(ref)
+        ]
+        assert not wrong, (
+            f"{workflow_file.name}: {wrong} pinned by SHA — rhiza's own reusable workflows are "
+            f"pinned by tag, which is what the release rewrites"
         )
 
     def test_workflows_were_collected(self) -> None:

--- a/tests/bundles/test_bundle_test_coverage.py
+++ b/tests/bundles/test_bundle_test_coverage.py
@@ -58,8 +58,6 @@ _GENERIC_TESTS = {
 _EXEMPT: dict[str, str] = {
     "legal": "Static community files (LICENSE, CODE_OF_CONDUCT, ...); no targets "
     "or workflows. Content is guarded by the bundle content-validity tests.",
-    "renovate": "Static renovate.json config; validated by the 'Validate Renovate "
-    "Config' pre-commit hook and the bundle content-validity tests, no behaviour to drive.",
     "vscode": "Static .vscode/extensions.json and settings.json; no targets or "
     "workflows. Covered by TestVscodeBundleSync in test_bundle_combinations.py "
     "(a generic test module) and the bundle content-validity tests.",


### PR DESCRIPTION
Fixes #1611. Fixes #1610. Two halves of one thing: what the pins in the workflows rhiza *ships* are, and what keeps them moving.

## One correction to #1611 first

The issue compared 13 live workflows against 0 bundle files. That overstates it, and the accurate version is narrower and still real: **exactly one shipped workflow has steps of its own** — `bundles/github/.github/workflows/rhiza_release.yml`. Every other stub delegates to a reusable workflow in this repository, so a consumer's CI, book, docker, marimo and paper jobs already run the mother repo's SHA-pinned, hardened jobs. The exception was the release pipeline: the most privileged workflow a consumer runs, with `id-token: write` and a PyPI publish.

## #1611 — SHA pins

26 tag pins → commit SHAs with `# vX.Y.Z` comments. Six of the eleven actions were also *behind* their live twin (`actions/checkout` at v6.0.2 against v6.1.0), so this closes the drift too. **Every SHA was verified against the upstream tag through the GitHub API**, not copied on trust — including the annotated-tag indirection.

`TestActionPinning` gains both halves of the rule:
- third-party actions must be SHA-pinned, in shipped workflows as well as live ones;
- `jebel-quant/rhiza` reusable-workflow refs must stay **tags** — `[[tool.bumpversion.files]]` rewrites those on every release, and a SHA would pin a consumer to a commit no release names.

**harden-runner is deliberately not shipped.** Adding a third-party agent that watches a runner and reports its egress belongs to whoever owns the repository and answers for its compliance, and nothing in the release pipeline needs it to cut a release. `TestRunnerHardening` records the decision *and* its counterpart — all 36 live jobs with steps open with it — so the divergence is asserted from both directions instead of being rediscovered as drift. Flipping the decision means deleting one test. `bundles/github/.github/CONFIG.md` explains both to consumers, including how to add it and keep it across syncs.

## #1610 — the bot that was not there

Why the pins aged: Renovate's `github-actions` manager was not in `enabledManagers` at all, and its default file patterns are anchored at the repository root, so `bundles/*/.github/workflows/` would have been missed even if it had been. Dependabot could not reach them either — its `github-actions` ecosystem reads `<directory>/.github/workflows` and has no globbing.

`renovate.json` now enables the manager for the bundle path and switches it off for `.github/workflows/**`, which stays Dependabot's. That second rule is the one that matters: `managerFilePatterns` merges with the manager's defaults rather than replacing them, so without it both bots would open a PR for every bump.

The guard generalises `test_renovate_managers.py` from `rhiza-task@` to every `uses:` literal: each workflow with a third-party action must have **exactly one** watcher — zero is #1610, two is a PR race — and no action may be pinned to two refs across the tree, which is the invariant that was actually broken.

`test_a_synced_repository_gets_a_bot_for_its_action_pins` covers the consumer side, and it matters more *after* this change than before: a tag pin at least follows patch releases of the action, a SHA follows nothing, so a synced repository with no bot freezes on the commit it synced with — while reading as hardened. CONFIG.md makes that promise to the reader, so it is asserted here.

Dropping `renovate` from `test_bundle_test_coverage.py`'s `_EXEMPT` is that gate working as designed: the bundle has a behavioural claim to test now, and the gate said so on the first run.

## Verification

Each new assertion was checked against the state it exists to reject:

| reverted to | fails with |
| --- | --- |
| `renovate.json` as on main | `the github-actions manager is not enabled …` |
| without the disabling packageRule | `.github/workflows/rhiza_benchmark.yml is watched by ['Renovate', 'Dependabot']` |
| the old bundle workflow | `actions/checkout` pinned to both `d23441a…` and `v6.0.2`, and two SHA-pin failures |

`make test` 1772 passed / 45 skipped, `make fmt` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)