### PR TITLE
chore(deps): update rhiza-task to v1.6.0, closing #1666, #1667 and #1668

### DIFF
--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -25,7 +25,7 @@ permissions:
 # from a consumer's `RHIZA_TASK`, which this workflow cannot see: it tracks the tag the
 # workflow is called at.
 env:
-  RHIZA_TASK: rhiza-task@1.5.0
+  RHIZA_TASK: rhiza-task@1.6.0
 
 on:
   push:

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -51,7 +51,7 @@ permissions:
 # from a consumer's `RHIZA_TASK`, which this workflow cannot see: it tracks the tag the
 # workflow is called at.
 env:
-  RHIZA_TASK: rhiza-task@1.5.0
+  RHIZA_TASK: rhiza-task@1.6.0
 
   # The LaTeX engine `book`'s `paper` prerequisite needs. Without it that prerequisite
   # *skips* -- `skipped  paper  tectonic not found` -- and `book` still reports ok, so the

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -39,7 +39,7 @@ permissions:
 # see -- and should not: the gates a build runs must not move under it. It tracks the tag
 # this workflow is called at, the same rule the OS-matrix step below states for its pin.
 env:
-  RHIZA_TASK: rhiza-task@1.5.0
+  RHIZA_TASK: rhiza-task@1.6.0
 
 on:
   push:
@@ -130,7 +130,7 @@ jobs:
             ${{ github.repository == 'jebel-quant/rhiza'
                 && '["ubuntu-latest","macos-latest"]' || '' }}
         run: |
-          OS_MATRIX=$(uvx rhiza-task@1.5.0 ci-os-matrix)
+          OS_MATRIX=$(uvx rhiza-task@1.6.0 ci-os-matrix)
           echo "list=$OS_MATRIX" >> "$GITHUB_OUTPUT"
 
       - name: Debug OS matrix

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -245,15 +245,22 @@ jobs:
         with:
           token: ${{ secrets.GH_PAT }}
 
-      - name: Install project with lowest-direct resolution
+      - name: Run the suite at the declared dependency floors (test-lowest gate)
+        # Delegated to rhiza-task's `test-lowest`, which is what closes #1666. The two
+        # steps this replaced called plain `uv`, so they bypassed the task graph -- and
+        # `setup` with it, which is the single insertion point a repository's
+        # `local-setup.sh` hangs off. A project whose suite needs a native binary
+        # (Graphviz's `dot`, in the report) therefore got a green `test` and a red job
+        # here on identical code, reporting a resolution problem that was really a
+        # missing tool on the runner: the inverted silent-green shape, where the
+        # diagnosis points at the wrong thing rather than at nothing.
+        #
+        # Arriving through `install` also means the gate shares `_pytest_args` instead of
+        # restating it. The copy had already drifted -- it omitted `-n auto`, so this job
+        # ran single-process while `test` ran under xdist.
         env:
           UV_EXTRA_INDEX_URL: ${{ secrets.UV_EXTRA_INDEX_URL }}
-        run: uv sync --all-extras --all-groups --resolution lowest-direct
-
-      - name: Run tests with lowest-direct resolution
-        env:
-          UV_EXTRA_INDEX_URL: ${{ secrets.UV_EXTRA_INDEX_URL }}
-        run: uv run --all-extras --all-groups --resolution lowest-direct pytest tests -q --ignore=tests/stress --ignore=tests/benchmarks
+        run: uvx "$RHIZA_TASK" test-lowest
 
   typecheck:
     name: Type checking (Python ${{ matrix.python-version }})

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -82,7 +82,7 @@ jobs:
           #
           # Pinned for the reason the OS matrix is pinned (#1546): the folder a build
           # discovers notebooks in must not move under a workflow called at a tag.
-          NOTEBOOK_DIR=$(uvx rhiza-task@1.5.0 print marimo_folder)
+          NOTEBOOK_DIR=$(uvx rhiza-task@1.6.0 print marimo_folder)
 
           echo "Searching notebooks in: $NOTEBOOK_DIR"
           # Check if directory exists

