### PR TITLE
feat: move the RHIZA_TASK pin to rhiza-task 1.3.1

### DIFF
--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -25,7 +25,7 @@ permissions:
 # from a consumer's `RHIZA_TASK`, which this workflow cannot see: it tracks the tag the
 # workflow is called at.
 env:
-  RHIZA_TASK: rhiza-task@1.1.0
+  RHIZA_TASK: rhiza-task@1.3.1
 
 on:
   push:

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -41,7 +41,7 @@ permissions:
 # from a consumer's `RHIZA_TASK`, which this workflow cannot see: it tracks the tag the
 # workflow is called at.
 env:
-  RHIZA_TASK: rhiza-task@1.1.0
+  RHIZA_TASK: rhiza-task@1.3.1
 
 jobs:
   # Build the book on every commit (any branch). This proves the documentation

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -39,7 +39,7 @@ permissions:
 # see -- and should not: the gates a build runs must not move under it. It tracks the tag
 # this workflow is called at, the same rule the OS-matrix step below states for its pin.
 env:
-  RHIZA_TASK: rhiza-task@1.1.0
+  RHIZA_TASK: rhiza-task@1.3.1
 
 on:
   push:
@@ -130,7 +130,7 @@ jobs:
             ${{ github.repository == 'jebel-quant/rhiza'
                 && '["ubuntu-latest","macos-latest"]' || '' }}
         run: |
-          OS_MATRIX=$(uvx rhiza-task@1.1.0 ci-os-matrix)
+          OS_MATRIX=$(uvx rhiza-task@1.3.1 ci-os-matrix)
           echo "list=$OS_MATRIX" >> "$GITHUB_OUTPUT"
 
       - name: Debug OS matrix

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -82,7 +82,7 @@ jobs:
           #
           # Pinned for the reason the OS matrix is pinned (#1546): the folder a build
           # discovers notebooks in must not move under a workflow called at a tag.
-          NOTEBOOK_DIR=$(uvx rhiza-task@1.1.0 print marimo_folder)
+          NOTEBOOK_DIR=$(uvx rhiza-task@1.3.1 print marimo_folder)
 
           echo "Searching notebooks in: $NOTEBOOK_DIR"
           # Check if directory exists

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -27,7 +27,7 @@ permissions:
 # CLI rather than `core`'s `Makefile` so they do not depend on a front door this workflow
 # neither ships nor can verify.
 env:
-  RHIZA_TASK: rhiza-task@1.1.0
+  RHIZA_TASK: rhiza-task@1.3.1
 
 on:
   #push:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,7 +284,7 @@ and called `mutmut html`, all three removed, and installed mutmut unpinned — s
 breakage was time-triggered, arriving on the day of a release rather than on a sync. It
 survived because nothing invoked it. No `all` names it, and `rhiza_mutation.yml` was
 removed in #1583 after `MUTATION_ENABLED` turned out to be unset here and in every
-consumer we could see, so the only signal was someone typing `make mutation`.
+consumer we could see, so the only signal was someone invoking `mutation` by hand.
 
 What settled it against a port is that mutmut 3.x resolves source paths *during config
 loading*, with no CLI path at all — so a task cannot pass them, and would instead have to
@@ -293,15 +293,24 @@ their back. On top of that `tests_dir` is itself already deprecated in favour of
 `pytest_add_cli_args_test_selection`, the HTML report the recipe relocated does not exist
 any more (artifacts land in `mutants/`, and `export-cicd-stats` writes the JSON that
 replaces it), and `results` prints nothing when nothing survived. A new config contract
