### PR TITLE
chore: release v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com),
 and entries are generated from [Conventional Commits](https://www.conventionalcommits.org).
 
+## [1.6.0] - 2026-08-24
+
+### New Features
+- Make rhiza_paper call the rhiza-task, and publish the PDF on the paper branch (#1623)
+- Give the paper branch a README explaining what it is (#1626)
+
+### Bug Fixes
+- Build the paper in the book workflow, and check the nav actually resolves (#1624)
+- Make the compiled paper reproducible, so the branch records revisions not runs (#1627)
+- Stop the changelog dropping a commit that merely mentions the CI-skip marker
+
+### Other Changes
+- Enforce non-empty benchmark input invariant for live benchmark workflow (#1625)
+
 ## [1.5.2] - 2026-08-24
 
 ### New Features

--- a/bundles/core/cliff.toml
+++ b/bundles/core/cliff.toml
@@ -64,8 +64,19 @@ sort_commits = "oldest"
 # Group commits into changelog sections. The leading HTML comment controls the
 # section ordering and is stripped from the rendered heading via `striptags`.
 commit_parsers = [
-  # Drop automated noise commits that don't provide user-facing signal.
-  { message = ".*\\[skip ci\\].*", skip = true },
+  # Drop automated noise commits that don't provide user-facing signal -- the machine-written
+  # `Update the compiled paper [skip ci]` kind, which puts the marker in its *subject*.
+  #
+  # Anchored to the subject line, and that is load-bearing rather than tidy. git-cliff matches
+  # this against the whole message, so the unanchored `.*\[skip ci\].*` also dropped any commit
+  # whose *body* merely mentioned the marker -- a commit message quoting the format of another
+  # commit message is enough. That silently ate `feat: give the paper branch a README` (#1626)
+  # out of v1.6.0's notes, for one backticked mention twenty lines down. Same failure as the
+  # `bump` alternative below: a substring search treating a mention as the thing itself.
+  #
+  # `^` with no `(?m)` is start-of-message, and `[^\n]*` cannot cross a newline, so only the
+  # subject can match.
+  { message = "^[^\\n]*\\[skip ci\\]", skip = true },
   # Only the release flow's own commits. A bare `bump` alternative here also ate every
   # `chore(deps): bump <dependency>` — the rhiza-hooks v1.2.0 bump (#1487) vanished from
   # v1.3.2's notes that way, and had been vanishing for a while unnoticed: a Dependabot

--- a/bundles/github-book/.github/workflows/rhiza_book.yml
+++ b/bundles/github-book/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.5.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.6.0
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml
+++ b/bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   devcontainer:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v1.5.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v1.6.0
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-docker/.github/workflows/rhiza_docker.yml
+++ b/bundles/github-docker/.github/workflows/rhiza_docker.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   docker:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v1.5.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v1.6.0
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-marimo/.github/workflows/rhiza_marimo.yml
+++ b/bundles/github-marimo/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.5.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.6.0
     secrets: inherit

--- a/bundles/github-paper/.github/workflows/rhiza_paper.yml
+++ b/bundles/github-paper/.github/workflows/rhiza_paper.yml
@@ -39,7 +39,7 @@ on:
 
 jobs:
   paper:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v1.5.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v1.6.0
     secrets: inherit
     # `contents: write` is for the `paper` branch publish and nothing else. A pull request
     # never reaches that step, so the scope is unused on every PR run.

--- a/bundles/github-quality-review/.github/workflows/rhiza_quality_review.yml
+++ b/bundles/github-quality-review/.github/workflows/rhiza_quality_review.yml
@@ -34,5 +34,5 @@ on:
 
 jobs:
   quality-review:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_quality_review.yml@v1.5.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_quality_review.yml@v1.6.0
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_benchmark.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.5.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.6.0
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_ci.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.5.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.6.0
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_codeql.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.5.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.6.0
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/bundles/github/.github/workflows/rhiza_scorecard.yml
+++ b/bundles/github/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.5.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.6.0
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/bundles/github/.github/workflows/rhiza_weekly.yml
+++ b/bundles/github/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.5.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.6.0
     secrets: inherit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rhiza"
-version = "1.5.2"
+version = "1.6.0"
 description = "Reusable configuration templates for modern Python projects"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -70,7 +70,7 @@ Issues = "https://github.com/jebel-quant/rhiza/issues"
 # python-core bundle no longer ships a `.rhiza/.cfg.toml` copy of this block; the
 # Rust and Go layers ship a root `.bumpversion.toml` instead, since neither
 # language has a discoverable file of its own.
-current_version = "1.5.2"
+current_version = "1.6.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:[-]?(?P<release>[a-z]+)[\\.]?(?P<pre_n>\\d+))?(?:\\+build\\.(?P<build_n>\\d+))?"
 serialize = [
     "{major}.{minor}.{patch}-{release}.{pre_n}+build.{build_n}",

--- a/tests/api/test_changelog_parsers.py
+++ b/tests/api/test_changelog_parsers.py
@@ -1,0 +1,134 @@
+r"""cliff.toml's skip rules must drop machine commits without eating real ones.
+
+Every rule in ``commit_parsers`` is matched by git-cliff against the **whole commit
+message**, subject and body together. That is easy to forget when writing one, and the
+consequence is the quietest kind of failure this repo keeps finding: the commit is not
+reported as skipped, it simply never appears, and the changelog understates what shipped.
+
+It has now happened twice, to two different rules:
+
+* A bare ``bump`` alternative ate every ``chore(deps): bump <dependency>``. The rhiza-hooks
+  v1.2.0 bump (#1487) vanished from v1.3.2's notes that way, and had been vanishing for a
+  while unnoticed.
+* ``.*\\[skip ci\\].*`` ate ``feat: give the paper branch a README`` (#1626) out of v1.6.0's
+  notes, because its body quoted the *format* of another commit's message -- one backticked
+  ``[skip ci]`` twenty lines below the subject.
+
+So these tests run the rules the way git-cliff does -- over a full message -- and assert
+both directions for each: the machine commit the rule exists for is dropped, and a commit
+that merely mentions the marker in prose survives. Asserting only the first is what let both
+regressions through.
+
+The rules are read from ``cliff.toml`` rather than restated here, so a rewritten pattern is
+tested rather than a copy of the old one.
+
+One consequence of anchoring to the subject is worth knowing before writing a commit *about*
+the marker: a subject containing it is still skipped, correctly, so such a commit has to name
+the marker in its body instead. The fix that introduced these tests was itself dropped from
+the release notes once for exactly that reason.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+# A commit whose body quotes another commit's message. This is not a contrived case: it is
+# what #1626 did, and the shape any commit takes when it documents what a publish step
+# writes.
+_MENTIONS_IN_BODY = """feat: give the paper branch a README explaining what it is
+
+Provenance goes in the commit message, which is only written when there is
+something to commit: `Update the compiled paper from <sha> [skip ci]`.
+"""
+
+# What the rule is actually for: a machine-written commit carrying the marker in its subject.
+_MARKER_IN_SUBJECT = "chore: update CHANGELOG.md for v0.18.9 [skip ci]"
+
+# A Dependabot subject, which the `bump` rule must not swallow.
+_DEPENDENCY_BUMP = "chore(deps): bump rhiza-hooks from 1.1.0 to 1.2.0"
+
+# The release flow's own commits, which the release rules exist to drop.
+_RELEASE_COMMIT = "chore: release v1.6.0"
+
+
+@pytest.fixture(scope="module")
+def skip_patterns() -> list[str]:
+    """Return every ``commit_parsers`` pattern marked ``skip``.
+
+    Returns:
+        The regexes, as written in cliff.toml.
+    """
+    config = tomllib.loads((_ROOT / "cliff.toml").read_text(encoding="utf-8"))
+    parsers = config["git"]["commit_parsers"]
+    return [p["message"] for p in parsers if p.get("skip") and "message" in p]
+
+
+def _skipped(message: str, patterns: list[str]) -> bool:
+    """Return whether any skip rule matches a full commit message.
+
+    Args:
+        message: The complete commit message, subject and body.
+        patterns: The skip regexes.
+
+    Returns:
+        True when git-cliff would drop the commit.
+    """
+    # `search`, not `match`: git-cliff's regexes are unanchored, which is the whole reason a
+    # body mention could match a rule intended for a subject.
+    return any(re.search(pattern, message) for pattern in patterns)
+
+
+def test_the_scan_finds_the_skip_rules(skip_patterns: list[str]) -> None:
+    """Positive control: no rules would make every assertion below vacuous."""
+    assert len(skip_patterns) >= 4, (
+        f"found only {len(skip_patterns)} skip rule(s) in cliff.toml: {skip_patterns}. The "
+        f"marker rule and the three release-flow rules alone are more than that, so this is "
+        f"reading the wrong table."
+    )
+
+
+def test_a_marker_in_the_subject_is_dropped(skip_patterns: list[str]) -> None:
+    """The rule must still do its job: machine commits stay out of the changelog."""
+    assert _skipped(_MARKER_IN_SUBJECT, skip_patterns), (
+        f"no skip rule matches {_MARKER_IN_SUBJECT!r}. Anchoring the marker rule to the "
+        f"subject must not stop it matching a subject."
+    )
+
+
+def test_a_marker_mentioned_in_the_body_survives(skip_patterns: list[str]) -> None:
+    """A commit that *talks about* the marker is a real change and must be reported.
+
+    This is #1626. The subject is a plain `feat:`; the body quotes another commit's message.
+    Under the unanchored rule the whole feature disappeared from the release notes.
+    """
+    assert not _skipped(_MENTIONS_IN_BODY, skip_patterns), (
+        "a skip rule matches a commit that only mentions `[skip ci]` in its body, so the "
+        "feature it describes will be missing from the changelog with nothing reporting it "
+        "(#1626). Anchor the rule to the subject line."
+    )
+
+
+def test_a_dependency_bump_survives(skip_patterns: list[str]) -> None:
+    """The other half of the same lesson, kept as a regression test.
+
+    A bare `bump` alternative in the release rules ate every `chore(deps): bump ...`, and
+    #1487 vanished from v1.3.2's notes. The rules name `release` and `bump version`
+    explicitly for this reason.
+    """
+    assert not _skipped(_DEPENDENCY_BUMP, skip_patterns), (
+        f"a skip rule matches {_DEPENDENCY_BUMP!r}. Dependency bumps are user-facing signal "
+        f"and belong in the Dependencies section."
+    )
+
+
+def test_the_release_commit_is_dropped(skip_patterns: list[str]) -> None:
+    """`chore: release vX.Y.Z` is bookkeeping and must not appear in its own notes."""
+    assert _skipped(_RELEASE_COMMIT, skip_patterns), (
+        f"no skip rule matches {_RELEASE_COMMIT!r}, so every release's notes would open with the commit that cut them."
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -869,7 +869,7 @@ wheels = [
 
 [[package]]
 name = "rhiza"
-version = "1.5.2"
+version = "1.6.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Release **v1.5.2 → v1.6.0**. Strictly increases past every published tag (highest is `v1.5.2`), checked by `check_version_bump.py`.

## Why minor

Two `feat` commits, no breaking change:

- `#1623` — `rhiza_paper.yml` calls the `paper` task and publishes the PDF to the `paper` branch
- `#1626` — that branch gets a generated README

Consumers who sync `github-paper` get new behaviour, including a stub that now asks for `contents: write`. Nothing existing changes shape, hence minor rather than major.

## What the bump touched

| File | Change |
|---|---|
| `pyproject.toml` | `[project].version` and `[tool.bumpversion].current_version` → `1.6.0` |
| `bundles/*/.github/workflows/*.yml` (11 stubs) | `@v1.5.2` → `@v1.6.0` |
| `uv.lock` | the root package's own version, refreshed with `uv lock` |
| `CHANGELOG.md` | one new `## [1.6.0]` section, prepended |

The `[project]` pattern is the anchored regex form, so no `[tool.*]` table or dependency pin sharing the number was rewritten — confirmed from the diff. The stub pins are template content; no **live** workflow self-references `jebel-quant/rhiza@v1.6.0`, so CI can reach green on this PR (the unmergeable-self-pin case does not apply here).

## One extra commit, and why it is in this PR

`d43f02c8` fixes a changelog rule, and it had to land before the notes were generated.

`cliff.toml`'s marker rule was `.*\[skip ci\].*`, and git-cliff matches every rule against the **whole** commit message. So any commit whose *body* mentioned the marker was dropped — and `#1626`'s body quotes the format of another commit's message, one backticked mention twenty lines below the subject. `feat: give the paper branch a README` was therefore **missing** from the first render of these notes, with nothing reporting it.

That is the same failure as the `bump` alternative documented two rules below, which ate every `chore(deps): bump …` and lost the rhiza-hooks v1.2.0 bump (`#1487`) from v1.3.2's notes.

The rule is now anchored to the subject line, where a machine-written marker actually appears. Both directions verified with git-cliff: `#1626` reappears, and a real `chore: update CHANGELOG.md … [skip ci]` commit still renders an empty section. `tests/api/test_changelog_parsers.py` reads the patterns out of `cliff.toml` and asserts both directions for each skip rule — the dependency-bump case kept as a regression test beside the new one.

A footnote that is its own evidence: this fix's subject originally contained the literal marker, so the anchored rule correctly skipped it and the fix vanished from the notes it was written to repair. The subject now names the marker in prose; the test module records the rule.

## Merging this does not publish the release

No tag exists yet. The tag is cut afterwards, from the merged commit, by a second `/rhiza:release` run — a tag created before a squash-merge would name a SHA that never lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