--- a/.github/workflows/rhiza_paper.yml
+++ b/.github/workflows/rhiza_paper.yml
@@ -45,7 +45,7 @@ env:
   # The rhiza-task pin the compile runs through. Pinned rather than read from a consumer's
   # `RHIZA_TASK`, which a reusable workflow cannot see: it tracks the tag this workflow is
   # called at, so a repository synced at a release compiles with that release's task.
-  RHIZA_TASK: rhiza-task@1.5.0
+  RHIZA_TASK: rhiza-task@1.6.0
 
   # The LaTeX engine the `paper` task drives. tectonic is a single static binary that
   # resolves what a document cites out of its own web bundle, which is why this workflow no

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -27,7 +27,7 @@ permissions:
 # CLI rather than `core`'s `Makefile` so they do not depend on a front door this workflow
 # neither ships nor can verify.
 env:
-  RHIZA_TASK: rhiza-task@1.5.0
+  RHIZA_TASK: rhiza-task@1.6.0
 
 on:
   #push:

--- a/README.md
+++ b/README.md
@@ -344,6 +344,10 @@ Run `make help` for a complete list of 40+ available targets.
  security            Python          install               run the bandit       
                                                            security scan        
  test                Python          install               run all tests        
+ test-lowest         Python          install               run the tests        
+                                                           against the oldest   
+                                                           dependencies the     
+                                                           manifest allows      
  typecheck           Python          install               run ty and/or mypy   
                                                            (typechecker = ty |  
                                                            mypy | both)         
@@ -368,6 +372,9 @@ Run `make help` for a complete list of 40+ available targets.
  todos               Quality                               list every TODO,     
                                                            FIXME and HACK       
                                                            comment              
+ update              Template                              sync the rhiza       
+                                                           template into this   
+                                                           repository           
  benchmark           Testing extras  install               run the performance  
                                                            benchmarks           
  hypothesis-test     Testing extras  install               run the              

--- a/bundles/core/Makefile
+++ b/bundles/core/Makefile
@@ -18,7 +18,7 @@
 # Repo-specific *tasks* go in a `rhiza_task.tasks` entry point, repo-specific *targets* in
 # `local.mk`, which core deliberately does not ignore. Nothing goes below the shim: this
 # file is synced, so the next `/rhiza:update` overwrites whatever was appended to it.
-RHIZA_TASK ?= rhiza-task@1.5.0
+RHIZA_TASK ?= rhiza-task@1.6.0
 
 # uv cannot be delegated, because uv is what runs the CLI. Prepended so a machine carrying
 # an older uv still resolves the pin, exported because task bodies shell out to bare `uv`.

--- a/bundles/gitlab-book/.gitlab/workflows/rhiza_book.yml
+++ b/bundles/gitlab-book/.gitlab/workflows/rhiza_book.yml
@@ -35,7 +35,7 @@ pages:
     - export UV_EXTRA_INDEX_URL="${UV_EXTRA_INDEX_URL}"
     - |
       # The musl build: statically linked, so it runs in whatever container $UV_IMAGE is.
-      folder=$(uvx rhiza-task@1.5.0 print paper-folder)
+      folder=$(uvx rhiza-task@1.6.0 print paper-folder)
       if [ -n "$(find "${folder}" -maxdepth 1 -name '*.tex' 2>/dev/null | head -1)" ]; then
         url="https://github.com/tectonic-typesetting/tectonic/releases/download"
         url="${url}/tectonic%40${TECTONIC_VERSION}/tectonic-${TECTONIC_VERSION}-x86_64-unknown-linux-musl.tar.gz"

--- a/bundles/gitlab-marimo/.gitlab/workflows/rhiza_marimo.yml
+++ b/bundles/gitlab-marimo/.gitlab/workflows/rhiza_marimo.yml
@@ -37,7 +37,7 @@ marimo:notebooks:
       #
       # The version is pinned rather than read from RHIZA_TASK: this pipeline cannot see a
       # consumer's Makefile, and a value a job depends on must not move under it.
-      NOTEBOOK_DIR=$(uvx rhiza-task@1.5.0 print marimo_folder 2>/dev/null || echo "marimo")
+      NOTEBOOK_DIR=$(uvx rhiza-task@1.6.0 print marimo_folder 2>/dev/null || echo "marimo")
       echo "Searching notebooks in: $NOTEBOOK_DIR"
 
       if [ ! -d "$NOTEBOOK_DIR" ]; then

