### PR TITLE
chore: release v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com),
 and entries are generated from [Conventional Commits](https://www.conventionalcommits.org).
 
+## [1.7.0] - 2026-08-26
+
+### New Features
+- A working seam for native binary dependencies (#1629)
+- Stop syncing the generic developer docs, and the bundles that only held them (#1644)
+
+### Bug Fixes
+- Run the setup-hook e2e in CI, and guard against a module running nowhere (#1640)
+- Deploy the Dockerfile to docker/, where both its consumers look (#1642)
+- Serve the logo from the docs site instead of syncing it (#1643)
+
+### Documentation
+- Correct three false claims in mkdocs-base.yml's header, and guard them (#1633) (#1647)
+
+### Dependencies
+- *(deps)* Update dependency plotly to v7 (#1648)
+- *(deps)* Update dependency pytest-rhiza to v0.5.0 (#1594)
+- *(deps)* Update pre-commit hook astral-sh/uv-pre-commit to v0.12.6 (#1593)
+
+### Maintenance
+- Chore(deps)(deps): bump the github-actions group across 1 directory with 6 updates (#1630)
+
+### Other Changes
+- Feat/local setup hook (#1639)
+
 ## [1.6.0] - 2026-08-24
 
 ### New Features

--- a/bundles/github-book/.github/workflows/rhiza_book.yml
+++ b/bundles/github-book/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.6.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.7.0
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml
+++ b/bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   devcontainer:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v1.6.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v1.7.0
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-docker/.github/workflows/rhiza_docker.yml
+++ b/bundles/github-docker/.github/workflows/rhiza_docker.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   docker:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v1.6.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v1.7.0
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-marimo/.github/workflows/rhiza_marimo.yml
+++ b/bundles/github-marimo/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.6.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.7.0
     secrets: inherit

--- a/bundles/github-paper/.github/workflows/rhiza_paper.yml
+++ b/bundles/github-paper/.github/workflows/rhiza_paper.yml
@@ -39,7 +39,7 @@ on:
 
 jobs:
   paper:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v1.6.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v1.7.0
     secrets: inherit
     # `contents: write` is for the `paper` branch publish and nothing else. A pull request
     # never reaches that step, so the scope is unused on every PR run.

--- a/bundles/github-quality-review/.github/workflows/rhiza_quality_review.yml
+++ b/bundles/github-quality-review/.github/workflows/rhiza_quality_review.yml
@@ -34,5 +34,5 @@ on:
 
 jobs:
   quality-review:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_quality_review.yml@v1.6.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_quality_review.yml@v1.7.0
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_benchmark.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.6.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.7.0
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_ci.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.6.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.7.0
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_codeql.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.6.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.7.0
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/bundles/github/.github/workflows/rhiza_scorecard.yml
+++ b/bundles/github/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.6.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.7.0
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/bundles/github/.github/workflows/rhiza_weekly.yml
+++ b/bundles/github/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.6.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.7.0
     secrets: inherit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rhiza"
-version = "1.6.0"
+version = "1.7.0"
 description = "Reusable configuration templates for modern Python projects"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -70,7 +70,7 @@ Issues = "https://github.com/jebel-quant/rhiza/issues"
 # python-core bundle no longer ships a `.rhiza/.cfg.toml` copy of this block; the
 # Rust and Go layers ship a root `.bumpversion.toml` instead, since neither
 # language has a discoverable file of its own.
-current_version = "1.6.0"
+current_version = "1.7.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:[-]?(?P<release>[a-z]+)[\\.]?(?P<pre_n>\\d+))?(?:\\+build\\.(?P<build_n>\\d+))?"
 serialize = [
     "{major}.{minor}.{patch}-{release}.{pre_n}+build.{build_n}",

--- a/uv.lock
+++ b/uv.lock
@@ -869,7 +869,7 @@ wheels = [
 
 [[package]]
 name = "rhiza"
-version = "1.6.0"
+version = "1.7.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Release **v1.6.0 → v1.7.0** (minor: 3 features, 3 fixes, no breaking changes).

## Merging this PR does not publish the release

There is **no tag yet**, deliberately. A squash-merge replaces this branch's commit
with a new one, so a tag cut here would name a SHA that never reaches `main`. The tag
is created afterwards, from the merged commit, by a second `/rhiza:release` run.

## Files the bump touched

Every location is declared in `[tool.bumpversion]`; nothing was hand-edited.

| File | What moved |
| --- | --- |
| `pyproject.toml` | `[project].version` and `[tool.bumpversion].current_version` |
| `uv.lock` | the `name = "rhiza"` entry, regenerated with `uv lock` |
| `bundles/**/.github/workflows/*.yml` (11 files) | `jebel-quant/rhiza/...@v1.6.0` → `@v1.7.0` |
| `CHANGELOG.md` | one new `## [1.7.0]` section, prepended |

The 11 stub pins have to move with the release: they are the workflows synced into
downstream repos, and a stale pin would ship consumers workflows calling v1.6.0's
reusable workflows. The live `.github/workflows/` are deliberately *not* in the config
— they point at `jebel-quant/actions` by SHA, which carries its own version — so this
PR contains no self-reference to a tag that does not exist yet, and its required
checks can go green normally.

## Changelog section being added

```
## [1.7.0] - 2026-08-26

### New Features
- A working seam for native binary dependencies (#1629)
- Stop syncing the generic developer docs, and the bundles that only held them (#1644)

### Bug Fixes
- Run the setup-hook e2e in CI, and guard against a module running nowhere (#1640)
- Deploy the Dockerfile to docker/, where both its consumers look (#1642)
- Serve the logo from the docs site instead of syncing it (#1643)

### Documentation
- Correct three false claims in mkdocs-base.yml's header, and guard them (#1633) (#1647)

### Dependencies
- Update dependency plotly to v7 (#1648)
- Update dependency pytest-rhiza to v0.5.0 (#1594)
- Update pre-commit hook astral-sh/uv-pre-commit to v0.12.6 (#1593)

### Maintenance
- bump the github-actions group across 1 directory with 6 updates (#1630)

### Other Changes
- Feat/local setup hook (#1639)
```

Prepended, not regenerated, so no existing section was rewritten — the diff is purely
additive.

One thing worth knowing when reading the release notes: **#1639 is a feature filed
under "Other Changes"**, because its subject is `Feat/local setup hook` rather than a
conventional `feat:`. git-cliff classifies on the subject, so it could not be sorted
correctly. Nothing to fix in this PR; it is a note for whoever reads the published
notes and wonders why the feature count looks short.

## Guard

`v1.7.0` strictly increases past every published tag (highest existing: `v1.6.0`),
checked as semver rather than as strings.
