### PR TITLE
chore(deps): update dependency rhiza-task to v1.4.1

### DIFF
--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -25,7 +25,7 @@ permissions:
 # from a consumer's `RHIZA_TASK`, which this workflow cannot see: it tracks the tag the
 # workflow is called at.
 env:
-  RHIZA_TASK: rhiza-task@1.4.0
+  RHIZA_TASK: rhiza-task@1.4.1
 
 on:
   push:

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -41,7 +41,7 @@ permissions:
 # from a consumer's `RHIZA_TASK`, which this workflow cannot see: it tracks the tag the
 # workflow is called at.
 env:
-  RHIZA_TASK: rhiza-task@1.4.0
+  RHIZA_TASK: rhiza-task@1.4.1
 
   # The LaTeX engine `book`'s `paper` prerequisite needs. Without it that prerequisite
   # *skips* -- `skipped  paper  tectonic not found` -- and `book` still reports ok, so the

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -39,7 +39,7 @@ permissions:
 # see -- and should not: the gates a build runs must not move under it. It tracks the tag
 # this workflow is called at, the same rule the OS-matrix step below states for its pin.
 env:
-  RHIZA_TASK: rhiza-task@1.4.0
+  RHIZA_TASK: rhiza-task@1.4.1
 
 on:
   push:
@@ -130,7 +130,7 @@ jobs:
             ${{ github.repository == 'jebel-quant/rhiza'
                 && '["ubuntu-latest","macos-latest"]' || '' }}
         run: |
-          OS_MATRIX=$(uvx rhiza-task@1.4.0 ci-os-matrix)
+          OS_MATRIX=$(uvx rhiza-task@1.4.1 ci-os-matrix)
           echo "list=$OS_MATRIX" >> "$GITHUB_OUTPUT"
 
       - name: Debug OS matrix

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -82,7 +82,7 @@ jobs:
           #
           # Pinned for the reason the OS matrix is pinned (#1546): the folder a build
           # discovers notebooks in must not move under a workflow called at a tag.
-          NOTEBOOK_DIR=$(uvx rhiza-task@1.4.0 print marimo_folder)
+          NOTEBOOK_DIR=$(uvx rhiza-task@1.4.1 print marimo_folder)
 
           echo "Searching notebooks in: $NOTEBOOK_DIR"
           # Check if directory exists

--- a/.github/workflows/rhiza_paper.yml
+++ b/.github/workflows/rhiza_paper.yml
@@ -45,7 +45,7 @@ env:
   # The rhiza-task pin the compile runs through. Pinned rather than read from a consumer's
   # `RHIZA_TASK`, which a reusable workflow cannot see: it tracks the tag this workflow is
   # called at, so a repository synced at a release compiles with that release's task.
-  RHIZA_TASK: rhiza-task@1.4.0
+  RHIZA_TASK: rhiza-task@1.4.1
 
   # The LaTeX engine the `paper` task drives. tectonic is a single static binary that
   # resolves what a document cites out of its own web bundle, which is why this workflow no

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -27,7 +27,7 @@ permissions:
 # CLI rather than `core`'s `Makefile` so they do not depend on a front door this workflow
 # neither ships nor can verify.
 env:
-  RHIZA_TASK: rhiza-task@1.4.0
+  RHIZA_TASK: rhiza-task@1.4.1
 
 on:
   #push:

--- a/bundles/core/Makefile
+++ b/bundles/core/Makefile
@@ -18,7 +18,7 @@
 # Repo-specific *tasks* go in a `rhiza_task.tasks` entry point, repo-specific *targets* in
 # `local.mk`, which core deliberately does not ignore. Nothing goes below the shim: this
 # file is synced, so the next `/rhiza:update` overwrites whatever was appended to it.
-RHIZA_TASK ?= rhiza-task@1.4.0
+RHIZA_TASK ?= rhiza-task@1.4.1
 
 # uv cannot be delegated, because uv is what runs the CLI. Prepended so a machine carrying
 # an older uv still resolves the pin, exported because task bodies shell out to bare `uv`.

--- a/bundles/gitlab-book/.gitlab/workflows/rhiza_book.yml
+++ b/bundles/gitlab-book/.gitlab/workflows/rhiza_book.yml
@@ -35,7 +35,7 @@ pages:
     - export UV_EXTRA_INDEX_URL="${UV_EXTRA_INDEX_URL}"
     - |
       # The musl build: statically linked, so it runs in whatever container $UV_IMAGE is.
-      folder=$(uvx rhiza-task@1.4.0 print paper-folder)
+      folder=$(uvx rhiza-task@1.4.1 print paper-folder)
       if [ -n "$(find "${folder}" -maxdepth 1 -name '*.tex' 2>/dev/null | head -1)" ]; then
         url="https://github.com/tectonic-typesetting/tectonic/releases/download"
         url="${url}/tectonic%40${TECTONIC_VERSION}/tectonic-${TECTONIC_VERSION}-x86_64-unknown-linux-musl.tar.gz"