--- a/bundles/gitlab-tests/.gitlab/workflows/rhiza_ci.yml
+++ b/bundles/gitlab-tests/.gitlab/workflows/rhiza_ci.yml
@@ -16,7 +16,7 @@
 # on a front door it neither ships nor can verify.
 
 variables:
-  RHIZA_TASK: "rhiza-task@1.5.0"
+  RHIZA_TASK: "rhiza-task@1.6.0"
 
 ci:test:
   # CI budget: ≤20 min (test matrix execution). Last measured: 2026-05-28.

--- a/bundles/gitlab/.gitlab/workflows/rhiza_paper.yml
+++ b/bundles/gitlab/.gitlab/workflows/rhiza_paper.yml
@@ -25,7 +25,7 @@
 # texlive-* packages. Both are watched by custom managers in the mother repo's
 # renovate.json; an unmanaged pin only ages (#1579).
 variables:
-  RHIZA_TASK: "rhiza-task@1.5.0"
+  RHIZA_TASK: "rhiza-task@1.6.0"
   TECTONIC_VERSION: "0.17.0"
 
 paper:build:

--- a/bundles/gitlab/.gitlab/workflows/rhiza_quality.yml
+++ b/bundles/gitlab/.gitlab/workflows/rhiza_quality.yml
@@ -18,7 +18,7 @@
 # on a front door it neither ships nor can verify.
 
 variables:
-  RHIZA_TASK: "rhiza-task@1.5.0"
+  RHIZA_TASK: "rhiza-task@1.6.0"
 
 quality:deptry:
   stage: test

--- a/bundles/gitlab/.gitlab/workflows/rhiza_weekly.yml
+++ b/bundles/gitlab/.gitlab/workflows/rhiza_weekly.yml
@@ -19,7 +19,7 @@
 # on a front door it neither ships nor can verify.
 
 variables:
-  RHIZA_TASK: "rhiza-task@1.5.0"
+  RHIZA_TASK: "rhiza-task@1.6.0"
 
 weekly:semgrep:
   stage: test

--- a/tests/api/test_ci_workflow.py
+++ b/tests/api/test_ci_workflow.py
@@ -69,6 +69,34 @@ def test_ci_security_job_runs_security_scans(root):
     assert any('uvx "$RHIZA_TASK" security' in run for run in run_steps)
 
 
+def test_ci_lowest_deps_job_reaches_pytest_through_the_task_graph(root):
+    """The floors job must delegate to ``test-lowest`` rather than calling ``uv`` itself.
+
+    This is #1666, and the assertion is about the *route* rather than the resolution flags.
+    The job used to run ``uv sync --resolution lowest-direct`` and then
+    ``uv run ... pytest`` directly, which reaches the suite without passing through
+    ``install`` -- and therefore without ``setup``, the single insertion point a
+    repository's ``local-setup.sh`` hangs off. A project whose tests need a native binary
+    got a green ``test`` and a red job here on the same commit, blaming a dependency floor
+    for a tool that was never installed.
+
+    So a bare ``uv`` call is what this forbids. Asserting only the presence of
+    ``test-lowest`` would still pass on a job that ran both, which is the state that
+    reintroduces the bug while looking fixed.
+    """
+    with (root / WORKFLOW_PATH).open(encoding="utf-8") as fh:
+        workflow = yaml.safe_load(fh)
+
+    run_steps = [step.get("run", "") for step in workflow["jobs"]["lowest-deps"].get("steps", [])]
+
+    assert any('uvx "$RHIZA_TASK" test-lowest' in run for run in run_steps), (
+        "the floors job must delegate to rhiza-task's `test-lowest`"
+    )
+    assert not any(re.search(r"(?<![-\w])uv (sync|run)\b", run) for run in run_steps), (
+        "a bare `uv sync`/`uv run` here bypasses `install`, and `setup` with it -- see #1666"
+    )
+
+
 def test_ci_jobs_define_timeout_budgets(root):
     """CI jobs must define explicit timeout budgets."""
     with (root / WORKFLOW_PATH).open(encoding="utf-8") as fh:

