### PR TITLE
chore: release v1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com),
 and entries are generated from [Conventional Commits](https://www.conventionalcommits.org).
 
+## [1.5.2] - 2026-08-23
+
+### New Features
+- Move the RHIZA_TASK pin to rhiza-task 1.3.1 (#1619)
+
+### Bug Fixes
+- Quote validate-pyproject rev so pre-commit accepts it (#1608)
+- Make the benchmark gate measure something, and stop its scaffolding breaking it (#1617)
+
+### Documentation
+- Retire rhiza-cli from the docs, shorten the README, and rewrite the two guides built on the make layer (#1609)
+- Link every page from the nav, and stop documenting the retired make layer (#1615)
+
 ## [1.5.1] - 2026-08-22
 
 ### Bug Fixes

--- a/bundles/github-book/.github/workflows/rhiza_book.yml
+++ b/bundles/github-book/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.5.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.5.2
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml
+++ b/bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   devcontainer:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v1.5.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v1.5.2
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-docker/.github/workflows/rhiza_docker.yml
+++ b/bundles/github-docker/.github/workflows/rhiza_docker.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   docker:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v1.5.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v1.5.2
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-marimo/.github/workflows/rhiza_marimo.yml
+++ b/bundles/github-marimo/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.5.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.5.2
     secrets: inherit

--- a/bundles/github-paper/.github/workflows/rhiza_paper.yml
+++ b/bundles/github-paper/.github/workflows/rhiza_paper.yml
@@ -36,7 +36,7 @@ on:
 
 jobs:
   paper:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v1.5.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v1.5.2
     secrets: inherit
     # `contents: read` only. The `write` scope this stub used to grant existed solely for
     # the retired branch push; compiling and uploading an artifact need no write access.

--- a/bundles/github-quality-review/.github/workflows/rhiza_quality_review.yml
+++ b/bundles/github-quality-review/.github/workflows/rhiza_quality_review.yml
@@ -34,5 +34,5 @@ on:
 
 jobs:
   quality-review:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_quality_review.yml@v1.5.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_quality_review.yml@v1.5.2
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_benchmark.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.5.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.5.2
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_ci.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.5.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.5.2
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_codeql.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.5.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.5.2
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/bundles/github/.github/workflows/rhiza_scorecard.yml
+++ b/bundles/github/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.5.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.5.2
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/bundles/github/.github/workflows/rhiza_weekly.yml
+++ b/bundles/github/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.5.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.5.2
     secrets: inherit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rhiza"
-version = "1.5.1"
+version = "1.5.2"
 description = "Reusable configuration templates for modern Python projects"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -70,7 +70,7 @@ Issues = "https://github.com/jebel-quant/rhiza/issues"
 # python-core bundle no longer ships a `.rhiza/.cfg.toml` copy of this block; the
 # Rust and Go layers ship a root `.bumpversion.toml` instead, since neither
 # language has a discoverable file of its own.
-current_version = "1.5.1"
+current_version = "1.5.2"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:[-]?(?P<release>[a-z]+)[\\.]?(?P<pre_n>\\d+))?(?:\\+build\\.(?P<build_n>\\d+))?"
 serialize = [
     "{major}.{minor}.{patch}-{release}.{pre_n}+build.{build_n}",

--- a/uv.lock
+++ b/uv.lock
@@ -869,7 +869,7 @@ wheels = [
 
 [[package]]
 name = "rhiza"
-version = "1.5.1"
+version = "1.5.2"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Bumps **v1.5.1 → v1.5.2**. Guarded as strictly increasing: floor `v1.5.1`, highest existing tag `v1.5.1`.

Five unreleased commits — 1 `feat`, 2 `fix`, 2 `docs`, no breaking marker.

## What a consumer gets

The `feat` is #1619, which moves the `RHIZA_TASK` pin from `rhiza-task@1.1.0` to `1.3.1`. Consumers sync this template at a tag, so **this release is what carries that CLI to them**, and with it two upstream removals:

- **`mutation` is gone** (rhiza-task v1.2.0). Asking the shim for it returns the CLI's unknown-task error.
- **`paper` compiles with tectonic**, not a TeX distribution (rhiza-task v1.3.0). A consumer whose runner has `latexmk` and not `tectonic` will find their paper stops building.

Nothing in this repository calls `paper` through the CLI — `rhiza_paper.yml` and the GitLab stub inline `latexmk` — so the template's own behaviour is unchanged. The exposure is downstream.

**This is a patch.** Worth stating plainly, because rhiza's `CHANGELOG.md` has no upgrade-note convention: entries are generated from commits alone, so the version number and the generated `New Features` line are the only signal a consumer gets that the CLI underneath their gates moved two minor versions.

## Files the bump touched

| file | what moved |
|---|---|
| `pyproject.toml` | `[project].version` and `[tool.bumpversion] current_version` |
| `bundles/**/.github/workflows/*.yml` (11 stubs) | the `jebel-quant/rhiza/…@vX.Y.Z` self-reference, so a synced stub names a tag that exists |
| `uv.lock` | the `name = "rhiza"` entry |

`uv.lock` is **deliberately not** a `[[tool.bumpversion.files]]` entry — the config says so, because a bare version-string search would also rewrite third-party pins. It is regenerated with `uv lock` after the bump, which is what this commit did.

## Changelog

Prepended, not regenerated: 13 insertions, **zero deletions**, so no earlier section moved. rhiza's `cliff.toml` carries the file header, so unlike some sibling repos the `# Changelog` title survives `--prepend` untouched.

## Test results

`1706 passed`. Three errors in `tests/benchmarks/test_dogfood_linker.py` (`fixture 'benchmark' not found`) are **pre-existing on `origin/main`** — confirmed by stashing and re-running there. They are a collection artifact: those tests need `pytest-benchmark`, which only the `benchmark` gate provisions, so a bare `uv run pytest` cannot satisfy them.

## Merging this does not publish the release

**No tag exists yet.** It is cut afterwards from the merged commit by a second `/rhiza:release` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
