### PR TITLE
chore: release v1.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com),
 and entries are generated from [Conventional Commits](https://www.conventionalcommits.org).
 
+## [1.7.3] - 2026-09-04
+
+### Dependencies
+- *(deps)* Update rhiza-task to v1.6.0, closing #1666, #1667 and #1668 (#1669)
+
 ## [1.7.2] - 2026-09-02
 
 ### Bug Fixes

--- a/bundles/github-book/.github/workflows/rhiza_book.yml
+++ b/bundles/github-book/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.7.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.7.3
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml
+++ b/bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   devcontainer:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v1.7.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v1.7.3
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-docker/.github/workflows/rhiza_docker.yml
+++ b/bundles/github-docker/.github/workflows/rhiza_docker.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   docker:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v1.7.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v1.7.3
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-marimo/.github/workflows/rhiza_marimo.yml
+++ b/bundles/github-marimo/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.7.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.7.3
     secrets: inherit

--- a/bundles/github-paper/.github/workflows/rhiza_paper.yml
+++ b/bundles/github-paper/.github/workflows/rhiza_paper.yml
@@ -39,7 +39,7 @@ on:
 
 jobs:
   paper:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v1.7.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v1.7.3
     secrets: inherit
     # `contents: write` is for the `paper` branch publish and nothing else. A pull request
     # never reaches that step, so the scope is unused on every PR run.

--- a/bundles/github-quality-review/.github/workflows/rhiza_quality_review.yml
+++ b/bundles/github-quality-review/.github/workflows/rhiza_quality_review.yml
@@ -34,5 +34,5 @@ on:
 
 jobs:
   quality-review:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_quality_review.yml@v1.7.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_quality_review.yml@v1.7.3
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_benchmark.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.7.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.7.3
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_ci.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.7.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.7.3
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_codeql.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.7.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.7.3
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/bundles/github/.github/workflows/rhiza_scorecard.yml
+++ b/bundles/github/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.7.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.7.3
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/bundles/github/.github/workflows/rhiza_weekly.yml
+++ b/bundles/github/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.7.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.7.3
     secrets: inherit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rhiza"
-version = "1.7.2"
+version = "1.7.3"
 description = "Reusable configuration templates for modern Python projects"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -70,7 +70,7 @@ Issues = "https://github.com/jebel-quant/rhiza/issues"
 # python-core bundle no longer ships a `.rhiza/.cfg.toml` copy of this block; the
 # Rust and Go layers ship a root `.bumpversion.toml` instead, since neither
 # language has a discoverable file of its own.
-current_version = "1.7.2"
+current_version = "1.7.3"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:[-]?(?P<release>[a-z]+)[\\.]?(?P<pre_n>\\d+))?(?:\\+build\\.(?P<build_n>\\d+))?"
 serialize = [
     "{major}.{minor}.{patch}-{release}.{pre_n}+build.{build_n}",

--- a/uv.lock
+++ b/uv.lock
@@ -866,7 +866,7 @@ wheels = [
 
 [[package]]
 name = "rhiza"
-version = "1.7.2"
+version = "1.7.3"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Version bump **v1.7.2 → v1.7.3**, cut from `main` at `dca2251c`.

## Why patch

One unreleased commit — `chore(deps): update rhiza-task to v1.6.0 (#1669)` — a
dependency pin bump. No `feat`, `fix` or breaking commit is in the log; git-cliff
files it under **Dependencies**.

## Files the bump touched

`bump-my-version` rewrote only what `[tool.bumpversion]` declares:

- `pyproject.toml` — `[project].version` and `current_version`
- 11 bundle CI stubs under `bundles/**/.github/workflows/*.yml` — the
  `jebel-quant/rhiza/...@vX.Y.Z` self-pins, so a downstream repo syncing v1.7.3
  gets stubs that delegate to v1.7.3's reusable workflows rather than v1.7.2's

Plus `uv.lock`, regenerated with `uv lock` (its `name = "rhiza"` entry is
deliberately outside the bumpversion config, since a bare version search there
would also rewrite third-party pins that happen to share the number).

The live `.github/workflows/*` are untouched by design — they pin
`jebel-quant/actions` by SHA, which carries that repo's version, not this one's.

## Changelog

One section prepended, nothing else in the file changed:

```
## [1.7.3] - 2026-09-04

### Dependencies
- *(deps)* Update rhiza-task to v1.6.0, closing #1666, #1667 and #1668 (#1669)
```

## Merging this does not publish the release

There is no tag yet. The tag is cut afterwards, from the commit this PR merges
as, by a second `/rhiza:release` run — which is what makes it survive a
squash-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
