### PR TITLE
feat: publish the compiled paper from the book, on an orphan paper branch

### DIFF
--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -16,6 +16,7 @@
 #   - 📖 Build documentation site via zensical
 #   - 🧪 Run tests and generate coverage reports
 #   - 🚀 Deploy combined documentation to GitHub Pages
+#   - 📄 Publish the compiled paper to an otherwise empty `paper` branch
 
 name: "(RHIZA) BOOK"
 
@@ -55,6 +56,11 @@ jobs:
     permissions:
       contents: read
 
+    # Lets `paper-branch` be skipped outright in a repository with no paper, rather than
+    # spinning up a runner to discover there is nothing to publish.
+    outputs:
+      tex_present: ${{ steps.check_tex.outputs.tex_present }}
+
     steps:
       # Check out the repository code
       - name: Harden the runner (Audit all outbound calls)
@@ -84,6 +90,33 @@ jobs:
           # will just use .python-version?
           uv sync --all-extras --all-groups --frozen
 
+      # `rhiza-task book` gets the paper's PDF by running `paper`, which is guarded on
+      # `latexmk`. With no TeX distribution here that guard *skips* -- and a skipped
+      # prerequisite does not block its dependent -- so the book built happily while
+      # `docs/paper/main.pdf` was never written. The site then shipped the paper's
+      # source next to a 404 where the PDF should be, green the whole way. Installed
+      # only when there is a paper to compile, so a repository without one pays a
+      # single `compgen` test. The path mirrors `rhiza_paper.yml`'s own guard; a repo
+      # that moves `paper-folder` elsewhere is not covered by either.
+      - name: Detect docs/paper/*.tex presence
+        id: check_tex
+        run: |
+          if compgen -G "docs/paper/*.tex" > /dev/null 2>&1; then
+            echo "tex_present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "tex_present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install TeX Live
+        if: ${{ steps.check_tex.outputs.tex_present == 'true' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            texlive-latex-extra \
+            texlive-fonts-recommended \
+            texlive-bibtex-extra \
+            latexmk
+
       - name: Cache MkDocs plugin cache
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
@@ -111,12 +144,104 @@ jobs:
           path: _book/
           retention-days: 30
 
+      # Handed to the `paper-branch` job below, which runs with `contents: write` and
+      # must not also hold this job's build environment. One day of retention: it is a
+      # hand-off inside one run, not a published artifact -- the book's own artifact
+      # above already carries a copy of the PDF for anyone who wants to download it.
+      - name: Upload the compiled paper for publication
+        if: ${{ steps.check_tex.outputs.tex_present == 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: paper-pdf
+          path: docs/paper/*.pdf
+          if-no-files-found: warn
+          retention-days: 1
+
       # Package the site as a Pages artifact so the deploy job can publish it.
       # Uploading on every commit is cheap; only the deploy job ever consumes it.
       - name: Upload static files as artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: _book/  # Path to the directory containing all artifacts to deploy
+
+  # Publish the compiled paper to an otherwise empty `paper` branch, from the default
+  # branch only and never from a fork.
+  #
+  # This restores a push that rhiza #1494 removed, and the reason it was removed still
+  # applies: git refs are paths, so `refs/heads/paper` cannot exist while any
+  # `refs/heads/paper/<topic>` does. The mitigation is that the collision is now
+  # *detected* rather than fatal -- a repository with such a branch gets a warning
+  # naming the problem and the book still deploys, where previously the push failed and
+  # took the run with it. The branch is a single orphan commit, force-pushed, so it
+  # never accumulates binary history.
+  #
+  # Its own job, so `build` keeps `contents: read`: the scope that can rewrite a branch
+  # is held only by a job that checks nothing out and runs no project code.
+  paper-branch:
+    needs: build
+    if: >-
+      ${{ needs.build.outputs.tex_present == 'true'
+          && github.ref_name == github.event.repository.default_branch
+          && !github.event.repository.fork }}
+    runs-on: "ubuntu-latest"
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Download the compiled paper
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: paper-pdf
+          path: paper-pdf
+
+      # `tex_present` gates the job, so a paper is expected here -- but latexmk can still
+      # have failed to produce a PDF, and that must not turn the book red. Reported as a
+      # notice: the compile failure itself is already visible in the build job's log.
+      - name: Publish to the paper branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if [ ! -d paper-pdf ] || [ -z "$(find paper-pdf -name '*.pdf' -print -quit)" ]; then
+            echo "::notice title=No paper to publish::this run compiled no PDF; nothing pushed"
+            exit 0
+          fi
+
+          REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}"
+
+          # rhiza #1494: `refs/heads/paper` and `refs/heads/paper/<topic>` cannot coexist.
+          # Warn and stop rather than letting the push fail the workflow -- that failure
+          # mode, in exactly the repositories most likely to open a `paper/...` branch, is
+          # why the push was removed in the first place.
+          if git ls-remote --heads "$REMOTE" 'refs/heads/paper/*' | grep -q .; then
+            msg="A 'paper/<topic>' branch exists, so refs/heads/paper cannot be created"
+            msg="${msg} (rhiza #1494). The PDF is still in the book and in this run's"
+            msg="${msg} artifact. Rename or delete that branch to enable publishing."
+            echo "::warning title=paper branch not updated::${msg}"
+            exit 0
+          fi
+
+          WORK="$(mktemp -d)"
+          find paper-pdf -name '*.pdf' -exec cp {} "$WORK/" \;
+
+          cd "$WORK"
+          git init -q -b paper
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -- '*.pdf'
+          git commit -q -m "docs: publish the compiled paper from ${GITHUB_SHA:0:7}"
+          git push -q --force "$REMOTE" paper
+
+          published=""
+          for pdf in ./*.pdf; do published="${published}$(basename "$pdf") "; done
+          echo "Published ${published}to the 'paper' branch" >> "$GITHUB_STEP_SUMMARY"
 
   # Publish to GitHub Pages only from the default branch, and never from a fork.
   # Referencing the github-pages environment here (not in build) keeps the build

--- a/bundles/github-book/.github/workflows/rhiza_book.yml
+++ b/bundles/github-book/.github/workflows/rhiza_book.yml
@@ -16,6 +16,7 @@
 #   - 📖 Build documentation site via zensical
 #   - 🧪 Run tests and generate coverage reports
 #   - 🚀 Deploy combined documentation to GitHub Pages
+#   - 📄 Publish the compiled paper to the `paper` branch (default branch only)
 
 name: "(RHIZA) BOOK"
 
@@ -32,6 +33,9 @@ jobs:
     uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.5.1
     secrets: inherit
     permissions:
-      contents: read
+      # `write` for the paper-branch job only: a called workflow cannot exceed what the
+      # caller grants, and that job force-pushes the compiled PDF to `paper`. The build
+      # and deploy jobs inside the reusable workflow keep `contents: read`.
+      contents: write
       pages: write
       id-token: write

--- a/tests/api/test_workflow_stubs.py
+++ b/tests/api/test_workflow_stubs.py
@@ -413,3 +413,77 @@ class TestPaperWorkflow:
                 f"the github-paper stub grants `contents: write` to job '{name}'. That scope "
                 "existed only for the branch push retired in #1494."
             )
+
+
+class TestBookPublishesThePaper:
+    """The book compiles the paper and publishes it to an otherwise empty `paper` branch.
+
+    The three properties tested here are the ones that made the previous attempt at this
+    (retired in #1494) fail, or would let it fail silently again: that a TeX distribution is
+    actually present so the PDF exists, that the ref collision is handled rather than fatal,
+    and that the write scope is confined to the job that needs it.
+    """
+
+    @pytest.fixture
+    def book_workflow(self, workflows_dir: Path) -> dict:
+        """The reusable book workflow document."""
+        path = workflows_dir / "rhiza_book.yml"
+        if not path.exists():
+            pytest.skip("rhiza_book.yml not found")
+        return _load_workflow(path)
+
+    @pytest.fixture
+    def book_workflow_text(self, workflows_dir: Path) -> str:
+        """The reusable book workflow as text, for assertions about its shell steps."""
+        path = workflows_dir / "rhiza_book.yml"
+        if not path.exists():
+            pytest.skip("rhiza_book.yml not found")
+        return path.read_text(encoding="utf-8")
+
+    def test_the_book_installs_latexmk(self, book_workflow_text: str) -> None:
+        """Without latexmk the `paper` prerequisite skips and no PDF is ever written.
+
+        A skipped prerequisite does not block its dependent, so the book kept building and
+        the site shipped the paper's source beside a 404. That is invisible to every other
+        gate, which is why it is asserted here rather than left to a reviewer.
+        """
+        assert "latexmk" in book_workflow_text, (
+            "the book workflow installs no latexmk, so `rhiza-task book` will skip its "
+            "`paper` prerequisite and publish a site with no PDF in it"
+        )
+
+    def test_only_the_paper_branch_job_may_write(self, book_workflow: dict) -> None:
+        """`contents: write` is confined to the job that force-pushes the branch."""
+        jobs = book_workflow.get("jobs") or {}
+        writers = {name for name, job in jobs.items() if (job.get("permissions") or {}).get("contents") == "write"}
+        assert writers == {"paper-branch"}, (
+            f"jobs holding `contents: write`: {sorted(writers)}. Only `paper-branch` should: "
+            "the build job runs project code and the deploy job holds `pages: write`, and "
+            "neither needs to be able to rewrite a ref."
+        )
+
+    def test_the_paper_branch_job_publishes_only_from_the_default_branch(self, book_workflow: dict) -> None:
+        """A feature branch must not overwrite the published PDF."""
+        job = (book_workflow.get("jobs") or {}).get("paper-branch")
+        assert job, "rhiza_book.yml declares no `paper-branch` job"
+        condition = str(job.get("if") or "")
+        assert "default_branch" in condition, (
+            f"the paper-branch job's condition is {condition!r}; it must publish only from "
+            "the repository's default branch, or a feature branch overwrites the published PDF"
+        )
+        assert "fork" in condition, (
+            f"the paper-branch job's condition is {condition!r}; it must never publish from a fork"
+        )
+
+    def test_the_paper_branch_job_handles_the_ref_collision(self, book_workflow_text: str) -> None:
+        """#1494's failure mode must degrade to a warning, not a failed run.
+
+        `refs/heads/paper` cannot coexist with any `refs/heads/paper/<topic>`. The previous
+        implementation discovered that by failing the push, in exactly the repositories most
+        likely to open such a branch. Detecting it first is the whole reason this is allowed
+        back, so the check is pinned by a test.
+        """
+        assert "refs/heads/paper/*" in book_workflow_text, (
+            "the paper-branch job does not check for a colliding `paper/<topic>` branch "
+            "before pushing (#1494); without it the push fails and takes the run with it"
+        )


### PR DESCRIPTION
## Why

`docs/paper/main.pdf` 404s on every consumer's site. The chain: `book` needs `paper`,
`paper` is guarded on `latexmk`, and `rhiza_book.yml` installs no TeX distribution — so the
guard skips, a skipped prerequisite doesn't block its dependent, and the book builds happily
with no PDF in it. From pyhrp's deployed book log:

```
skipped  paper  latexmk not found; install a LaTeX distribution (MacTeX, TeX Live)
...
./paper/   ./paper/index.html   ./paper/main.tex   ./paper/references.bib
```

Live right now: `paper/` 200, `paper/main.tex` 200, `paper/references.bib` 200,
`paper/main.pdf` **404**. The site publishes the paper's *source* next to a 404, and
`paper/index.html` is the bundle README telling the reader the PDF ships as a site asset.
`book-nav`, the gate written for exactly this, is invoked by no workflow.

## What this does

1. **`build` installs TeX Live when `docs/paper/*.tex` exists.** This alone fixes the 404 —
   the PDF then exists when zensical sweeps `docs_dir`. Guarded, so a repo without a paper
   pays one `compgen` test. The path mirrors `rhiza_paper.yml`'s existing guard.
2. **A new `paper-branch` job force-pushes the PDF to an otherwise empty `paper` branch**,
   from the default branch only, never from a fork, skipped entirely when there is no paper
   (via a `tex_present` output on `build`). One orphan commit, so no binary history.

## The part you should push back on if you want to

**This restores the push that #1494 removed, and the reason it was removed still applies:**
git refs are paths, so `refs/heads/paper` cannot exist while any `refs/heads/paper/<topic>`
does. My mitigation is that the collision is now *detected* rather than fatal — the job
`ls-remote`s for `refs/heads/paper/*` first and, if one exists, emits a warning naming the
problem and exits 0. Previously the push failed and took the run with it, in exactly the
repositories most likely to open such a branch. None of the six fleet repos currently has a
`paper` or `paper/*` ref, so the hazard is latent rather than active.

Worth noting: the site asset from (1) is at a stable versioned URL and is what a `nav`
entry can point at; the branch from (2) is a second location that `nav` cannot reach. If
you only want the 404 fixed, (1) is sufficient and (2) can be dropped.

`contents: write` is confined to the new job — `build` and `deploy` keep `contents: read`.
The stub grants it because a called workflow cannot exceed its caller. The existing tests
forbidding a push in `rhiza_paper.yml` and `contents: write` in the `github-paper` stub are
untouched and still green.

## Verification

- `pre-commit run` clean on all three changed files, including `actionlint` (one SC2012 fixed).
- `pytest tests/api/test_workflow_stubs.py` — 26 passed, including 4 new tests pinning:
  latexmk is installed; only `paper-branch` holds `contents: write`; it publishes only from
  the default branch and never a fork; and the `refs/heads/paper/*` collision check exists.

Not verified end-to-end: the push itself needs a real run on a default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
