### PR TITLE
docs: correct three false claims in mkdocs-base.yml's header, and guard them (#1633)

### DIFF
--- a/bundles/book/docs/mkdocs-base.yml
+++ b/bundles/book/docs/mkdocs-base.yml
@@ -1,14 +1,8 @@
 # docs/mkdocs-base.yml — Base MkDocs configuration for rhiza-based projects.
 #
-# USAGE (standalone)
-#   Build or serve this file directly if you have no root-level mkdocs.yml:
-#     uvx --with mkdocs-material mkdocs serve -f docs/mkdocs-base.yml
-#   The rhiza build system (make book) will pick this file up automatically
-#   as a fallback when no root-level mkdocs.yml is found.
-#
-# USAGE (with INHERIT)
-#   To extend this config from a root-level mkdocs.yml, add the following
-#   at the top of your mkdocs.yml and override only what you need:
+# HOW IT IS READ
+#   Only through `INHERIT:` from a root-level `mkdocs.yml`. Add this at the top of
+#   that file and override only what you need:
 #
 #     INHERIT: docs/mkdocs-base.yml
 #
@@ -17,15 +11,31 @@
 #     repo_url: https://github.com/example/my-project
 #     repo_name: example/my-project
 #
-#     docs_dir: docs   # always set this explicitly — base uses docs_dir: . which
-#                      # resolves relative to docs/mkdocs-base.yml, not mkdocs.yml
-#
-#     nav:             # nav is fully replaced — not merged — by the child config
+#     nav:      # nav is fully replaced -- not merged -- by the child config
 #       - Home: index.md
 #       - Guide: guide.md
 #
-#   Any key you omit in mkdocs.yml is inherited from this file.
-#   The 'nav' key is always fully replaced when defined in the child.
+#   Every other key you omit is inherited, `docs_dir` included: relative paths in
+#   this file resolve against the *primary* config, so `docs_dir: docs` below means
+#   `<repo>/docs` and a child need not restate it.
+#
+# HOW IT IS NOT READ -- three claims this header used to make, all measured false (#1633)
+#   * There is no standalone build. Point mkdocs at this file directly and it aborts:
+#     `Config value 'site_name': Required configuration not provided.` -- this file
+#     declares no site, deliberately, because the site is the consumer's.
+#   * `book` does not fall back to it. rhiza-task's task requires a root `mkdocs.yml`
+#     and prints `skipped  book  no mkdocs.yml` without one. The fallback was real
+#     under `book.mk` and retired with the make layer.
+#   * A child that omits `INHERIT:` gets none of this, and nothing says so. That is
+#     the whole of #1633: 120 synced lines a consumer can silently not read.
+#
+# WHAT IT ACTUALLY BUYS
+#   The book is built by zensical, not mkdocs, and zensical already defaults to the
+#   Material theme and to most of the markdown extensions below. Measured against a
+#   bare config, inheriting this one adds the light/dark palette toggle, the
+#   `theme.features` list, the back-to-top button and `pymdownx.snippets`
+#   resolution -- and `mkdocstrings`, which is why `mkdocs-extra-packages` is
+#   non-empty by default. The rest is there for a consumer who builds with mkdocs.
 
 docs_dir: docs
 site_dir: _book

--- a/tests/integration/test_book_targets.py
+++ b/tests/integration/test_book_targets.py
@@ -189,3 +189,58 @@ def test_every_nav_exclusion_is_still_needed() -> None:
         if not (_DOCS / rel).is_file() or rel in linked
     }
     assert not stale, f"_NOT_IN_THE_NAV entries that {stale} — drop them"
+
+
+def test_the_root_mkdocs_inherits_the_base_config() -> None:
+    """This repo's own `mkdocs.yml` must carry the `INHERIT:` that reads the base config.
+
+    `bundles/book/` ships `docs/mkdocs-base.yml` and nothing makes a consumer read it: mkdocs
+    merges it only when the root config names it in `INHERIT:`, and a config that omits the key
+    builds a perfectly good site without it. `chebpy/chebpy` is in exactly that state, which is
+    what #1633 reported -- 120 synced lines that nothing there reads.
+
+    Measured against a bare config, what the omission costs under zensical is the light/dark
+    palette toggle, the whole `theme.features` list, the back-to-top button and `pymdownx.snippets`
+    resolution. None of that fails a build; the site simply comes out plainer, on every run.
+
+    A downstream `mkdocs.yml` is repo-owned, so this repo cannot assert the key is there. What it
+    can do is not be the counter-example: rhiza publishes the theme it ships to everyone else.
+    """
+    config = (_ROOT / "mkdocs.yml").read_text(encoding="utf-8")
+    base = "docs/mkdocs-base.yml"
+    assert (_ROOT / base).is_file(), f"{base} is missing, so the root config inherits from nothing"
+    assert f"INHERIT: {base}" in config, (
+        f"mkdocs.yml does not inherit {base}, so the theme rhiza ships to every consumer is "
+        f"absent from rhiza's own book -- silently, because the build succeeds either way"
+    )
+
+
+def test_the_base_config_cannot_be_built_on_its_own() -> None:
+    """The base config must declare no site, and its header must not offer a standalone build.
+
+    Its header documented one for years -- `mkdocs serve -f docs/mkdocs-base.yml` -- and the
+    command cannot work: with no `site_name`, mkdocs aborts with `Config value 'site_name':
+    Required configuration not provided.` The absence is deliberate, because the site metadata is
+    the consumer's, so the fix is to stop documenting the invocation rather than to add a name.
+
+    The second retired claim was that `book` picks this file up when no root-level `mkdocs.yml` is
+    found. It did under `book.mk`; rhiza-task's task prints `skipped  book  no mkdocs.yml` instead,
+    measured against the pinned version. Both were shipped to every consumer, in the header of the
+    file they describe, and nothing read either one.
+
+    Asserted as an absence, the way `test_fmt_target_no_longer_needs_python_version` is: what
+    matters is that the header stops telling a reader to run a command that aborts.
+    """
+    text = (_ROOT / "docs" / "mkdocs-base.yml").read_text(encoding="utf-8")
+    header = "\n".join(line for line in text.splitlines() if line.startswith("#"))
+    body = "\n".join(line for line in text.splitlines() if not line.startswith("#"))
+
+    assert "site_name" not in body, (
+        "the base config declares a site_name, so every consumer inheriting it publishes rhiza's "
+        "site metadata as its own"
+    )
+    offered = [claim for claim in ("mkdocs serve -f", "mkdocs build -f", "will pick this file up") if claim in header]
+    assert not offered, (
+        f"the header offers {offered}, which no longer works: a standalone build aborts for want "
+        f"of site_name, and `book` skips without a root mkdocs.yml (#1633)"
+    )


