### PR TITLE
chore: update changelog.md for v1.5.2's dependency entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com),
 and entries are generated from [Conventional Commits](https://www.conventionalcommits.org).
 
-## [1.5.2] - 2026-08-23
+## [1.5.2] - 2026-08-24
 
 ### New Features
 - Move the RHIZA_TASK pin to rhiza-task 1.3.1 (#1619)
@@ -17,6 +17,9 @@ and entries are generated from [Conventional Commits](https://www.conventionalco
 ### Documentation
 - Retire rhiza-cli from the docs, shorten the README, and rewrite the two guides built on the make layer (#1609)
 - Link every page from the nav, and stop documenting the retired make layer (#1615)
+
+### Dependencies
+- *(deps)* Lock file maintenance (#1621)
 
 ## [1.5.1] - 2026-08-22
 


### PR DESCRIPTION
Blocks the `v1.5.2` tag until the record matches the tree.

## The gap

The v1.5.2 section was generated in #1620 **before** #1621 (`chore(deps): lock file maintenance`) merged. rhiza's `cliff.toml` groups `chore(deps)` under **Dependencies** rather than skipping it — and the comment above those parsers records a dependency bump vanishing from a release as a defect worth naming. So the tag would have carried #1621's lockfile change while the changelog denied it.

Adds:

```
### Dependencies
- *(deps)* Lock file maintenance (#1621)
```

Also corrects the date — `git-cliff` stamped `2026-08-23` from UTC while the release is being cut on the 24th.

## Verification

The section is now **byte-identical** to `git-cliff v1.5.1..HEAD --tag v1.5.2`, checked by `diff` before committing rather than asserted.

## Why this subject line

`chore: update changelog.md` is matched by an existing `skip = true` parser in `cliff.toml`, so a changelog correction doesn't generate a changelog entry of its own. Nothing else about it is incidental.

## No version moves

The bump landed in #1620; `current_version` stays `1.5.2`. Once this merges, `/rhiza:release` phase B tags **this** commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