--- a/tests/bundles/test_gitlab_ci.py
+++ b/tests/bundles/test_gitlab_ci.py
@@ -54,6 +54,30 @@ GITLAB_PROJECT_BUNDLES = [
 # Pinned so a gitlab-ci-local release cannot silently change validation behaviour.
 GITLAB_CI_LOCAL_VERSION = "4.73.0"
 
+# What the pinned tool is allowed, and what the subprocess call below passes.
+GITLAB_CI_LOCAL_TIMEOUT = 600
+
+# The pytest-timeout budget for the two network-bound tests in this module, and the reason
+# it is declared here rather than inherited.
+#
+# pytest.ini sets a global ``timeout = 60``. That is right for a suite which is almost
+# entirely in-process, and wrong for these two, whose work is a package download and a
+# series of registry round-trips. ``npx --yes`` fetches gitlab-ci-local before it validates
+# anything -- measured at 67s on a cold cache -- so the global budget could not cover the
+# *setup* of the check, never mind the check. The image test sums the same way: one
+# ``_manifest_status`` call is up to three requests at 20s each, per image, and there are
+# currently more than seven images.
+#
+# **The ordering is the whole point: this must exceed the inner allowances, not sit under
+# them.** While the subprocess was allowed 600s and the test 60, the inner number was
+# decoration -- pytest-timeout always won, and what it left behind was a traceback into
+# ``subprocess._communicate`` naming neither the command nor its captured output, where
+# ``subprocess.run``'s own ``TimeoutExpired`` reports both. A slow npm day therefore failed
+# every job in the matrix with a diagnosis that pointed at pytest. The job's
+# ``timeout-minutes`` is the backstop against a genuine hang; that is its job, not this
+# marker's.
+NETWORK_TEST_TIMEOUT = GITLAB_CI_LOCAL_TIMEOUT + 60
+
 _NPX = shutil.which("npx")
 _GIT = shutil.which("git") or "/usr/bin/git"
 
@@ -319,7 +343,7 @@ def _run_gitlab_ci_local(project: Path, *args: str) -> subprocess.CompletedProce
         cwd=project,
         capture_output=True,
         text=True,
-        timeout=600,
+        timeout=GITLAB_CI_LOCAL_TIMEOUT,
     )
 
 
@@ -328,6 +352,7 @@ def _run_gitlab_ci_local(project: Path, *args: str) -> subprocess.CompletedProce
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.timeout(NETWORK_TEST_TIMEOUT)
 def test_pipeline_images_exist(gitlab_project: Path, root: Path) -> None:
     """Every container image the GitLab pipeline / Dockerfiles reference must exist.
 
@@ -363,6 +388,7 @@ def test_pipeline_images_exist(gitlab_project: Path, root: Path) -> None:
 
 @_skip_on_windows
 @pytest.mark.skipif(_NPX is None, reason="npx (Node.js) not available; gitlab-ci-local cannot run")
+@pytest.mark.timeout(NETWORK_TEST_TIMEOUT)
 def test_pipeline_schema_validates(gitlab_project: Path) -> None:
     """gitlab-ci-local must resolve every include and validate the merged schema.
 


### PR DESCRIPTION
Moves the `rhiza-task` pin from 1.5.0 to 1.6.0, and takes the one workflow change the bump enables.

That release exists to fix three issues filed here today, all escalated upstream with the same resolution path — fixed in rhiza-task, arrives here by a pin bump:

| here | upstream | what 1.6.0 does |
| --- | --- | --- |
| #1667 | rhiza-task#170 | `typecheck` provisions the checkers at a configured version |
| #1668 | rhiza-task#171 | `install` clears pre-commit's legacy hook instead of entering migration mode |
| #1666 | rhiza-task#169 | `test-lowest` exists, so the floors job has something to delegate to |

Closes #1666, closes #1667, closes #1668.

## The bump was blocked when this started

1.6.0 was a **draft** GitHub release created this morning with the release run still in flight, and not on PyPI. Pinning it then would have made `uvx rhiza-task@1.6.0` fail in every workflow and every consumer's `make`. Waited for the publish, then bumped.

## Commit 1 — the pin