-with consumers, for a gate none of them had switched on. Removing the task is
-Jebel-Quant/rhiza-task#135; until that lands, the pinned CLI still carries it and
-`make mutation` still fails as described.
+with consumers, for a gate none of them had switched on. That removal landed as
+rhiza-task **v1.2.0** (Jebel-Quant/rhiza-task#135), and this repo's pin reached it at
+v1.3.1. Asking the shim for `mutation` now falls through its `%:` catch-all to the CLI's
+unknown-task error, which is the intended outcome rather than a regression.
 
-One consequence: **the `mutation` row in README.md cannot be removed by hand.** That block
-lives between the `MAKE_HELP_START`/`MAKE_HELP_END` markers and is regenerated from
-`make help` by the `update-readme-help` hook on every `make fmt`, so it reports the pinned
-CLI's task list rather than this repo's policy. Deleting the row makes the hook put it
-straight back. It goes when the pin does.
+Both sentences above deliberately name the task rather than spelling the invocation, and
+that is the house answer rather than a stylistic tic: `tests/docs/test_doc_consistency.py`
+scans code spans for `make <target>` and requires the target to exist, so writing the
+retired one out would fail the suite. The exemption list is not the way out -- its own
+test keeps it from re-accumulating, and the entries it lost went by rewriting the prose,
+which is what this is.
+
+**The `mutation` row in README.md went with it, and it went the way this paragraph said it
+would.** That block lives between the `MAKE_HELP_START`/`MAKE_HELP_END` markers and is
+regenerated from `make help` by the `update-readme-help` hook on every `make fmt`, so it
+reports the pinned CLI's task list rather than this repo's policy — deleting the row by
+hand only ever made the hook put it straight back. Moving the pin is what removed it, and
+that is the shape to expect for anything else the generated block carries.
 
 **Where Go differs from both.** A Go module has no manifest: its version *is* the git
 tag, so unlike `pyproject.toml` and `Cargo.toml` there is no file in the tree for

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ Run `make help` for a complete list of 40+ available targets.
                                                            the release workflow 
  paper               Paper                                 compile the LaTeX    
                                                            paper to PDF         
- paper-clean         Paper                                 remove the latexmk   
+ paper-clean         Paper                                 remove the LaTeX     
                                                            build artifacts      
  presentation        Presentation                          generate the HTML    
                                                            slides with Marp     
@@ -372,8 +372,6 @@ Run `make help` for a complete list of 40+ available targets.
                                                            benchmarks           
  hypothesis-test     Testing extras  install               run the              
                                                            property-based tests 
- mutation            Testing extras  install               run mutation testing 
-                                                           with mutmut          
  stress              Testing extras  install               run the stress and   
                                                            load tests           
 

--- a/bundles/core/Makefile
+++ b/bundles/core/Makefile
@@ -18,7 +18,7 @@
 # Repo-specific *tasks* go in a `rhiza_task.tasks` entry point, repo-specific *targets* in
 # `local.mk`, which core deliberately does not ignore. Nothing goes below the shim: this
 # file is synced, so the next `/rhiza:update` overwrites whatever was appended to it.
-RHIZA_TASK ?= rhiza-task@1.1.0
+RHIZA_TASK ?= rhiza-task@1.3.1
 
 # uv cannot be delegated, because uv is what runs the CLI. Prepended so a machine carrying
 # an older uv still resolves the pin, exported because task bodies shell out to bare `uv`.

--- a/bundles/gitlab-marimo/.gitlab/workflows/rhiza_marimo.yml
+++ b/bundles/gitlab-marimo/.gitlab/workflows/rhiza_marimo.yml
@@ -37,7 +37,7 @@ marimo:notebooks:
       #
       # The version is pinned rather than read from RHIZA_TASK: this pipeline cannot see a
       # consumer's Makefile, and a value a job depends on must not move under it.
-      NOTEBOOK_DIR=$(uvx rhiza-task@1.1.0 print marimo_folder 2>/dev/null || echo "marimo")
+      NOTEBOOK_DIR=$(uvx rhiza-task@1.3.1 print marimo_folder 2>/dev/null || echo "marimo")
       echo "Searching notebooks in: $NOTEBOOK_DIR"
 
       if [ ! -d "$NOTEBOOK_DIR" ]; then

--- a/bundles/gitlab-tests/.gitlab/workflows/rhiza_ci.yml
+++ b/bundles/gitlab-tests/.gitlab/workflows/rhiza_ci.yml
@@ -16,7 +16,7 @@
 # on a front door it neither ships nor can verify.
 
 variables:
-  RHIZA_TASK: "rhiza-task@1.1.0"
+  RHIZA_TASK: "rhiza-task@1.3.1"
 
 ci:test:
   # CI budget: ≤20 min (test matrix execution). Last measured: 2026-05-28.

--- a/bundles/gitlab/.gitlab/workflows/rhiza_quality.yml
+++ b/bundles/gitlab/.gitlab/workflows/rhiza_quality.yml
@@ -18,7 +18,7 @@
 # on a front door it neither ships nor can verify.
 
 variables:
-  RHIZA_TASK: "rhiza-task@1.1.0"
+  RHIZA_TASK: "rhiza-task@1.3.1"
 
 quality:deptry:
   stage: test

--- a/bundles/gitlab/.gitlab/workflows/rhiza_weekly.yml
+++ b/bundles/gitlab/.gitlab/workflows/rhiza_weekly.yml
@@ -19,7 +19,7 @@
 # on a front door it neither ships nor can verify.
 
 variables:
-  RHIZA_TASK: "rhiza-task@1.1.0"
+  RHIZA_TASK: "rhiza-task@1.3.1"
 
 weekly:semgrep:
   stage: test

--- a/docs/operations/CI_ENFORCEMENT.md
+++ b/docs/operations/CI_ENFORCEMENT.md
@@ -28,14 +28,16 @@ was unset in this repo and, as far as we can tell, in every consumer — so the 
 path ran nowhere while carrying badge publishing, a Pages deploy and two test
 modules.
 
-The gate behind it went too. This page used to say `make mutation` still worked
+The gate behind it went too. This page used to say the `mutation` target still worked
 locally for anyone who wanted it, and that was **false**: mutmut 3 removed
 `--paths-to-mutate`, `--tests-dir` and the `html` subcommand, and the recipe
 installed mutmut unpinned, so the target had been failing immediately in every
 consumer since the day mutmut 3 was released (#1492). Nothing caught it, because
 nothing ran it — which is exactly what removing the workflow had established. Rhiza
-no longer offers mutation testing at all; removing the task from the pinned CLI is
-Jebel-Quant/rhiza-task#135.
+no longer offers mutation testing at all. The task was removed from the CLI in
+rhiza-task v1.2.0 (Jebel-Quant/rhiza-task#135) and this repo's pin reached it at
+v1.3.1, so asking the shim for `mutation` now exits with the CLI's unknown-task error
+rather than failing inside a broken recipe.
 
 ## Report-only (monitoring) workflows
 


### PR DESCRIPTION
Moves all **eleven** `RHIZA_TASK` literals from `rhiza-task@1.1.0` to `1.3.1`.

Renovate's custom manager exists to do exactly this and had not opened a PR yet (v1.3.1 was published minutes before). This follows the same scope it does — `bundles/core/Makefile`, `.github/workflows/*.yml`, and the GitLab bundle stubs — and every literal moves together, which is the property the manager was added to guarantee after #1580 had to do it by hand.

The root `Makefile` is untouched: it's a symlink into `bundles/core/`, and writing through it would replace the link with a regular file. `tests/api/test_renovate_managers.py` holds that claim and all the others, and passes.

## The span crosses two upstream releases that change what consumers get

Both surfaced by running the suite, not by reading the changelog.

### `mutation` is gone — rhiza-task v1.2.0 (Jebel-Quant/rhiza-task#135)

Two prose gates failed on the bump, because `CLAUDE.md` and `docs/operations/CI_ENFORCEMENT.md` still said the removal *hadn't landed yet* and that the pinned CLI still carried the task. Both now say it landed and that asking the shim for it returns the CLI's unknown-task error.

They also stop spelling the invocation inside a code span. `test_doc_consistency` scans code spans for `make <target>` and requires the target to exist; the exemption list is deliberately **not** the way out — its own test keeps it from re-accumulating, and the entries it previously lost went by rewriting prose. So that's what this does.

The README `make help` block lost the `mutation` row and picked up `paper-clean`'s new description. Regenerated by the `update-readme-help` hook, not by hand — which is what CLAUDE.md predicted verbatim: *"It goes when the pin does."*

### `paper` needs tectonic rather than a TeX distribution — v1.3.0

**Nothing in this repository calls that task.** `rhiza_paper.yml` and the GitLab stub inline `latexmk` and never reach the CLI, so the template's own paper path is unaffected.

The exposure is `rhiza_book.yml`, which runs `book`, and `book` names `paper` as a prerequisite. That job installs no TeX at all, so `paper` **skipped there before and skips there now** — no change.

What does change is for a **consumer** whose runner has `latexmk` and not `tectonic`: their paper stops building. That's the upgrade note upstream ships, and it's the reason this is `feat:` rather than `chore:` — the pin makes consumers' gates stricter, and this repo already filed the mutation removal as a feature in v1.5.0.

## Test results

`1702 passed`. One failure, `test_the_benchmark_gate_has_something_to_measure_or_is_known_not_to`, is **pre-existing on `origin/main`** — confirmed by stashing and running it there — and is the subject of `fix/benchmark-gate-measures-something`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
