### PR TITLE
feat: a working seam for native binary dependencies

### DIFF
--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -25,7 +25,7 @@ permissions:
 # from a consumer's `RHIZA_TASK`, which this workflow cannot see: it tracks the tag the
 # workflow is called at.
 env:
-  RHIZA_TASK: rhiza-task@1.3.1
+  RHIZA_TASK: rhiza-task@1.4.0
 
 on:
   push:

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -41,7 +41,7 @@ permissions:
 # from a consumer's `RHIZA_TASK`, which this workflow cannot see: it tracks the tag the
 # workflow is called at.
 env:
-  RHIZA_TASK: rhiza-task@1.3.1
+  RHIZA_TASK: rhiza-task@1.4.0
 
   # The LaTeX engine `book`'s `paper` prerequisite needs. Without it that prerequisite
   # *skips* -- `skipped  paper  tectonic not found` -- and `book` still reports ok, so the

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -39,7 +39,7 @@ permissions:
 # see -- and should not: the gates a build runs must not move under it. It tracks the tag
 # this workflow is called at, the same rule the OS-matrix step below states for its pin.
 env:
-  RHIZA_TASK: rhiza-task@1.3.1
+  RHIZA_TASK: rhiza-task@1.4.0
 
 on:
   push:
@@ -130,7 +130,7 @@ jobs:
             ${{ github.repository == 'jebel-quant/rhiza'
                 && '["ubuntu-latest","macos-latest"]' || '' }}
         run: |
-          OS_MATRIX=$(uvx rhiza-task@1.3.1 ci-os-matrix)
+          OS_MATRIX=$(uvx rhiza-task@1.4.0 ci-os-matrix)
           echo "list=$OS_MATRIX" >> "$GITHUB_OUTPUT"
 
       - name: Debug OS matrix

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -82,7 +82,7 @@ jobs:
           #
           # Pinned for the reason the OS matrix is pinned (#1546): the folder a build
           # discovers notebooks in must not move under a workflow called at a tag.
-          NOTEBOOK_DIR=$(uvx rhiza-task@1.3.1 print marimo_folder)
+          NOTEBOOK_DIR=$(uvx rhiza-task@1.4.0 print marimo_folder)
 
           echo "Searching notebooks in: $NOTEBOOK_DIR"
           # Check if directory exists

--- a/.github/workflows/rhiza_paper.yml
+++ b/.github/workflows/rhiza_paper.yml
@@ -45,7 +45,7 @@ env:
   # The rhiza-task pin the compile runs through. Pinned rather than read from a consumer's
   # `RHIZA_TASK`, which a reusable workflow cannot see: it tracks the tag this workflow is
   # called at, so a repository synced at a release compiles with that release's task.
-  RHIZA_TASK: rhiza-task@1.3.1
+  RHIZA_TASK: rhiza-task@1.4.0
 
   # The LaTeX engine the `paper` task drives. tectonic is a single static binary that
   # resolves what a document cites out of its own web bundle, which is why this workflow no

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -27,7 +27,7 @@ permissions:
 # CLI rather than `core`'s `Makefile` so they do not depend on a front door this workflow
 # neither ships nor can verify.
 env:
-  RHIZA_TASK: rhiza-task@1.3.1
+  RHIZA_TASK: rhiza-task@1.4.0
 
 on:
   #push:

--- a/README.md
+++ b/README.md
@@ -392,11 +392,12 @@ Repo-owned targets:
 ## 🎯 Customising Safely
 
 Everything a sync delivers is **template-owned and overwritten by the next one** — the
-`Makefile` included, since `core` ships it. Extensions live in four places no sync touches:
+`Makefile` included, since `core` ships it. Extensions live in five places no sync touches:
 
 | Where | For |
 |-------|-----|
 | `local.mk` | Your own make targets, and extending a template task by shadowing it |
