### PR TITLE
fix: make the benchmark gate measure something, and stop its scaffolding breaking it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,6 +277,41 @@ and `stress`, each needing its own tool and folder convention, and none named by
 `cargo nextest` and `go test` need no configuration, so such a bundle would own nothing
 at all.
 
+**The benchmark gate measures something here now, and both halves of why it did not are
+worth knowing.** `rhiza_benchmark.yml` runs `benchmark` on every push to `main`, and the
+task's guard globs `tests_folder` for `benchmarks/*.py` — so with no `tests/benchmarks/`
+in this repo it printed `skipped  benchmark  no benchmarks folder`, exited 0, and wrote a
+duration into the step summary for a run that measured nothing. Same silent-green shape as
+#1505, #1511, #1516 and #1535, reached through an absent folder.
+`tests/benchmarks/test_dogfood_linker.py` fills it, and deliberately not with the bundle's
+blueprint: those placeholders time string concatenation and `dict` insertion, so a
+regression in them would be a story about CPython. What it times instead is
+`utils/link_dogfood.py` — the index walk over `bundles/`, the carve-out predicate, and the
+classification pass — the only code here whose cost grows with the template. Each
+benchmark asserts the size of its own workload, because an input that narrows to nothing
+gets *faster*, and faster reads as an improvement in the very report meant to catch
+regressions.
+
+The second half is that the `benchmarks` bundle's `conftest.py` broke the gate it ships
+with, in every consumer. It defined `pytest_html_report_title` while `benchmark` injects
+only `pytest-benchmark` and `pygal` — it writes a histogram and a JSON file, not an HTML
+report — and pluggy validates hook *names* at collection, so pytest raised
+`PluginValidationError: unknown hook` as an INTERNALERROR and exited 3 before collecting a
+thing. `make book` went with it, since `book` needs `benchmark`. Two things hid it: the
+`test` gate passes `--ignore=$(tests_folder)/benchmarks`, so the file is never collected by
+the gate everything else runs, and the mother repo had no benchmarks folder, so dogfooding
+never reached it either. The fix keeps the path rather than deleting the file — a sync that
+stops delivering a file does not remove a consumer's copy, so overwriting it is what
+repairs a repo that already has the broken one. `test_bundle_combinations.py`'s
+`test_the_synced_scaffolding_declares_no_hook_the_gate_cannot_provide` asserts the rule and
+not that one name, deriving pytest's own hookspec list rather than restating it.
+
+A related trap for anyone adding to `tests/benchmarks/`: **do not reuse the bundle's
+filenames.** `conftest.py` and `test_benchmarks.py` are paths the `benchmarks` bundle
+claims, and a root file whose path has a bundle twin must be a symlink into it
+(`test_bundle_dogfood_symlinks.py`). A same-path copy that merely diverges is classified as
+an undeclared mother-repo override and left alone — silently.
+
 **Mutation testing is not part of the ecosystem, and that is now a decision rather than
 an omission (#1492).** `mutation` was a fourth extra, and it had been broken in every
 consumer since mutmut 3 shipped: the recipe passed `--paths-to-mutate` and `--tests-dir`

--- a/bundles/benchmarks/tests/benchmarks/conftest.py
+++ b/bundles/benchmarks/tests/benchmarks/conftest.py
@@ -1,14 +1,21 @@
-"""Pytest configuration for benchmark tests.
+"""Pytest configuration for the benchmark tests.
 
-This file can be used to add custom fixtures or configuration
-for your benchmark tests.
+Shared fixtures for your benchmarks belong here. Keep them to what the ``benchmark`` gate
+itself provides: it runs pytest with ``pytest-benchmark`` and ``pygal``, and nothing else.
+A fixture from another plugin may or may not be present, depending on what the project's
+own environment happens to carry.
+
+For *hooks* that is not a soft warning but a hard failure, which is why this file used to
+break the gate it ships with. It defined ``pytest_html_report_title``, a ``pytest-html``
+hook -- and the gate injects no ``pytest-html``, because it writes a histogram and a JSON
+file rather than an HTML report. pluggy validates hook *names* when collection starts, so
+an implementation of a hook that no installed plugin declares is not ignored: pytest raises
+``PluginValidationError: unknown hook 'pytest_html_report_title'`` as an INTERNALERROR and
+exits 3 before a single benchmark is collected. Any consumer of this bundle whose
+environment did not happen to carry pytest-html therefore had a ``make benchmark`` that
+could not run -- and no ``make book`` either, since ``book`` needs ``benchmark``.
 
 Security Notes:
 - S101 (assert usage): Asserts are the standard way to validate test conditions in pytest.
   They provide clear test failure messages and are expected in test code.
 """
-
-
-def pytest_html_report_title(report):
-    """Set the HTML report title."""
-    report.title = "Benchmark Tests"

--- a/tests/benchmarks/__init__.py
+++ b/tests/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Performance benchmarks."""

--- a/tests/benchmarks/test_dogfood_linker.py
+++ b/tests/benchmarks/test_dogfood_linker.py
@@ -1,0 +1,154 @@
+"""Benchmarks for the dogfood linker — the one code path here whose cost grows with the template.
+
+**Why this folder exists at all.** ``rhiza_benchmark.yml`` has run ``benchmark`` on every push
+to ``main`` for as long as the workflow has existed, and this repo had no ``tests/benchmarks/``.
+The gate's guard globs ``tests_folder`` for ``benchmarks/*.py``, so every one of those runs
+printed ``skipped  benchmark  no benchmarks folder`` and exited 0: a green workflow, a step
+summary with a duration in it, and nothing measured. That is the same silent-green shape as
+#1505, #1511, #1516 and #1535, reached through a missing folder rather than a mis-scoped
+variable, and ``tests/integration/test_benchmark_targets.py`` was already carrying it as a
+recorded observation waiting to flip.
+
+**Why not the blueprint.** The ``benchmarks`` bundle ships a ``test_benchmarks.py`` that times
+string concatenation, a list comprehension and ``dict`` insertion. It says of itself that it is
+placeholder code to be replaced, and it is right to: those numbers describe CPython's
+performance, not rhiza's, so a regression in them would be a story about the interpreter. The
+mother repo therefore writes its own rather than dogfooding that file — which is also why this
+module's name deliberately does not collide with the bundle's. A root file whose path has a
+bundle twin must be a symlink into it (``test_bundle_dogfood_symlinks.py``), and a same-path
+copy that merely diverges is classified as an *undeclared* mother-repo override and left alone,
+silently.
+
+**What is worth measuring.** ``utils/link_dogfood.py`` is the only thing here with a cost that
+scales: ``_bundle_index`` walks every file under ``bundles/``, and ``relink`` classifies every
+git-tracked path against that index, reading bytes for each candidate whose size matches its
+bundle owner's. Both grow as bundles are added, and both run in every ``make sync-self``,
+``make sync-self-check`` and — via ``test_bundle_dogfood_symlinks.py``, twice per parametrised
+case — every ``make test``. So this is the baseline that would notice the template outgrowing
+its linker.
+
+**Every benchmark asserts the size of what it measured**, and that is not decoration. A
+benchmark whose input narrows to nothing gets *faster*, and faster reads as an improvement: an
+empty bundle index or an empty tracked-file list would show up as a win in the very report meant
+to catch regressions. The assertions are what make the timings mean something, so each one pins
+that both arms of the work it times were actually reached.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture(scope="module")
+def linker() -> ModuleType:
+    """Load ``utils/link_dogfood.py`` as a module.
+
+    ``utils/`` is not a package, so it is loaded from its file path — the same approach
+    ``tests/utils/test_link_dogfood.py`` and ``tests/bundles/test_bundle_dogfood_symlinks.py``
+    take, and for the same reason: benchmark the linker's own helpers rather than a
+    reimplementation of them.
+
+    Returns:
+        The imported ``link_dogfood`` module.
+    """
+    module_path = _ROOT / "utils" / "link_dogfood.py"
+    spec = importlib.util.spec_from_file_location("link_dogfood", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def tracked(linker: ModuleType) -> list[str]:
+    """Return every git-tracked path, resolved once outside the measured region.
+
+    ``_tracked_files`` shells out to ``git ls-files``, so calling it inside a benchmark would
+    time the subprocess rather than the linker. Resolved once here, and skipped rather than
+    failed where git is absent — the benchmark gate is opt-in tooling, not a correctness gate.
+
+    Args:
+        linker: The ``link_dogfood`` module.
+
+    Returns:
+        Repo-root-relative POSIX paths.
+    """
+    if shutil.which("git") is None:
+        pytest.skip("git is not installed, so the tracked-file list cannot be resolved")
+    return linker._tracked_files(_ROOT)
+
+
+@pytest.fixture(scope="module")
+def index(linker: ModuleType) -> dict[str, list[Path]]:
+    """Return the bundle index, built once for the benchmarks that consume rather than build it.
+
+    Args:
+        linker: The ``link_dogfood`` module.
+
+    Returns:
+        The mapping from bundle-relative path to the bundle files providing it.
+    """
+    return linker._bundle_index(_ROOT / "bundles")
+
+
+def test_building_the_bundle_index(benchmark, linker: ModuleType) -> None:
+    """Time the ``bundles/`` tree walk that every dogfood operation starts with.
+
+    This is the one measurement that grows purely with the template: one ``rglob`` over every
+    bundle, and a path rewrite per file. Adding a bundle makes it slower, which is exactly the
+    signal worth having a baseline for.
+
+    The anchors are two paths the index must contain — ``core``'s front door and the Python
+    layer's lint config — because an index built against a moved or renamed bundle tree comes
+    back small and quick rather than empty and obviously wrong.
+    """
+    result = benchmark(linker._bundle_index, _ROOT / "bundles")
+
+    assert result, "the bundle index is empty, so this benchmark timed a walk over nothing"
+    for anchor in ("Makefile", "ruff.toml"):
+        assert anchor in result, f"the bundle index has no entry for {anchor} — the bundle tree moved"
+
+
+def test_deciding_the_carveout_predicate_for_every_tracked_path(benchmark, linker: ModuleType, tracked) -> None:
+    """Time ``is_dogfood_carveout`` across the whole tracked-file list.
+
+    The cheapest of the three, and the one run most often: it is the first question
+    ``_classify_dogfood`` asks about every path, and the guard test asks it separately again.
+    Pure string and ``Path`` work, no I/O.
+
+    Both arms are pinned. A predicate that answered True for everything, or False for
+    everything, would be *faster* than the real ladder while turning either the linker or its
+    guard into a no-op — the failure this file's docstring is about.
+    """
+    carved = benchmark(lambda: [rel for rel in tracked if linker.is_dogfood_carveout(rel)])
+
+    assert carved, "no tracked path is a carve-out, so the predicate's True arm was never reached"
+    assert len(carved) < len(tracked), "every tracked path is a carve-out, so its False arm was never reached"
+
+
+def test_classifying_every_tracked_path_against_the_index(benchmark, linker: ModuleType, tracked, index) -> None:
+    """Time the full dogfood verdict for every tracked path — the work ``sync-self-check`` does.
+
+    The index is prebuilt, so what is measured is the classification itself: the eligibility
+    ladder, plus a ``stat`` and (where sizes match) a byte comparison for each path that has a
+    bundle owner. That content read is the part that scales with both trees at once, and it is
+    why this is timed separately from the walk above rather than as one end-to-end number.
+
+    ``relink`` itself is deliberately not the subject: it would drag ``git ls-files`` and, in
+    write mode, filesystem mutation into the measurement.
+
+    Both verdicts that this repo's layout must produce are asserted. ``ambiguous`` is not —
+    whether one occurs is the drift guard's business, not this file's.
+    """
+    verdicts = benchmark(lambda: [linker._classify_dogfood(_ROOT, rel, index)[0] for rel in tracked])
+
+    assert "link" in verdicts, "no tracked path classified as a dogfood symlink — the linking arm was never reached"
+    assert "skip" in verdicts, "every tracked path is a dogfood copy, which cannot be right"

--- a/tests/bundles/test_bundle_combinations.py
+++ b/tests/bundles/test_bundle_combinations.py
@@ -13,15 +13,26 @@ and the dependency-group assertions to ``test_dependency_groups.py``.
 
 from __future__ import annotations
 
+import ast
 import json
 from pathlib import Path
 
 import pytest
 import yaml
 
+# pytest's own hookspecs, read rather than listed: the alternative is a hand-written set of
+# names that goes stale silently. Private, so the anchor assertion in the test using it is
+# what turns a pytest reorganisation into a failure instead of a check that accepts anything.
+from _pytest import hookspec
+
 from tests.registry import require as require_registry
 from tests.registry import resolves
 from tests.util import sync_bundles
+
+# Hook-name prefixes the `benchmark` gate does provide, because its own plugin declares them.
+# The gate runs `pytest` with `pytest-benchmark` and `pygal`; pygal is a charting library and
+# contributes no hooks.
+_GATE_PLUGIN_HOOK_PREFIXES = ("pytest_benchmark_",)
 
 
 class TestDockerBundleSync:
@@ -260,3 +271,50 @@ class TestBenchmarksBundleSync:
         benchmarks_dir = self.project / "tests" / "benchmarks"
         has_setup = (benchmarks_dir / "conftest.py").is_file() or (benchmarks_dir / "__init__.py").is_file()
         assert has_setup, "tests/benchmarks/ has no conftest.py or __init__.py"
+
+    def test_the_synced_scaffolding_declares_no_hook_the_gate_cannot_provide(self) -> None:
+        """No synced benchmark module may implement a hook from a plugin the gate does not install.
+
+        This is the one way a *template* file can break the gate it ships with, and it did.
+        ``conftest.py`` defined ``pytest_html_report_title`` while the ``benchmark`` task injects
+        only ``pytest-benchmark`` and ``pygal`` — it writes a histogram and a JSON file, not an
+        HTML report. pluggy validates hook *names* at ``perform_collect``, so this is not an
+        unused function: pytest raises ``PluginValidationError: unknown hook`` as an
+        INTERNALERROR and exits 3 having collected nothing. Every consumer of this bundle whose
+        environment did not happen to carry pytest-html had a ``make benchmark`` that could not
+        run, and — since ``book`` needs ``benchmark`` — no ``make book`` either.
+
+        Two properties made it survivable for so long, and both argue for a guard rather than a
+        fixed assertion about that one name. The ``test`` gate passes
+        ``--ignore=$(tests_folder)/benchmarks``, so the file is never collected by the gate
+        everything else runs; and the mother repo shipped no ``tests/benchmarks/`` of its own, so
+        the benchmark gate skipped here and dogfooding never reached it either. The check is
+        therefore written against the *rule* — the gate's environment is pytest plus
+        pytest-benchmark — so the next borrowed hook fails as well.
+
+        The core hookspec list is derived rather than written down, so it cannot rot into a set of
+        names pytest no longer has; the anchor assertion is what keeps that derivation from
+        narrowing to nothing and passing everything.
+        """
+        core_hooks = frozenset(name for name in dir(hookspec) if name.startswith("pytest_"))
+        assert "pytest_collection_modifyitems" in core_hooks, (
+            "pytest's hookspec module yielded no recognisable hook names, so this check would "
+            "accept anything — pytest moved them and this derivation needs updating"
+        )
+
+        offenders: list[str] = []
+        for path in sorted((self.project / "tests" / "benchmarks").glob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            offenders += [
+                f"{path.name}::{node.name}"
+                for node in tree.body
+                if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)
+                and node.name.startswith("pytest_")
+                and node.name not in core_hooks
+                and not node.name.startswith(_GATE_PLUGIN_HOOK_PREFIXES)
+            ]
+
+        assert not offenders, (
+            f"synced benchmark scaffolding implements hooks the `benchmark` gate provides no "
+            f"plugin for, which makes pytest exit 3 before collecting anything: {offenders}"
+        )

--- a/tests/integration/test_benchmark_targets.py
+++ b/tests/integration/test_benchmark_targets.py
@@ -55,15 +55,16 @@ def test_extra_target_resolves(target: str) -> None:
 def test_the_benchmark_gate_has_something_to_measure_or_is_known_not_to() -> None:
     """Record whether `benchmark` has any input in *this* repo.
 
-    Written as an observation rather than a demand, because the answer here is "no": rhiza ships
-    configuration, so it has no ``tests/benchmarks/`` — while ``rhiza_benchmark.yml`` runs
-    ``make benchmark`` on every push. That gate therefore measures nothing on this repo, and has
-    for as long as the folder has been absent. It predates the rhiza-task migration and is not its
-    doing.
+    The answer used to be "no", which is why this is written as an observation with two branches
+    rather than a plain demand: rhiza ships configuration, had no ``tests/benchmarks/``, and
+    ``rhiza_benchmark.yml`` ran ``make benchmark`` on every push to ``main`` regardless — so the
+    gate printed ``skipped  benchmark  no benchmarks folder``, exited 0, and wrote a duration into
+    the step summary for a run that measured nothing.
 
-    Asserted this way round so the fact is visible in the suite instead of being something a reader
-    has to notice: if a benchmarks folder is ever added, the second branch takes over and starts
-    requiring content, and if the workflow is dropped the first branch stops being reachable.
+    The folder exists now (``tests/benchmarks/test_dogfood_linker.py``), so the second branch is
+    the live one and this is a demand after all: the gate has input, and must keep it. The first
+    branch stays reachable for the case that removes the folder again, which would otherwise turn
+    the workflow green-and-empty without a single assertion changing.
     """
     folder = Path(__file__).resolve().parents[2] / "tests" / "benchmarks"
     if not folder.is_dir():


### PR DESCRIPTION
Two independent silent failures in the same gate, found while looking at why `make benchmark` had never reported a number for this repo.

## The gate had no input here

`rhiza_benchmark.yml` runs `benchmark` on every push to `main`, and the task's guard globs `tests_folder` for `benchmarks/*.py`. With no `tests/benchmarks/` in this repo every one of those runs printed `skipped  benchmark  no benchmarks folder`, exited 0, and wrote a duration into the step summary for a run that measured nothing — the same silent-green shape as #1505, #1511, #1516 and #1535, reached through an absent folder rather than a mis-scoped variable. `tests/integration/test_benchmark_targets.py` was already carrying the fact as a two-branch observation waiting to flip; it flips here.

`tests/benchmarks/test_dogfood_linker.py` fills the folder, and deliberately not with the bundle's blueprint: those placeholders time string concatenation and `dict` insertion, so a regression in them would be a story about CPython. What it times instead is `utils/link_dogfood.py` — the `bundles/` index walk, the carve-out predicate, and the classification pass — the only code here whose cost grows with the template, and code that runs in every `sync-self`, `sync-self-check` and `make test`.

Every benchmark asserts the size of its own workload. An input that narrows to nothing gets *faster*, and faster reads as an improvement in the very report meant to catch regressions, so each case pins that both arms of the work it times were actually reached.

## The bundle's own conftest broke the gate, in every consumer

`bundles/benchmarks/tests/benchmarks/conftest.py` defined `pytest_html_report_title`, a pytest-html hook — while `benchmark` injects only `pytest-benchmark` and `pygal`, because it writes a histogram and a JSON file, not an HTML report. pluggy validates hook *names* when collection starts, so this was not an unused function: pytest raised `PluginValidationError: unknown hook` as an INTERNALERROR and exited 3 before collecting a thing. `make book` went with it, since `book` needs `benchmark`.

Two things hid it. The `test` gate passes `--ignore=$(tests_folder)/benchmarks`, so the file is never collected by the gate everything else runs; and the mother repo had no benchmarks folder, so dogfooding never reached it either.

The file keeps its path rather than being deleted — a sync that stops delivering a file does not remove a consumer's copy, so overwriting it is what repairs a repo that already has the broken one. Its docstring now carries the reason, so the next person adding a fixture knows what the gate's environment actually is.

## The guard

`test_the_synced_scaffolding_declares_no_hook_the_gate_cannot_provide` asserts the *rule* — the gate's environment is pytest plus pytest-benchmark — rather than that one hook name, so the next borrowed hook fails too. pytest's core hookspec list is derived from `_pytest.hookspec` rather than written down, with an anchor assertion so a pytest reorganisation fails the test instead of silently narrowing it to a check that accepts anything.

## Verification

- `make benchmark` — 3 benchmarks collected and timed, gate `ok` (was `skipped`)
- `make test` — 1697 passed, coverage 100%
- `make fmt` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)