### PR TITLE
chore: release v1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com),
 and entries are generated from [Conventional Commits](https://www.conventionalcommits.org).
 
+## [1.7.1] - 2026-08-27
+
+### Dependencies
+- *(deps)* Update dependency rhiza-task to v1.4.1 (#1652)
+
+### Other Changes
+- Add logo and favicon to mkdocs configuration (#1650)
+
 ## [1.7.0] - 2026-08-26
 
 ### New Features

--- a/bundles/github-book/.github/workflows/rhiza_book.yml
+++ b/bundles/github-book/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.7.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.7.1
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml
+++ b/bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   devcontainer:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v1.7.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v1.7.1
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-docker/.github/workflows/rhiza_docker.yml
+++ b/bundles/github-docker/.github/workflows/rhiza_docker.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   docker:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v1.7.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v1.7.1
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-marimo/.github/workflows/rhiza_marimo.yml
+++ b/bundles/github-marimo/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.7.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.7.1
     secrets: inherit

--- a/bundles/github-paper/.github/workflows/rhiza_paper.yml
+++ b/bundles/github-paper/.github/workflows/rhiza_paper.yml
@@ -39,7 +39,7 @@ on:
 
 jobs:
   paper:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v1.7.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v1.7.1
     secrets: inherit
     # `contents: write` is for the `paper` branch publish and nothing else. A pull request
     # never reaches that step, so the scope is unused on every PR run.

--- a/bundles/github-quality-review/.github/workflows/rhiza_quality_review.yml
+++ b/bundles/github-quality-review/.github/workflows/rhiza_quality_review.yml
@@ -34,5 +34,5 @@ on:
 
 jobs:
   quality-review:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_quality_review.yml@v1.7.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_quality_review.yml@v1.7.1
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_benchmark.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.7.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.7.1
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_ci.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.7.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.7.1
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_codeql.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.7.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.7.1
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/bundles/github/.github/workflows/rhiza_scorecard.yml
+++ b/bundles/github/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.7.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.7.1
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/bundles/github/.github/workflows/rhiza_weekly.yml
+++ b/bundles/github/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.7.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.7.1
     secrets: inherit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rhiza"
-version = "1.7.0"
+version = "1.7.1"
 description = "Reusable configuration templates for modern Python projects"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -70,7 +70,7 @@ Issues = "https://github.com/jebel-quant/rhiza/issues"
 # python-core bundle no longer ships a `.rhiza/.cfg.toml` copy of this block; the
 # Rust and Go layers ship a root `.bumpversion.toml` instead, since neither
 # language has a discoverable file of its own.
-current_version = "1.7.0"
+current_version = "1.7.1"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:[-]?(?P<release>[a-z]+)[\\.]?(?P<pre_n>\\d+))?(?:\\+build\\.(?P<build_n>\\d+))?"
 serialize = [
     "{major}.{minor}.{patch}-{release}.{pre_n}+build.{build_n}",

--- a/uv.lock
+++ b/uv.lock
@@ -869,7 +869,7 @@ wheels = [
 
 [[package]]
 name = "rhiza"
-version = "1.7.0"
+version = "1.7.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Cuts **v1.7.0 → v1.7.1**, a patch release. It strictly increases past every existing tag (highest is `v1.7.0`).

## What is being released

Two commits since `v1.7.0`, neither marked `feat`, `fix` or breaking:

- `chore(deps)`: the `RHIZA_TASK` pin moves 1.4.0 → 1.4.1 across all thirteen literals (#1652)
- `Add logo and favicon to mkdocs configuration` (#1650)

## Files the bump touched

- `pyproject.toml` — `[project].version` and `[tool.bumpversion].current_version`
- eleven `bundles/**/.github/workflows/*.yml` stubs — their `jebel-quant/rhiza/...@v1.7.0` self-references become `@v1.7.1`, so a repo synced at this tag calls this tag's reusable workflows
- `uv.lock` — regenerated by the `uv-lock` hook (`rhiza v1.7.0 -> v1.7.1`); deliberately not a bumpversion location, since a bare version search there would also rewrite third-party pins
- `CHANGELOG.md` — one prepended section, below

```
## [1.7.1] - 2026-08-27

### Dependencies
- *(deps)* Update dependency rhiza-task to v1.4.1 (#1652)

### Other Changes
- Add logo and favicon to mkdocs configuration (#1650)
```

The live `.github/workflows/` are untouched by design: they carry no self-reference to this repo's tag, which is what keeps a release PR's required checks able to go green.

## Merging this does not publish the release

There is **no tag yet**. The tag is cut afterwards, from the commit this PR actually merges — a second `/rhiza:release` run does that, and pushing the tag is what triggers release CI. The split exists because a squash-merge replaces this branch's commit, so a tag created now would name a SHA that never lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