+| `local-setup.sh` | Native binaries your project needs before any gate can run |
 | `[tool.rhiza-task]` in `pyproject.toml` (or `rhiza.toml`) | Settings — `source-folder`, `coverage-fail-under`, … |
 | `pyproject.toml` | Dependencies, scripts, other tools' configuration |
 | `.rhiza/.env` | Developer-local overrides (gitignored) |

--- a/README.md
+++ b/README.md
@@ -287,6 +287,9 @@ Run `make help` for a complete list of 40+ available targets.
                                                            local branches       
  doctor              Dev                                   check local          
                                                            prerequisites        
+ setup               Dev                                   run the repository's 
+                                                           own environment      
+                                                           setup hook           
  docker-build        Docker                                build the Docker     
                                                            image                
  docker-clean        Docker                                remove the Docker    
@@ -337,7 +340,7 @@ Run `make help` for a complete list of 40+ available targets.
  docs-coverage       Python          install               check docstring      
                                                            coverage with        
                                                            interrogate          
- install             Python                                create the venv and  
+ install             Python          setup                 create the venv and  
                                                            sync dependencies    
  license             Python          install               scan for copyleft    
                                                            licences             

--- a/bundles/core/.gitignore
+++ b/bundles/core/.gitignore
@@ -111,6 +111,11 @@ cython_debug/
 # overwritten by every sync, so `local.mk` is the only place a repo's own make targets can
 # live, and anything CI invokes has to be committed. rhiza's own `make e2e`, which
 # rhiza_e2e.yml runs in all three language jobs, is exactly that case.
+#
+# `local-setup.sh` is not ignored either, and for the same reason one step further out: it
+# is the hook every layer's `install` runs to provision a native binary the project needs
+# (graphviz, libpq, pandoc), so CI invokes it on every job. A gitignored provisioning script
+# is one that works on its author's machine and nowhere else.
 
 .bandit-baseline.json
 

--- a/bundles/core/Makefile
+++ b/bundles/core/Makefile
@@ -18,7 +18,7 @@
 # Repo-specific *tasks* go in a `rhiza_task.tasks` entry point, repo-specific *targets* in
 # `local.mk`, which core deliberately does not ignore. Nothing goes below the shim: this
 # file is synced, so the next `/rhiza:update` overwrites whatever was appended to it.
-RHIZA_TASK ?= rhiza-task@1.3.1
+RHIZA_TASK ?= rhiza-task@1.4.0
 
 # uv cannot be delegated, because uv is what runs the CLI. Prepended so a machine carrying
 # an older uv still resolves the pin, exported because task bodies shell out to bare `uv`.

--- a/bundles/gitlab-book/.gitlab/workflows/rhiza_book.yml
+++ b/bundles/gitlab-book/.gitlab/workflows/rhiza_book.yml
@@ -35,7 +35,7 @@ pages:
     - export UV_EXTRA_INDEX_URL="${UV_EXTRA_INDEX_URL}"
     - |
       # The musl build: statically linked, so it runs in whatever container $UV_IMAGE is.
-      folder=$(uvx rhiza-task@1.3.1 print paper-folder)
+      folder=$(uvx rhiza-task@1.4.0 print paper-folder)
       if [ -n "$(find "${folder}" -maxdepth 1 -name '*.tex' 2>/dev/null | head -1)" ]; then
         url="https://github.com/tectonic-typesetting/tectonic/releases/download"
         url="${url}/tectonic%40${TECTONIC_VERSION}/tectonic-${TECTONIC_VERSION}-x86_64-unknown-linux-musl.tar.gz"

--- a/bundles/gitlab-marimo/.gitlab/workflows/rhiza_marimo.yml
+++ b/bundles/gitlab-marimo/.gitlab/workflows/rhiza_marimo.yml
@@ -37,7 +37,7 @@ marimo:notebooks:
       #
       # The version is pinned rather than read from RHIZA_TASK: this pipeline cannot see a
       # consumer's Makefile, and a value a job depends on must not move under it.