All 14 literals, in 13 files: `RHIZA_TASK` in `bundles/core/Makefile`, the six root `.github/workflows/*` copies (including the inline `uvx rhiza-task@… ci-os-matrix` and `print marimo_folder` calls, not only the `RHIZA_TASK:` env vars), and the seven GitLab bundle workflows. They move together because `test_renovate_managers.py` asserts the pin agrees with itself across files, and `test_bundle_cli_targets.py` asks that exact version what tasks it has.

**#1667 — the typechecker is pinned now.** `ty_version` defaults to `==0.0.78` where `--with ty` previously carried no constraint. The issue measured it: one warning locally, where the project's lock supplied ty 0.0.18 for `--with ty` to reuse, against ~24 errors on a runner that had none — same commit. `mypy_version` is deliberately empty, mypy being post-1.0. This repo is clean under the pin.

**#1668 — the prek hook.** Upstream took the conditional route rather than a bare `-f`, which is the alternative the issue's own follow-up comment proposed: it forces only when the hook in place carries pre-commit's `File generated by pre-commit` header, so a hand-written `.git/hooks/pre-commit` is not overwritten on every gate. It also asks git where the hooks live (`rev-parse --git-path`), so a linked worktree or submodule — the checkouts most likely to be carrying a legacy hook — is not silently reported clean.

## Commit 2 — #1666, the floors job

This is the one part that needed a change **here**, and the issue said so: *"The workflow change here follows whatever name lands there."* The name is `test-lowest`.

The `lowest-deps` job called plain `uv` twice, bypassing the task graph and `setup` with it — the single insertion point a repository's `local-setup.sh` hangs off. In the report (janushendersonassetallocation/loman) Graphviz's `dot` was absent, so the job blamed a dependency floor for a missing tool: the silent-green shape inverted, and worse for it, since the diagnosis sends you to the manifest.

Two steps became `uvx "$RHIZA_TASK" test-lowest`. Beyond the fix that buys:

- **The gate shares `_pytest_args`** instead of restating it. The hand-rolled copy had already drifted by a flag — it omitted `-n auto`, so this job ran single-process while `test` ran under xdist.
- **`--isolated`**, which keeps the answer free of charge. A bare `--resolution lowest-direct` re-resolves the project environment in place and leaves `.venv` and `uv.lock` downgraded — invisible on a runner, a gate that rewrites a tracked file on a developer's machine. Verified: the tree is clean after `make test-lowest`.

`test_ci_lowest_deps_job_reaches_pytest_through_the_task_graph` asserts the route in **both** directions — `test-lowest` present *and* no bare `uv sync`/`uv run`. Presence alone would pass on a job that ran both, which is the state that reintroduces the bug while looking fixed.

The `github-tests` stub needs no change: it delegates through `jobs.ci` to this reusable workflow.

## A gap this surfaced, left open deliberately

`README.md`'s `MAKE_HELP` block gained two rows: `test-lowest`, new in 1.6.0 — and `update`, which dates from an **earlier** pin. That second row is the tell.

CLAUDE.md states the block "is regenerated from `make help` by the `update-readme-help` hook on every `make fmt`". True for `bundles/python-core`, `rust-core` and `go-core`, which all ship that hook. But the mother repo's root `.pre-commit-config.yaml` is an intentional override that **omits it**, so it has never run here and the block drifts silently on every pin move. The shape CLAUDE.md warns about elsewhere: a claim confident enough that nobody checks whether the thing it describes still happens.

Regenerated here by invoking the hook from rhiza-hooks v1.3.0 directly, rather than hand-editing. The gap is **not** fixed, because the fix is a judgment call rather than part of a bump — add `update-readme-help` to the root config so the block self-maintains, or correct the CLAUDE.md paragraph. The first is the better trade; either belongs in its own change.

## Verification

| gate | result |
| --- | --- |
| `test-lowest` | 1704 passed at the floors, `setup` firing |
| `test` | 1705 passed, 46 skipped; `utils` at 100% (90% bar) |
| `typecheck` | ok — `ty==0.0.78` and `mypy --strict` both clean |
| `fmt` | ok — 20 hooks |
| `rhiza-test` | 35 passed |

`make e2e` is opt-in and toolchain-gated, so CI is the only place the Rust and Go layers meet this pin at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
