### PR TITLE
fix: run the setup-hook e2e in CI, and guard against a module running nowhere

### DIFF
--- a/.github/workflows/rhiza_e2e.yml
+++ b/.github/workflows/rhiza_e2e.yml
@@ -82,8 +82,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-prek-e2e-python-
 
+      # `test_setup_hook_e2e.py` rides along here rather than getting a job of its own:
+      # `setup` is language-neutral, and its scaffold needs exactly what this job already
+      # installs (uv and git). Named explicitly because E2E_ARGS narrows to a file list --
+      # a module no job names is collected by nothing, and the suite still reports green.
+      # `tests/api/test_e2e_coverage.py` is what keeps that from happening silently again.
       - name: Run the Python layer end to end
-        run: make e2e E2E_ARGS=tests/e2e/test_python_layer_e2e.py
+        run: make e2e E2E_ARGS="tests/e2e/test_python_layer_e2e.py tests/e2e/test_setup_hook_e2e.py"
 
   rust:
     name: Rust layer

--- a/tests/api/test_e2e_coverage.py
+++ b/tests/api/test_e2e_coverage.py
@@ -1,0 +1,97 @@
+"""Every end-to-end module is named by a job in `rhiza_e2e.yml`.
+
+`make e2e` runs `tests/e2e` whole, so a new module is picked up locally the moment it
+is written. CI is the opposite: each job narrows with `E2E_ARGS` to a named file list,
+one per language layer, because a job installs only its own toolchain. Nothing
+reconciles the two.
+
+That asymmetry has a failure mode with no symptom. A module no job names is collected
+by nothing, the E2E workflow still reports success, and the only evidence is a test
+count in a log nobody reads. It is the shape this repository keeps finding — #1505,
+#1511, #1516, #1535 — and it happened here: `test_setup_hook_e2e.py` was added, passed
+locally under `make e2e`, and ran in none of the three CI jobs while the workflow went
+green.
+
+Asserted against the workflow's shell rather than a hand-kept list, so adding a module
+and forgetting the job is a red test rather than a quiet gap. The reverse -- a job
+naming a module that no longer exists -- is caught too, since `pytest` would exit 4 on
+the missing path and that is worth failing here instead of in CI.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+_WORKFLOW = _ROOT / ".github" / "workflows" / "rhiza_e2e.yml"
+_E2E_DIR = _ROOT / "tests" / "e2e"
+
+# `E2E_ARGS=<value>`, bare or quoted. The value is a whitespace-separated path list, which
+# is why this captures the whole of it rather than one path: `make e2e E2E_ARGS="a b"` is
+# how a job runs two modules, and matching a single path would silently see only the first.
+_E2E_ARGS = re.compile(r"""E2E_ARGS=(?:"([^"]*)"|'([^']*)'|(\S+))""")
+
+
+def _named_modules() -> set[str]:
+    """Return every `tests/e2e/*.py` path the workflow's jobs name.
+
+    Returns:
+        Repo-relative paths, as written in the workflow.
+    """
+    source = _WORKFLOW.read_text(encoding="utf-8")
+    named: set[str] = set()
+    for match in _E2E_ARGS.finditer(source):
+        value = next(group for group in match.groups() if group is not None)
+        named.update(part for part in value.split() if part.endswith(".py"))
+    return named
+
+
+def _e2e_modules() -> set[str]:
+    """Return every end-to-end test module on disk.
+
+    Returns:
+        Repo-relative paths.
+    """
+    return {
+        f"tests/e2e/{path.name}"
+        for path in _E2E_DIR.glob("test_*.py")
+        if path.name != "harness.py"  # not a test module, and not glob-matched anyway
+    }
+
+
+def test_the_workflow_names_at_least_one_module() -> None:
+    """The regex still matches, so the two assertions below cannot pass vacuously."""
+    assert _named_modules(), (
+        f"no E2E_ARGS assignment found in {_WORKFLOW.name}; the pattern has gone stale and "
+        f"the coverage assertions below would pass over nothing"
+    )
+
+
+@pytest.mark.parametrize("module", sorted(_e2e_modules()))
+def test_every_e2e_module_runs_in_ci(module: str) -> None:
+    """A module no job names is collected by nothing, and the workflow still goes green.
+
+    Args:
+        module: The end-to-end module that must appear in some job's `E2E_ARGS`.
+    """
+    assert module in _named_modules(), (
+        f"{module} is not named by any job in {_WORKFLOW.name}, so it never runs in CI. "
+        f"`make e2e` runs tests/e2e whole and will pass locally, which is what makes this "
+        f"silent. Add it to the E2E_ARGS of whichever job installs the toolchain it needs."
+    )
+
+
+@pytest.mark.parametrize("module", sorted(_named_modules()))
+def test_every_named_module_exists(module: str) -> None:
+    """A job naming a module that was renamed or removed fails the whole job on exit 4.
+
+    Args:
+        module: A path named in some job's `E2E_ARGS`.
+    """
+    assert (_ROOT / module).is_file(), (
+        f"{_WORKFLOW.name} names {module}, which does not exist -- pytest exits 4 on a "
+        f"missing path, so that job fails rather than skipping the module."
+    )


### PR DESCRIPTION
## What is wrong on `main` right now

#1629 added `tests/e2e/test_setup_hook_e2e.py`. **It runs in none of the three E2E jobs**, and the E2E workflow reports success anyway.

`make e2e` runs `tests/e2e` whole, so it passes locally. CI narrows with `E2E_ARGS` to a named file list per layer, because each job installs only its own toolchain:

```
E2E_ARGS=tests/e2e/test_python_layer_e2e.py
E2E_ARGS=tests/e2e/test_rust_layer_e2e.py
E2E_ARGS=tests/e2e/test_go_layer_e2e.py
```

Nothing reconciles the two lists. I caught this after #1629 was already merged, by asking what CI actually ran rather than reading the green tick — the fix commit landed on that branch minutes too late.

The irony is the point: this is the same silent-green shape #1629 exists to remove — a seam that resolves, reports success, and does no work — reached this time through the *test of the fix* rather than the fix itself. #1505, #1511, #1516 and #1535 are the same family.

## The fix

**Wire it.** The module is named by the Python job, which already installs everything its scaffold needs (uv and git). `setup` is language-neutral, so one job is enough and a job of its own would pay for a fourth assemble to prove nothing extra.

**Guard the general property.** `tests/api/test_e2e_coverage.py` asserts that every `tests/e2e` module is named by some job, and that every named module exists — read off the workflow's own shell rather than a hand-kept list, so adding a module and forgetting the job is a red test rather than a quiet gap.

The reverse direction is guarded too, and it is not hypothetical: `pytest` exits **4** on a missing path, so a job naming a renamed module fails that job outright. Better to learn it here than in a CI log.

A third case asserts the regex still matches something, so the other two cannot pass vacuously if the workflow's spelling changes.

## Verification

- `tests/api/test_e2e_coverage.py` — 9 passed, on this branch rebased onto current `main`.
- **Falsified**: dropping the module from `E2E_ARGS` fails it, naming that module and explaining that `make e2e` will still pass locally.
- `make e2e E2E_ARGS="tests/e2e/test_python_layer_e2e.py tests/e2e/test_setup_hook_e2e.py"` — 16 passed, confirming the quoted two-file form survives make's expansion into pytest's argv.
- `make test` — 1740 passed. `make fmt` — clean.

This PR's own E2E run is the real check: the Python job should now report 16 tests where it previously reported 14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)