-      NOTEBOOK_DIR=$(uvx rhiza-task@1.3.1 print marimo_folder 2>/dev/null || echo "marimo")
+      NOTEBOOK_DIR=$(uvx rhiza-task@1.4.0 print marimo_folder 2>/dev/null || echo "marimo")
       echo "Searching notebooks in: $NOTEBOOK_DIR"
 
       if [ ! -d "$NOTEBOOK_DIR" ]; then

--- a/bundles/gitlab-tests/.gitlab/workflows/rhiza_ci.yml
+++ b/bundles/gitlab-tests/.gitlab/workflows/rhiza_ci.yml
@@ -16,7 +16,7 @@
 # on a front door it neither ships nor can verify.
 
 variables:
-  RHIZA_TASK: "rhiza-task@1.3.1"
+  RHIZA_TASK: "rhiza-task@1.4.0"
 
 ci:test:
   # CI budget: ≤20 min (test matrix execution). Last measured: 2026-05-28.

--- a/bundles/gitlab/.gitlab/workflows/rhiza_paper.yml
+++ b/bundles/gitlab/.gitlab/workflows/rhiza_paper.yml
@@ -25,7 +25,7 @@
 # texlive-* packages. Both are watched by custom managers in the mother repo's
 # renovate.json; an unmanaged pin only ages (#1579).
 variables:
-  RHIZA_TASK: "rhiza-task@1.3.1"
+  RHIZA_TASK: "rhiza-task@1.4.0"
   TECTONIC_VERSION: "0.17.0"
 
 paper:build:

--- a/bundles/gitlab/.gitlab/workflows/rhiza_quality.yml
+++ b/bundles/gitlab/.gitlab/workflows/rhiza_quality.yml
@@ -18,7 +18,7 @@
 # on a front door it neither ships nor can verify.
 
 variables:
-  RHIZA_TASK: "rhiza-task@1.3.1"
+  RHIZA_TASK: "rhiza-task@1.4.0"
 
 quality:deptry:
   stage: test

--- a/bundles/gitlab/.gitlab/workflows/rhiza_weekly.yml
+++ b/bundles/gitlab/.gitlab/workflows/rhiza_weekly.yml
@@ -19,7 +19,7 @@
 # on a front door it neither ships nor can verify.
 
 variables:
-  RHIZA_TASK: "rhiza-task@1.3.1"
+  RHIZA_TASK: "rhiza-task@1.4.0"
 
 weekly:semgrep:
   stage: test

--- a/docs/guides/CUSTOMIZATION.md
+++ b/docs/guides/CUSTOMIZATION.md
@@ -9,6 +9,7 @@ Rhiza provides four extension mechanisms that survive every `/rhiza:update`. **N
 | Extension point | Where to add | Committed? | Use for |
 |-----------------|--------------|------------|---------|
 | `local.mk` | Project root | Yes | Your own make targets, and extending a template task |
+| `local-setup.sh` | Project root | Yes | Native binaries the project needs before any gate runs |
 | `[tool.rhiza-task]` | `pyproject.toml` | Yes | Settings — `source-folder`, `coverage-fail-under`, … |
 | `pyproject.toml` | Project root | Yes | Dependencies, scripts, tool configuration |
 | `.rhiza/.env` | Project root | No (gitignored) | Per-developer setting overrides |
@@ -29,19 +30,44 @@ Targets carrying a `##` comment are listed by `make help` under *Repo-owned targ
 
 The `pre-install::` / `post-install::` hooks the synced make layer anchored are **gone**: the tasks live in the pinned `rhiza-task` CLI, which knows nothing about make targets. The replacement is to **shadow** the target from `local.mk` — an explicit rule always beats the shim's `%:` catch-all, so the rule can call the task and then do the extra work.
 
-### Example: Installing System Dependencies
-
 ```makefile
 # local.mk
-install: $(UVX)
-	@if ! command -v dot >/dev/null 2>&1; then \
-		echo "Installing graphviz..."; \
-		sudo apt-get update && sudo apt-get install -y graphviz; \
-	fi
-	@$(UVX) $(RHIZA_TASK) install
+report: $(UVX)
+	@$(UVX) $(RHIZA_TASK) test
+	@./scripts/publish-test-report.sh
 ```
 
