### PR TITLE
ci: name the failing jobs in the CI gate's error annotation

### DIFF
--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -547,18 +547,35 @@ jobs:
           egress-policy: audit
 
       - name: Verify test, typecheck, lowest-deps and rhiza-test succeeded
+        # The ::error:: annotation names the jobs that did not succeed, and their
+        # results. That annotation is what appears in the checks list and in the PR's
+        # merge box, so "and/or" spent a click sending the reader into the job log to
+        # learn something this step had already computed.
+        #
+        # "cancelled" is still accepted alongside "success", deliberately and
+        # unchanged: see tests/api/test_workflow_stubs.py::
+        # test_ci_gate_tolerates_cancelled_results and the run it cites. Rejecting it
+        # is a separate question from how the failure is reported.
         run: |
-          echo "test result:        ${{ needs.test.result }}"
-          echo "typecheck result:   ${{ needs.typecheck.result }}"
-          echo "lowest-deps result: ${{ needs.lowest-deps.result }}"
-          echo "rhiza-test result:  ${{ needs.rhiza-test.result }}"
-          # Accept "success" or "cancelled" (transient runner cancellation).
-          # Reject "failure" (real failure) and "skipped" (job never ran).
-          if [[ "${{ needs.test.result }}" != "success" && "${{ needs.test.result }}" != "cancelled" \
-             || "${{ needs.typecheck.result }}" != "success" && "${{ needs.typecheck.result }}" != "cancelled" \
-             || "${{ needs.lowest-deps.result }}" != "success" && "${{ needs.lowest-deps.result }}" != "cancelled" \
-             || "${{ needs.rhiza-test.result }}" != "success" && "${{ needs.rhiza-test.result }}" != "cancelled" ]]; then
-            echo "::error::test, typecheck, lowest-deps and/or rhiza-test did not succeed; failing the CI gate."
+          failed=""
+          for entry in \
+            "test:${{ needs.test.result }}" \
+            "typecheck:${{ needs.typecheck.result }}" \
+            "lowest-deps:${{ needs.lowest-deps.result }}" \
+            "rhiza-test:${{ needs.rhiza-test.result }}"; do
+            name="${entry%%:*}"
+            result="${entry#*:}"
+            printf '%-12s result: %s\n' "$name" "$result"
+            # Accept "success" or "cancelled" (transient runner cancellation).
+            # Reject "failure" (real failure) and "skipped" (job never ran).
+            case "$result" in
+              success|cancelled) ;;
+              *) failed="${failed:+$failed, }$name ($result)" ;;
+            esac
+          done
+
+          if [ -n "$failed" ]; then
+            echo "::error::CI gate failed -- $failed. See those job(s) for the cause."
             exit 1
           fi
           echo "All required CI jobs succeeded."


### PR DESCRIPTION
The roll-up gate reports the same sentence whichever leg is red:

> `test, typecheck, lowest-deps and/or rhiza-test did not succeed; failing the CI gate.`

That string is the `::error::` annotation, which is what appears in the checks list and
in the PR's merge box — so the reader opens the job to learn something the step had
already computed and echoed one line above.

## What changes

The four-way `if` becomes a loop that collects the offenders and interpolates them:

```
CI gate failed -- lowest-deps (failure). See those job(s) for the cause.
```

and with several:

```
CI gate failed -- test (failure), lowest-deps (skipped). See those job(s) for the cause.
```

The per-job `result:` lines are kept — they are useful when the gate passes too.

## What does not change

**The accept-set is identical.** `success` and `cancelled` pass; `failure` and `skipped`
fail. I checked the truth table against the old boolean rather than assuming:

| test | typecheck | lowest-deps | rhiza-test | before | after |
|---|---|---|---|---|---|
| success | success | success | success | pass | pass |
| success | success | failure | success | fail | fail |
| failure | success | skipped | failure | fail | fail |
| success | cancelled | success | success | pass | pass |

## Verification

- `tests/api/test_ci_workflow.py` and `tests/api/test_workflow_stubs.py`: **48 passed**,
  unchanged. That includes the two tests that constrain this step —
  `test_ci_gate_rolls_up_rhiza_test` (the script must still read
  `needs.rhiza-test.result`) and `test_ci_gate_tolerates_cancelled_results` (it must
  still accept `cancelled`).
- `actionlint` passes.
- The loop was exercised directly over the four cases in the table above.

## A question rather than a change — @tschm

While reading this I wondered whether `cancelled` should keep counting as a pass, and
then found `test_ci_gate_tolerates_cancelled_results`, which pins it to a specific run
where a transient cancellation blocked a PR. So it is a deliberate answer to a real
incident, not an oversight — which is exactly why I have not touched it here.

The question I would still put to you: the gate is a **required** status check, so
`cancelled → pass` means a required gate can go green over a job that did not finish.
With `cancel-in-progress: true` the usual case is the whole run being superseded, and
the gate is cancelled along with everything else, so nothing false is reported. The
exposure is the narrower one where an individual leg is cancelled while the gate still
runs.

Is that worth distinguishing — for example, treating `cancelled` as a pass only when
the gate itself was not part of the same cancellation — or does the transient-runner
case make that more trouble than it is worth? Happy to follow up with whichever you
prefer, including leaving it exactly as it is. I did not want to change the semantics
of a gate that protects the default branch on my own reading of it.

## Context

Found while migrating janushendersonassetallocation/loman from rhiza v0.10.3 to v1.7.2.
The consumer's reaction to the annotation was to ask whether the gate was doing anything
useful at all — it is, and the ruleset shows why: `ci / CI gate` is the required context
standing in for the matrix jobs, whose per-leg names are generated and so cannot be named
in branch protection. Naming the culprit makes that job easier to trust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