--- a/bundles/gitlab-marimo/.gitlab/workflows/rhiza_marimo.yml
+++ b/bundles/gitlab-marimo/.gitlab/workflows/rhiza_marimo.yml
@@ -37,7 +37,7 @@ marimo:notebooks:
       #
       # The version is pinned rather than read from RHIZA_TASK: this pipeline cannot see a
       # consumer's Makefile, and a value a job depends on must not move under it.
-      NOTEBOOK_DIR=$(uvx rhiza-task@1.4.0 print marimo_folder 2>/dev/null || echo "marimo")
+      NOTEBOOK_DIR=$(uvx rhiza-task@1.4.1 print marimo_folder 2>/dev/null || echo "marimo")
       echo "Searching notebooks in: $NOTEBOOK_DIR"
 
       if [ ! -d "$NOTEBOOK_DIR" ]; then

--- a/bundles/gitlab-tests/.gitlab/workflows/rhiza_ci.yml
+++ b/bundles/gitlab-tests/.gitlab/workflows/rhiza_ci.yml
@@ -16,7 +16,7 @@
 # on a front door it neither ships nor can verify.
 
 variables:
-  RHIZA_TASK: "rhiza-task@1.4.0"
+  RHIZA_TASK: "rhiza-task@1.4.1"
 
 ci:test:
   # CI budget: ≤20 min (test matrix execution). Last measured: 2026-05-28.

--- a/bundles/gitlab/.gitlab/workflows/rhiza_paper.yml
+++ b/bundles/gitlab/.gitlab/workflows/rhiza_paper.yml
@@ -25,7 +25,7 @@
 # texlive-* packages. Both are watched by custom managers in the mother repo's
 # renovate.json; an unmanaged pin only ages (#1579).
 variables:
-  RHIZA_TASK: "rhiza-task@1.4.0"
+  RHIZA_TASK: "rhiza-task@1.4.1"
   TECTONIC_VERSION: "0.17.0"
 
 paper:build:

--- a/bundles/gitlab/.gitlab/workflows/rhiza_quality.yml
+++ b/bundles/gitlab/.gitlab/workflows/rhiza_quality.yml
@@ -18,7 +18,7 @@
 # on a front door it neither ships nor can verify.
 
 variables:
-  RHIZA_TASK: "rhiza-task@1.4.0"
+  RHIZA_TASK: "rhiza-task@1.4.1"
 
 quality:deptry:
   stage: test

--- a/bundles/gitlab/.gitlab/workflows/rhiza_weekly.yml
+++ b/bundles/gitlab/.gitlab/workflows/rhiza_weekly.yml
@@ -19,7 +19,7 @@
 # on a front door it neither ships nor can verify.
 
 variables:
-  RHIZA_TASK: "rhiza-task@1.4.0"
+  RHIZA_TASK: "rhiza-task@1.4.1"
 
 weekly:semgrep:
   stage: test


### PR DESCRIPTION
Moves the `RHIZA_TASK` pin from 1.4.0 to 1.4.1.

All thirteen literals move together, which is the property that matters — a partial bump leaves the shim and the workflows disagreeing about which CLI runs the gates:

- `bundles/core/Makefile` (the root `Makefile` is a dogfood symlink into it, so it follows)
- the six live `.github/workflows/*` — `rhiza_ci` twice (the env var and the `ci-os-matrix` call), plus `rhiza_book`, `rhiza_paper`, `rhiza_weekly`, `rhiza_benchmark`, `rhiza_marimo`
- the five GitLab bundle stubs — `gitlab/rhiza_paper`, `gitlab/rhiza_quality`, `gitlab/rhiza_weekly`, `gitlab-tests/rhiza_ci`, `gitlab-book/rhiza_book`, `gitlab-marimo/rhiza_marimo`

The `v1.4.0 retired the synced make layer` comments are statements about history and stay as they are.

## What is in 1.4.1

One bug fix — [run the setup hook through `sh` where the platform cannot exec it](https://github.com/Jebel-Quant/rhiza-task/releases/tag/v1.4.1).

## Verification

- `make test` — 1693 passed, 46 skipped, coverage 100%
- `make fmt` — all hooks pass, and the `MAKE_HELP_START`/`MAKE_HELP_END` block in README.md is unchanged, so 1.4.1 adds and removes no task
- `RHIZA_E2E=1 pytest tests/e2e/test_setup_hook_e2e.py` — 2 passed: the fix's own chain (`make install` → `setup` → an executable `local-setup.sh`) works at the new pin, against a project assembled from these bundles

Renovate's `RHIZA_TASK` custom manager would have produced the same single grouped PR; this just gets there sooner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