-`RHIZA_TASK` and `UVX` are defined by the `Makefile` above the `-include`, so a shadowing rule runs the same pinned CLI the rest of the project does — and naming `$(UVX)` as a prerequisite keeps the bootstrap that installs `uv` on a runner without one. Put the extra step before or after the delegation to get the old `pre-` or `post-` behaviour.
+`RHIZA_TASK` and `UVX` are defined by the `Makefile` above the `-include`, so a shadowing rule runs the same pinned CLI the rest of the project does — and naming `$(UVX)` as a prerequisite keeps the bootstrap that installs `uv` on a runner without one.
+
+**Shadowing only reaches a task that make resolves.** An explicit rule wins when you type its name, or when another make rule names it as a prerequisite. It does not win when the CLI reaches the task internally: `test` needs `install`, but the shim forwards the goal `test` to `rhiza-task`, which resolves `install` in its own task graph — no make rule of that name is consulted. And CI never invokes make at all; every workflow calls `uvx "$RHIZA_TASK" <gate>` directly.
+
+So shadowing adds work around a task **you invoke**. Work that has to happen before every gate belongs in the setup hook.
+
+## 🧰 Installing System Dependencies
+
+A project may need a native binary before any gate can run — graphviz for a docs plugin, `libpq` for psycopg, pandoc, an ODBC driver. Put it in an executable `local-setup.sh` at the repository root:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v dot >/dev/null 2>&1; then
+    echo "Installing graphviz..."
+    sudo apt-get update && sudo apt-get install -y graphviz
+fi
+```
+
+```bash
+chmod +x local-setup.sh
+```
+
+Every language layer's `install` runs it first, and `install` is the prerequisite of essentially every gate — so this one file covers a local `make test`, GitHub Actions, GitLab CI and the devcontainer, with no workflow edit anywhere. Commit it: `core` leaves it un-ignored for the same reason it leaves `local.mk` un-ignored — anything CI invokes has to be in the repository.
+
+Three things worth knowing:
+
+- **Guard the expensive part yourself**, as above. The hook runs on every fresh CI job and on every local invocation of a gate.
+- **A non-executable hook fails**, with a `chmod +x` hint — a provisioning step someone wrote and believed was running is exactly what must not pass quietly. Having no hook at all simply succeeds, so a project that needs nothing pays nothing, `--strict` runs included.
+- **It is a shell script rather than a list of package names**, because a list cannot survive contact with more than one package manager — `graphviz` is spelled the same on apt and brew, `libgl1-mesa-glx` is not — and cannot express "download this tarball" at all. The script puts platform detection with the people who know which platforms they build on.
 
 > Releasing is not a `make` target at all. Releases are driven by the rhiza-claude
 > `/rhiza:release` command, which bumps the version, regenerates `CHANGELOG.md`, and

--- a/docs/guides/EXTENDING_RHIZA.md
+++ b/docs/guides/EXTENDING_RHIZA.md
@@ -88,12 +88,7 @@ call the task itself wherever you want it in the sequence:
 ```makefile
 # local.mk
 
-# The old `pre-install::` — extra work first, then the real task.
-install: $(UVX)
-	@command -v dot >/dev/null 2>&1 || sudo apt-get install -y graphviz
-	@$(UVX) $(RHIZA_TASK) install
-
-# The old `post-install::` — the real task first, then the extra work.
+# The real task first, then the extra work.
 test: $(UVX)
 	@$(UVX) $(RHIZA_TASK) test
 	@./scripts/publish-test-report.sh
@@ -103,8 +98,41 @@ test: $(UVX)
 shadowing rule always drives the same pinned CLI as everything else. Naming `$(UVX)` as a
 prerequisite keeps the bootstrap that installs `uv` on a runner that has none.
 
