### PR TITLE
chore: release v1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com),
 and entries are generated from [Conventional Commits](https://www.conventionalcommits.org).
 
+## [1.7.2] - 2026-09-02
+
+### Bug Fixes
+- Stop the docker job failing on the Dockerfile the template ships (#1651) (#1658)
+
+### Dependencies
+- *(deps)* Lock file maintenance (#1655)
+- *(deps)* Update pre-commit hook astral-sh/uv-pre-commit to v0.12.7 (#1657)
+- *(deps)* Update pre-commit hook astral-sh/ruff-pre-commit to v0.16.5 (#1656)
+- *(deps)* Update pre-commit hook astral-sh/uv-pre-commit to v0.12.9 (#1662)
+- *(deps)* Update dependency rhiza-task to v1.5.0 (#1663)
+
+### Maintenance
+- Chore(deps)(deps): bump the github-actions group with 6 updates (#1661)
+
+### Other Changes
+- [WIP] Add artifact-only deployment option for book workflow (#1660)
+- Update .pre-commit-config.yaml (#1664)
+
 ## [1.7.1] - 2026-08-27
 
 ### Dependencies

--- a/bundles/github-book/.github/workflows/rhiza_book.yml
+++ b/bundles/github-book/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.7.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.7.2
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml
+++ b/bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   devcontainer:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v1.7.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v1.7.2
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-docker/.github/workflows/rhiza_docker.yml
+++ b/bundles/github-docker/.github/workflows/rhiza_docker.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   docker:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v1.7.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v1.7.2
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-marimo/.github/workflows/rhiza_marimo.yml
+++ b/bundles/github-marimo/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.7.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.7.2
     secrets: inherit

--- a/bundles/github-paper/.github/workflows/rhiza_paper.yml
+++ b/bundles/github-paper/.github/workflows/rhiza_paper.yml
@@ -39,7 +39,7 @@ on:
 
 jobs:
   paper:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v1.7.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v1.7.2
     secrets: inherit
     # `contents: write` is for the `paper` branch publish and nothing else. A pull request
     # never reaches that step, so the scope is unused on every PR run.

--- a/bundles/github-quality-review/.github/workflows/rhiza_quality_review.yml
+++ b/bundles/github-quality-review/.github/workflows/rhiza_quality_review.yml
@@ -34,5 +34,5 @@ on:
 
 jobs:
   quality-review:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_quality_review.yml@v1.7.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_quality_review.yml@v1.7.2
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_benchmark.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.7.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.7.2
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_ci.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.7.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.7.2
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_codeql.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.7.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.7.2
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/bundles/github/.github/workflows/rhiza_scorecard.yml
+++ b/bundles/github/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.7.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.7.2
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/bundles/github/.github/workflows/rhiza_weekly.yml
+++ b/bundles/github/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.7.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.7.2
     secrets: inherit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rhiza"
-version = "1.7.1"
+version = "1.7.2"
 description = "Reusable configuration templates for modern Python projects"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -70,7 +70,7 @@ Issues = "https://github.com/jebel-quant/rhiza/issues"
 # python-core bundle no longer ships a `.rhiza/.cfg.toml` copy of this block; the
 # Rust and Go layers ship a root `.bumpversion.toml` instead, since neither
 # language has a discoverable file of its own.
-current_version = "1.7.1"
+current_version = "1.7.2"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:[-]?(?P<release>[a-z]+)[\\.]?(?P<pre_n>\\d+))?(?:\\+build\\.(?P<build_n>\\d+))?"
 serialize = [
     "{major}.{minor}.{patch}-{release}.{pre_n}+build.{build_n}",

--- a/uv.lock
+++ b/uv.lock
@@ -866,7 +866,7 @@ wheels = [
 
 [[package]]
 name = "rhiza"
-version = "1.7.1"
+version = "1.7.2"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Release **v1.7.1 → v1.7.2** (patch). Cut by `/rhiza:release`, phase A.

## Merging this PR does not publish the release

There is **no tag yet**, deliberately. A squash-merge replaces this branch's commit
with a new one, so a tag cut here would name a SHA that never lands on `main`. The
tag is created afterwards, on the merged commit, by a second `/rhiza:release` run.

## Files the bump touched

| File | What moved |
| --- | --- |
| `pyproject.toml` | `[project].version` and `[tool.bumpversion].current_version` |
| `bundles/**/.github/workflows/*.yml` (11 files) | the self-referencing `jebel-quant/rhiza/...@v1.7.1` stub pins → `@v1.7.2` |
| `uv.lock` | the `name = "rhiza"` entry only, regenerated by the `uv-lock` hook |
| `CHANGELOG.md` | one new `## [1.7.2]` section, prepended |

Every location came from a `[[tool.bumpversion.files]]` entry — nothing was hand-edited.
The live `.github/workflows/` are **not** listed and carry no self-reference, so this
PR's own checks do not depend on a tag that does not exist yet.

## Changelog section being added

```
## [1.7.2] - 2026-09-02

### Bug Fixes
- Stop the docker job failing on the Dockerfile the template ships (#1651) (#1658)

### Dependencies
- *(deps)* Lock file maintenance (#1655)
- *(deps)* Update pre-commit hook astral-sh/uv-pre-commit to v0.12.7 (#1657)
- *(deps)* Update pre-commit hook astral-sh/ruff-pre-commit to v0.16.5 (#1656)
- *(deps)* Update pre-commit hook astral-sh/uv-pre-commit to v0.12.9 (#1662)
- *(deps)* Update dependency rhiza-task to v1.5.0 (#1663)

### Maintenance
- Chore(deps)(deps): bump the github-actions group with 6 updates (#1661)

### Other Changes
- [WIP] Add artifact-only deployment option for book workflow (#1660)
- Update .pre-commit-config.yaml (#1664)
```

Prepended with `git-cliff --unreleased --prepend`, so no earlier section was rewritten.

## Why patch

9 unreleased commits: 1 `fix`, 6 `chore(deps)`, 2 untyped. No commit carries `!` or
`BREAKING CHANGE`. The one judgement call is #1660 (artifact-only deployment option for
the book workflow), which adds behaviour but is not typed `feat` — chosen as patch.

## Next step

Review, let the checks run, merge. Then re-run `/rhiza:release`, which will tag the
merged commit and push the tag.