### PR DESCRIPTION
Closes #1633 — but not by doing what it asks. Both proposals were measured and
neither survives, so the file stays. What the measurement turned up instead is
that every claim its header makes is false, and that the defect the issue
actually found is one indirection away from where it looked.

## Why the file is not moving

**Option 2 — make it an mkdocs plugin — is dead empirically.** The book is built
by **zensical**, not mkdocs, and zensical runs no mkdocs plugin hooks. Probe: a
plugin whose `on_config` *and* `on_pre_build` both `raise SystemExit`, declared in
`plugins:`:

```
Build started
No issues found
Build finished in 0.19s
exit=0
```

Site written, hooks never invoked. An unknown plugin name (`no-such-plugin-xyz`)
builds just as clean — zensical silently ignores plugins it does not natively
know, which is why `mkdocstrings` works and a third-party one would not. The
theme/markdown block would become a silent no-op.

**Option 1 — ship it in a package — has no stable path**, which is the finding
that closed #1636. `uvx` resolves package files inside a hash-keyed cache
archive, and `INHERIT:` takes a filesystem path in a *committed* `mkdocs.yml`. The
only variant that works is rhiza-task materialising the file at build time: three
repos (a rhiza-task feature and release; `/rhiza:docs`, which scaffolds `INHERIT`
*"only if that file exists"*; then the pin bump here), a skew window, and a new
hard failure for anyone building without `make book`. Same arithmetic as #1636,
for 120 lines of static YAML.

**And the Note is moot** — the fallback it asks to keep working had already gone
with `book.mk`:

```
$ uvx rhiza-task@1.4.0 book      # repo holds docs/mkdocs-base.yml, no mkdocs.yml
 skipped  book  no mkdocs.yml
```

## The header made three false claims

All three shipped to every consumer, in the header of the file they describe:

| Claim | Measured |
| --- | --- |
| `uvx --with mkdocs-material mkdocs serve -f docs/mkdocs-base.yml` | aborts: `Config value 'site_name': Required configuration not provided.` |
| "`make book` will pick this file up automatically as a fallback" | `skipped  book  no mkdocs.yml`, above |
| "base uses `docs_dir: .` — always set this explicitly" | the file says `docs_dir: docs`; a child that omits the key inherits it correctly |

The missing `site_name` is deliberate — the site metadata is the consumer's — so
the fix is to stop documenting the invocation, not to add a name.

The header now also records what the file actually buys, measured by diffing a
build that inherits it against a bare config: the light/dark palette toggle, the
`theme.features` list, the back-to-top button and `pymdownx.snippets` resolution,
plus `mkdocstrings` — which is why `mkdocs-extra-packages` is non-empty by
default. Most of the `markdown_extensions` block is already zensical's default;
kept, because it is load-bearing for a consumer who builds with mkdocs.

## Two guards

Both verified to fail when their invariant is broken, not merely to pass now.

- **`test_the_root_mkdocs_inherits_the_base_config`** — this is the defect #1633
  really found. The base is read *only* when the child names it in `INHERIT:`, and
  a child that omits it builds a perfectly good, plainer site with nothing
  reporting it. That is `chebpy/chebpy`'s state. A downstream `mkdocs.yml` is
  repo-owned, so this repo cannot assert the key is there — what it can do is not
  be the counter-example, and publish the theme it ships to everyone else.
- **`test_the_base_config_cannot_be_built_on_its_own`** — pins the absent
  `site_name` and the absence of the retired invocations. Asserted as an absence
  the way `test_fmt_target_no_longer_needs_python_version` is, so the header
  cannot go stale silently again.

## Gates

`make test` (1693 passed, 46 skipped), `make fmt`, `make sync-self-check`
(16 links correct) and `make book` all green. The 9 zensical `page does not exist`
issues in the book build pre-date this branch and are untouched by a comment-only
YAML edit.

## Left open deliberately

Nothing tells a *consumer* that its `mkdocs.yml` ignores the base. The natural
home is a pytest-rhiza check, but `RHIZA_CHECKS` is derived from the **layer** set
now and `book` is a feature bundle, so there is no delivery path for a
book-specific check today. Worth its own issue rather than a workaround here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