-This is strictly more capable than the hooks were: it works for **every** task rather than the
-six that happened to have anchors, and the order is written down rather than implied.
+> **Shadowing reaches a task only when make is what resolves it.** A shadowing rule fires
+> when you type its name, or when another *make* rule names it as a prerequisite. It does
+> **not** fire when the task is reached as a prerequisite inside the CLI: `test` needs
+> `install`, but the shim forwards the goal `test` to `rhiza-task`, which resolves `install`
+> in its own task graph and never consults a make rule of that name. CI never runs make at
+> all — every workflow invokes `uvx "$RHIZA_TASK" <gate>` directly.
+>
+> So shadowing is for adding work around a task **you invoke**. For work that must happen
+> before every gate — installing a native binary, say — use the setup hook below, which is
+> anchored where the CLI can see it.
+
+### Provide a native binary
+
+Some projects need a tool on the machine before any gate can run: graphviz for a docs
+plugin, `libpq` for psycopg, pandoc. Put it in an executable `local-setup.sh` at the
+repository root:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+command -v dot >/dev/null 2>&1 || sudo apt-get update && sudo apt-get install -y graphviz
+```
+
+Every language layer's `install` runs it, and `install` is the prerequisite of essentially
+every gate — so one file covers a local `make test`, both CI platforms and the devcontainer,
+with no workflow edit anywhere. Commit it, like `local.mk`: `core` leaves it un-ignored
+because anything CI invokes has to be in the repository.
+
+Guard the expensive part yourself, as above — it runs on each fresh CI job, and on every
+local invocation. Two behaviours worth knowing: a hook that exists and is **not executable
+fails** with a `chmod +x` hint, because a provisioning step someone wrote and believed was
+running is exactly what must not pass quietly — while having no hook at all simply succeeds,
+so a project that needs nothing pays nothing.
+
+The hook is POSIX shell; a Windows-only project needs its own arrangement.
 
 ### Change a setting
 

--- a/docs/reference/ARCHITECTURE.md
+++ b/docs/reference/ARCHITECTURE.md
@@ -512,10 +512,15 @@ the files they must not modify, since `core` ships it and every sync overwrites 
 
 1. **`local.mk`**: own targets, and wrapping a task by shadowing its name. The `Makefile`
    `-include`s it and `core` leaves it un-ignored, so it is committed like any source file.
-2. **`[tool.rhiza-task]`**: settings, in `pyproject.toml` or `rhiza.toml`.
-3. **`RHIZA_*` in the environment**: the same settings for a CI job, or for a `local.mk`
+   Shadowing reaches a task make resolves — not one the CLI reaches internally, and not CI,
+   which never runs make.
+2. **`local-setup.sh`**: a native binary the project needs before any gate. Every layer's
+   `install` runs it, which is what puts it on the path of local make, both CI platforms and
+   the devcontainer at once. Committed, un-ignored by `core` for the same reason `local.mk` is.
+3. **`[tool.rhiza-task]`**: settings, in `pyproject.toml` or `rhiza.toml`.
+4. **`RHIZA_*` in the environment**: the same settings for a CI job, or for a `local.mk`
    `export` when the value must be committed.
-4. **`exclude:` in `.rhiza/template.yml`**: opting a managed file out of the sync entirely.
+5. **`exclude:` in `.rhiza/template.yml`**: opting a managed file out of the sync entirely.
 
 The full account, with the failure mode of each, is the
 [Customization Guide](../guides/CUSTOMIZATION.md).

--- a/tests/api/test_bundle_cli_targets.py
+++ b/tests/api/test_bundle_cli_targets.py
@@ -103,6 +103,27 @@ def test_the_pinned_cli_still_provides_the_bundles_targets(bundle: str, cli_task
     )
 
 
+def test_the_pinned_cli_still_carries_the_setup_hook(cli_tasks: set[str]) -> None:
+    """`setup` is what runs a consumer's `local-setup.sh`, and its loss would be silent.
+
+    Its own case rather than a sixth `BUNDLE_TARGETS` entry, because it is not a retired
+    fragment's target -- no bundle ever shipped a `setup` recipe. It is guarded here for a
+    sharper reason than the five above. Those fail loudly when someone types the target; this
+    one is never typed at all. Every layer's `install` names it as a prerequisite, and an
+    unresolvable prerequisite is *skipped* rather than an error -- so a pin that stopped
+    carrying it would leave every consumer's `install` quietly running no provisioning hook,
+    with every gate still green and a missing native binary as the only symptom.
+
+    Args:
+        cli_tasks: What the pinned rhiza-task exposes.
+    """
+    assert "setup" in cli_tasks, (
+        f"{pinned_cli()} has no `setup` task, so `local-setup.sh` would never run. Consumers "
+        f"reach it only as a prerequisite of `install`, and a prerequisite the CLI cannot "
+        f"resolve is skipped rather than failed -- nothing would report this at run time."
+    )
+
+
 @pytest.mark.parametrize("target", ALL_TARGETS)
 def test_the_shim_forwards_each_target_to_the_cli(logger, target: str) -> None:
     """`make <target>` resolves and delegates rather than failing on a missing rule.

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -66,6 +66,10 @@ class Layer:
             that the release config can still find the version it is about to
             rewrite — would never run.
         files: Project files to write after the sync, keyed by relative path.
+        executables: Paths within `files` to mark executable before `install` runs.
+            A real consumer's script carries its execute bit in git; a scaffold
+            writes plain text, so a layer that needs one has to say so. Empty for
+            all three language layers — `local-setup.sh` is the only user.
     """
 
     name: str
@@ -74,6 +78,7 @@ class Layer:
     tools: tuple[str, ...]
     version: str
     files: dict[str, str] = field(repr=False)
+    executables: frozenset[str] = frozenset()
 
 
 # `book` is in every set on purpose: book.mk declares `test:: ; @:` as a no-op
@@ -250,6 +255,11 @@ def assemble(layer: Layer, root: Path, workdir: Path, logger) -> Project:
         target = project / relative
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text(content, encoding="utf-8")
+
+    # Before `_init_repo`, so the bit is what gets committed -- which is how a real
+    # consumer's hook arrives, and what `setup` refuses to run without.
+    for relative in layer.executables:
+        (project / relative).chmod(0o755)
 
     _init_repo(project, layer.version)
     logger.info("assembled %s project at %s from bundles %s", layer.name, project, ", ".join(layer.bundles))

--- a/tests/e2e/test_setup_hook_e2e.py
+++ b/tests/e2e/test_setup_hook_e2e.py
@@ -1,0 +1,97 @@
+"""`local-setup.sh` runs, on a freshly synced project, through the real chain.
+
+This is the one assertion that would have caught the bug the hook replaced. Rhiza
+documented shadowing `install` in `local.mk` as the way to install a native binary
+— graphviz was its worked example — and that recipe never ran: the Makefile's `%:`
+catch-all forwards the *goal* to the pinned CLI, which resolves `install` inside its
+own task graph and consults no make rule of that name, and CI never invokes make at
+all. It fired only when someone typed `make install` by hand, which is exactly how
+a consumer would test it and conclude it worked.
+
+So what is proved here is deliberately the whole chain and not the task: a project
+assembled from real bundles, with a committed executable hook, whose `make install`
+leaves the hook's side effect behind. Nothing shorter distinguishes a seam that
+works from the one that looked like it did — `tests/api/` dry runs cannot, because
+the delegation line is identical either way.
+
+Python is the layer under test because one is enough for a chain that is
+language-neutral: `setup` is a neutral task, and rhiza-task's own suite asserts all
+three layers' `install` names it. The negative case — a hook present but not
+executable, which fails rather than passing quietly — is covered there too, and
+reproducing it here would cost a second full assemble for a branch that never
+touches rhiza's own wiring.
+
+Skips unless ``RHIZA_E2E=1`` and uv is on PATH. See `harness.py`.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from tests.e2e.harness import GATE_TIMEOUT_SECONDS, PYTHON, Project, assemble
+
+pytestmark = [pytest.mark.e2e, pytest.mark.timeout(GATE_TIMEOUT_SECONDS)]
+
+SENTINEL = "setup-hook-ran.txt"
+"""What the hook leaves behind. A file rather than a printed line, because stdout
+would also carry the hook's own `echo` from the scaffold and prove less: the file
+exists only if the script actually executed."""
+
+HOOK = f"""#!/usr/bin/env bash
+set -euo pipefail
+# Stands in for `apt-get install -y graphviz`, without needing a package manager,
+# the network, or root in CI.
+printf 'provisioned\\n' > "$(dirname "$0")/{SENTINEL}"
+"""
+
+WITH_HOOK = dataclasses.replace(
+    PYTHON,
+    files={**PYTHON.files, "local-setup.sh": HOOK},
+    executables=frozenset({"local-setup.sh"}),
+)
+"""The Python layer plus a committed, executable hook.
+
+`executables` is not decoration: `setup` refuses to run a hook without the bit, so a
+scaffold that only wrote the text would assert the failure path while looking like
+the success one.
+"""
+
+
+@pytest.fixture(scope="module")
+def project(root, tmp_path_factory, logger) -> Project:
+    """Assemble a Python project that ships a `local-setup.sh`, and install it."""
+    return assemble(WITH_HOOK, root, tmp_path_factory.mktemp("e2e-setup-hook"), logger)
+
+
+def test_install_runs_the_repo_owned_hook(project: Project):
+    """`make install` executes the hook — the property the old recipe never had.
+
+    The sentinel is the whole assertion. `ok  setup` in the summary would pass on a
+    task that found no hook and said so, which is the shape being ruled out.
+    """
+    sentinel = project.path / SENTINEL
+    assert sentinel.is_file(), (
+        f"`make install` did not run local-setup.sh: no {SENTINEL}.\n"
+        f"This is the failure the hook exists to remove — the seam resolves, reports "
+        f"success, and provisions nothing.\n{project.install_output[-800:]}"
+    )
+    assert sentinel.read_text(encoding="utf-8").strip() == "provisioned"
+
+
+def test_the_hook_is_reported_and_precedes_the_dependency_sync(project: Project):
+    """It runs before `uv sync`, and says so — a build dependency is needed by then.
+
+    Ordering is the half that matters for a native library a wheel has to compile
+    against: arriving after the sync is arriving too late. Asserted on the run
+    summary rather than the venv, since both steps succeed either way.
+    """
+    out = project.install_output
+    assert "ok  setup" in out, f"the setup task did not report success:\n{out[-800:]}"
+    assert "nothing to provision" not in out, (
+        f"setup reported no hook, on a project that ships one — the file was not seen:\n{out[-800:]}"
+    )
+    assert out.index("ok  setup") < out.index("ok  install"), (
+        f"setup must complete before install's own body, not after it:\n{out[-800:]}"
+    )


### PR DESCRIPTION
## The problem

A rhiza-managed project may need a **native binary** before any gate can run — graphviz for a docs plugin, `libpq` for psycopg, pandoc. The template owns every configuration file in such a repository, so there was nowhere to put that step, and **the answer rhiza documented never ran.**

`docs/guides/CUSTOMIZATION.md` used graphviz as its literal worked example: shadow `install:` in `local.mk`, apt-get graphviz, delegate. `EXTENDING_RHIZA.md` repeated it. Neither fires:

- **Locally**, the `Makefile`'s catch-all is `%: $(UVX) FORCE` → `uvx $(RHIZA_TASK) $@`, and `install` is a prerequisite *inside* rhiza-task's task graph rather than at make level — so `make test`, `make all` and `make book` forward the goal straight to the CLI and never consult a `local.mk` rule of that name. Only literally typing `make install` reached it.
- **In CI** it was unreachable by construction: all sixteen gate invocations across the reusable workflows are `uvx "$RHIZA_TASK" <task>`. make is never used for a gate.

So a consumer followed the guide, tested it by hand where it *did* work, and got nothing on any real run — the silent-green shape of #1505, #1511, #1516 and #1535, reached here through a documented extension point.

## The change

`local-setup.sh`, a repo-owned executable at the project root, run by every language layer's `install` ([rhiza-task#145](https://github.com/Jebel-Quant/rhiza-task/pull/145), released as v1.4.0). `install` is the prerequisite of essentially every gate, so one file covers local `make test`, GitHub Actions, GitLab CI and the devcontainer — no workflow edit anywhere.

Deliberately a script and not a `system-packages = [...]` setting: `graphviz` is spelled the same on apt and brew, `libgl1-mesa-glx` is not, and a list cannot express "download this tarball" — which is what rhiza itself does for tectonic. The script puts platform detection with the people who know which platforms they build on, and keeps the CLI out of the package-manager business (the rule `lfs-install` states).

Both guides now also explain **why** shadowing does not reach a task the CLI resolves internally. That trap is what produced the original recipe, and without it written down the next reader reinvents it.

## Two things this repo's own guards caught

Worth recording, because in both cases the guard was right and my first attempt was incomplete.

**The pin is thirteen literals, not one.** I bumped `bundles/core/Makefile` and `test_every_pin_names_the_same_version` went red: six of this repo's workflows and six GitLab bundle templates carry `rhiza-task@…` inline for the steps that reach the CLI directly. A split pin would have had the shim and CI running different gates.

**README's help block is generated.** `update-readme-help` regenerated it from the new pin, adding the `setup` row and `setup` to `install`'s needs column. Left to the hook rather than hand-edited, as CLAUDE.md requires.

## Guards added, at the two levels this could hide at

`test_the_pinned_cli_still_carries_the_setup_hook` — its own case rather than a sixth `BUNDLE_TARGETS` entry, and for a sharper reason than the five there. Those fail loudly when someone types the target. This one is **never typed**: consumers reach it only as a prerequisite, and an unresolvable prerequisite is *skipped* rather than failed — so a pin that stopped carrying `setup` would leave every consumer's `install` quietly provisioning nothing, with every gate still green.

`tests/e2e/test_setup_hook_e2e.py` — proves the **chain**, not the task: a project assembled from real bundles, with a committed executable hook, whose `make install` leaves the hook's side effect behind. Nothing shorter distinguishes a seam that works from one that only looks like it does; the `tests/api/` dry runs print an identical delegation line either way, which is exactly why the `local.mk` recipe went unnoticed. `Layer.executables` is what lets the scaffold commit the execute bit — a real consumer's hook carries it in git, and without it the e2e would have asserted the *refusal* path while looking like the success one.

## Verification

- `make test` — **1730 passed**
- `make e2e` — **45 passed**, all three real toolchains (Python, Rust, Go)
- `make fmt` — clean, stable on re-run
- **Falsified**: with the pin reverted to 1.3.1 the new e2e test fails (`did not run local-setup.sh`); at 1.4.0 it passes. The test has teeth, and consumers on the old pin genuinely do not get the hook.

## Scope notes

The e2e covers the Python layer and the positive case. `setup` is language-neutral and rhiza-task's suite asserts all three layers' `install` names it, plus the non-executable-fails path; reproducing that here would cost a second full assemble for a branch that never touches rhiza's wiring. The module docstring says so.

Not included, and worth their own PRs — both the same silent-skip class, found while investigating:

- **`rhiza_docker.yml` looks for the wrong path.** It tests `[ -f docker/Dockerfile ]`, but the `docker` bundle deploys to **root** `Dockerfile` (`test_bundle_combinations.py:48-49` asserts exactly that). So in every consumer that adopted the bundle, hadolint, the image build and the Trivy scan self-skip with a green tick.
- **`rhiza_book.yml:150` has no `--strict`** while `rhiza_paper.yml:151` does, and both header comments acknowledge the resulting failure mode — a deployed site whose nav points at a PDF that was never built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)