### PR TITLE
feat: derive rhiza's own version from the git tag

### DIFF
--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -56,7 +56,10 @@
 #   - SBOM attestations generated for supply chain transparency (public repos only)
 #
 # 📄 Requirements:
-#   - pyproject.toml with top-level version field (for Python packages)
+#   - pyproject.toml declaring a version (for Python packages): either written as
+#     `[project].version`, or listed in `[project].dynamic` for the build backend to
+#     derive from the VCS (hatch-vcs, setuptools-scm). A derived version is checked
+#     against the tag on the built distribution rather than in the file.
 #   - Package registered on PyPI as Trusted Publisher (for PyPI publishing)
 #   - Conda recipe generation is optional and only runs when PyPI publishing is active
 #   - PUBLISH_DEVCONTAINER variable set to "true" (for devcontainer publishing)
@@ -269,16 +272,47 @@ jobs:
 
       - name: Verify version matches tag
         if: hashFiles('pyproject.toml') != ''
+        env:
+          # Read from the environment, not interpolated into the script: that is what
+          # lets tests/api/test_release_version_verification.py run this exact shell
+          # against purpose-built projects instead of asserting on the step's name.
+          TAG: ${{ needs.tag.outputs.tag }}
         run: |
-          TAG_VERSION="${{ needs.tag.outputs.tag }}"
-          TAG_VERSION=${TAG_VERSION#v}
-          PROJECT_VERSION=$(uv version --short)
+          TAG_VERSION="${TAG#v}"
 
           # Normalize tag version to PEP 440 format for comparison.
           # Tags use semver format (e.g., 0.11.1-beta.1) while uv version --short
           # returns PEP 440 normalized format (e.g., 0.11.1b1).
           NORMALIZED_TAG=$(uv run --with packaging --no-project python3 -c "from packaging.version import Version; print(Version('$TAG_VERSION'))")
 
+          # A project may derive its version from the VCS rather than write one: PEP 621's
+          # `dynamic = ["version"]` with a backend plugin such as hatch-vcs. There is then
+          # no number in the file to compare, and `uv version --short` does not return a
+          # differing one -- it exits 2 ("We cannot get or set dynamic project versions"),
+          # which would fail every release of such a project. The tag-versus-version check
+          # moves to "Verify built distribution matches the tag" below, which is where a
+          # derived version can actually be wrong.
+          DYNAMIC=$(uv run --with tomli --no-project python3 -c "
+          import pathlib, tomli
+          project = tomli.loads(pathlib.Path('pyproject.toml').read_text()).get('project') or {}
+          print('dynamic' if 'version' in (project.get('dynamic') or []) else 'written')")
+
+          case "$DYNAMIC" in
+            dynamic)
+              echo "[project].version is dynamic: derived from the VCS, so there is no written number to compare against $NORMALIZED_TAG. The distribution built below is checked against the tag instead."
+              exit 0
+              ;;
+            written)
+              ;;
+            *)
+              # Never assume "written": that would call `uv version --short` on a dynamic
+              # project and fail with an error about the probe, not about the release.
+              echo "::error::Could not tell whether [project].version is written or dynamic (probe returned '$DYNAMIC')"
+              exit 1
+              ;;
+          esac
+
+          PROJECT_VERSION=$(uv version --short)
           if [[ "$PROJECT_VERSION" != "$NORMALIZED_TAG" ]]; then
             echo "::error::Version mismatch: pyproject.toml has '$PROJECT_VERSION' but tag is '$NORMALIZED_TAG' (from tag '$TAG_VERSION')"
             exit 1
@@ -299,6 +333,52 @@ jobs:
         run: |
           printf "[INFO] Building package...\n"
           uv build
+
+      - name: Verify built distribution matches the tag
+        if: steps.buildable.outputs.buildable == 'true'
+        env:
+          TAG: ${{ needs.tag.outputs.tag }}
+        run: |
+          # The only place a version *derived* from the VCS can be caught being wrong.
+          # hatch-vcs and setuptools-scm fall back rather than fail, so a checkout that
+          # cannot see the tag builds `0.1.dev1+g<sha>` and publishes it under a green
+          # tick with no error anywhere -- which is why the checkout above uses
+          # fetch-depth: 0. Runs for a written version too: it costs one filename parse
+          # and closes the gap between what the step above read and what `uv build`
+          # actually produced.
+          TAG_VERSION="${TAG#v}"
+          uv run --with packaging --no-project python3 -c '
+          import pathlib
+          import sys
+
+          from packaging.utils import parse_sdist_filename, parse_wheel_filename
+          from packaging.version import Version
+
+          expected = Version(sys.argv[1])
+          dist = pathlib.Path("dist")
+          built = sorted(dist.glob("*.whl")) + sorted(dist.glob("*.tar.gz"))
+          if not built:
+              print("::error::uv build produced no distribution in dist/ -- there is nothing to publish or verify")
+              sys.exit(1)
+
+          mismatched = []
+          for artifact in built:
+              parse = parse_wheel_filename if artifact.name.endswith(".whl") else parse_sdist_filename
+              found = parse(artifact.name)[1]
+              print(f"{artifact.name}: {found}")
+              if found != expected:
+                  mismatched.append(f"{artifact.name} carries {found}")
+
+          if mismatched:
+              print(
+                  f"::error::Built distribution does not carry the release version {expected}: "
+                  + ", ".join(mismatched)
+                  + ". A version derived from the VCS falls back to a dev version when the tag "
+                  "is not visible to the build -- check the checkout depth and that tags were fetched."
+              )
+              sys.exit(1)
+          print(f"Built distribution verified at {expected}")
+          ' "$TAG_VERSION"
 
       - name: Install Python for SBOM generation
         if: hashFiles('pyproject.toml') != ''

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,36 @@ Two things do not follow from it, and both are worth knowing before reaching for
   rather than fail: a clone with no tags derives `0.1.dev1+g<sha>`, so a distribution built
   from a shallow checkout is published at a version nobody asked for, with a green build and
   no error anywhere — the same silent shape as #1505, #1511, #1516 and #1535, reached through
-  a checkout depth. Any job that builds a distribution needs `fetch-depth: 0`.
+  a checkout depth. Any job that builds a distribution needs `fetch-depth: 0`, and the
+  release workflow now *checks* that rather than only documenting it — see below.
+
+**rhiza itself derives its version now, and adopting the shape it documents meant fixing
+the release path first.** The mother repo is the thin end of the case: it is a uv *virtual*
+project — no `[build-system]`, nothing built, nothing published — so there is no backend to
+derive a version *for* anything, and none is needed. Git's tag was already the only source
+`/rhiza:release` and the `@vX.Y.Z` stub pins read. What changes is that the number stops
+being written down: `[project]` carries `dynamic = ["version"]`, `[tool.bumpversion]` keeps
+its table and loses `current_version` (the newest tag matching `tag_name` answers instead,
+exactly as in rust-core's and go-core's synced configs), the `[[files]]` entry for
+pyproject.toml goes with the line it used to rewrite, and `uv lock` records `(dynamic)`
+where it recorded a version.
+
+**`rhiza_release.yml` was what blocked it, for every consumer as much as here.** Its
+`Verify version matches tag` step called `uv version --short` unconditionally — and on a
+dynamic project that does not return a number that differs, it exits **2** ("We cannot get
+or set dynamic project versions"). So the workflow rhiza ships failed *every* release of a
+repo that adopted the shape the section above declares legal, in the one job whose failure
+means no release at all. The step now probes the declaration and, when it is dynamic, says
+so and skips; the tag-versus-version comparison moves to a second step, **`Verify built
+distribution matches the tag`**, which parses the version out of what `uv build` wrote into
+`dist/`. That is the honest place for it: a derived version cannot disagree with the file
+(there is none) but it can very much be *wrong*, and being wrong looks exactly like the
+`0.1.dev1+g<sha>` fallback in the bullet above. It runs for a written version too, since it
+costs one filename parse and closes the gap between what the earlier step read and what the
+build actually produced — and it does not run at all for a project that builds nothing,
+which is why this repo's own release is verified by the tag job alone.
+`tests/api/test_release_version_verification.py` runs both scripts, lifted out of the YAML,
+against fixture projects in all three shapes; the GitLab twin carries the same two halves.
 
 `/rhiza:release` handles the shape, and needed a fix to: it tells its two phases apart by
 comparing the declared version against the highest tag, and on a derived version the two are
@@ -762,7 +791,7 @@ be invisible in the output of the gate this repo runs most, which is the shape o
 
 This repo runs on **GitHub Actions only**: `.github/workflows/` — CI, e2e, release, docker, CodeQL, weekly, sync. There is no root `.gitlab-ci.yml` here.
 
-`rhiza_release.yml`'s `Validate Tag` job is the only gate the release path has, so all three of its checks are behavioural, not advisory: the release must not already exist, the version must be strictly newer than every published tag (#1126), and the tagged commit must be reachable from a branch (#1454). The last one exists because a release cut on a branch that is then squash-merged leaves its tag on the pre-squash commit, which nothing contains — `git describe` skips the release and a git-cliff regeneration *deletes* that version's CHANGELOG section, silently. A tag on a non-default branch (a maintenance release) warns rather than fails; only a genuinely orphaned commit is refused. `tests/api/test_release_tag_reachability.py` lifts that guard's shell out of the YAML and runs it against purpose-built repositories, so the logic is tested rather than the step name.
+`rhiza_release.yml`'s `Validate Tag` job is the only gate the release path has before anything is built, so all three of its checks are behavioural, not advisory: the release must not already exist, the version must be strictly newer than every published tag (#1126), and the tagged commit must be reachable from a branch (#1454). The last one exists because a release cut on a branch that is then squash-merged leaves its tag on the pre-squash commit, which nothing contains — `git describe` skips the release and a git-cliff regeneration *deletes* that version's CHANGELOG section, silently. A tag on a non-default branch (a maintenance release) warns rather than fails; only a genuinely orphaned commit is refused. `tests/api/test_release_tag_reachability.py` lifts that guard's shell out of the YAML and runs it against purpose-built repositories, so the logic is tested rather than the step name.
 
 `rhiza_e2e.yml` is separate from `rhiza_ci.yml` rather than more jobs inside it: it installs three toolchains CI does not otherwise need, costs minutes per layer against CI's ≤20 min test budget, and is the only place the Rust and Go layers execute at all (see **Language layers** above).
 

--- a/bundles/github/.github/workflows/rhiza_release.yml
+++ b/bundles/github/.github/workflows/rhiza_release.yml
@@ -67,7 +67,10 @@
 #   - SBOM attestations generated for supply chain transparency (public repos only)
 #
 # 📄 Requirements:
-#   - pyproject.toml with top-level version field (for Python packages)
+#   - pyproject.toml declaring a version (for Python packages): either written as
+#     `[project].version`, or listed in `[project].dynamic` for the build backend to
+#     derive from the VCS (hatch-vcs, setuptools-scm). A derived version is checked
+#     against the tag on the built distribution rather than in the file.
 #   - Package registered on PyPI as Trusted Publisher (for PyPI publishing)
 #   - Conda recipe generation is optional and only runs when PyPI publishing is active
 #   - PUBLISH_DEVCONTAINER variable set to "true" (for devcontainer publishing)
@@ -270,16 +273,47 @@ jobs:
 
       - name: Verify version matches tag
         if: hashFiles('pyproject.toml') != ''
+        env:
+          # Read from the environment, not interpolated into the script: that is what
+          # lets tests/api/test_release_version_verification.py run this exact shell
+          # against purpose-built projects instead of asserting on the step's name.
+          TAG: ${{ needs.tag.outputs.tag }}
         run: |
-          TAG_VERSION="${{ needs.tag.outputs.tag }}"
-          TAG_VERSION=${TAG_VERSION#v}
-          PROJECT_VERSION=$(uv version --short)
+          TAG_VERSION="${TAG#v}"
 
           # Normalize tag version to PEP 440 format for comparison.
           # Tags use semver format (e.g., 0.11.1-beta.1) while uv version --short
           # returns PEP 440 normalized format (e.g., 0.11.1b1).
           NORMALIZED_TAG=$(uv run --with packaging --no-project python3 -c "from packaging.version import Version; print(Version('$TAG_VERSION'))")
 
+          # A project may derive its version from the VCS rather than write one: PEP 621's
+          # `dynamic = ["version"]` with a backend plugin such as hatch-vcs. There is then
+          # no number in the file to compare, and `uv version --short` does not return a
+          # differing one -- it exits 2 ("We cannot get or set dynamic project versions"),
+          # which would fail every release of such a project. The tag-versus-version check
+          # moves to "Verify built distribution matches the tag" below, which is where a
+          # derived version can actually be wrong.
+          DYNAMIC=$(uv run --with tomli --no-project python3 -c "
+          import pathlib, tomli
+          project = tomli.loads(pathlib.Path('pyproject.toml').read_text()).get('project') or {}
+          print('dynamic' if 'version' in (project.get('dynamic') or []) else 'written')")
+
+          case "$DYNAMIC" in
+            dynamic)
+              echo "[project].version is dynamic: derived from the VCS, so there is no written number to compare against $NORMALIZED_TAG. The distribution built below is checked against the tag instead."
+              exit 0
+              ;;
+            written)
+              ;;
+            *)
+              # Never assume "written": that would call `uv version --short` on a dynamic
+              # project and fail with an error about the probe, not about the release.
+              echo "::error::Could not tell whether [project].version is written or dynamic (probe returned '$DYNAMIC')"
+              exit 1
+              ;;
+          esac
+
+          PROJECT_VERSION=$(uv version --short)
           if [[ "$PROJECT_VERSION" != "$NORMALIZED_TAG" ]]; then
             echo "::error::Version mismatch: pyproject.toml has '$PROJECT_VERSION' but tag is '$NORMALIZED_TAG' (from tag '$TAG_VERSION')"
             exit 1
@@ -300,6 +334,52 @@ jobs:
         run: |
           printf "[INFO] Building package...\n"
           uv build
+
+      - name: Verify built distribution matches the tag
+        if: steps.buildable.outputs.buildable == 'true'
+        env:
+          TAG: ${{ needs.tag.outputs.tag }}
+        run: |
+          # The only place a version *derived* from the VCS can be caught being wrong.
+          # hatch-vcs and setuptools-scm fall back rather than fail, so a checkout that
+          # cannot see the tag builds `0.1.dev1+g<sha>` and publishes it under a green
+          # tick with no error anywhere -- which is why the checkout above uses
+          # fetch-depth: 0. Runs for a written version too: it costs one filename parse
+          # and closes the gap between what the step above read and what `uv build`
+          # actually produced.
+          TAG_VERSION="${TAG#v}"
+          uv run --with packaging --no-project python3 -c '
+          import pathlib
+          import sys
+
+          from packaging.utils import parse_sdist_filename, parse_wheel_filename
+          from packaging.version import Version
+
+          expected = Version(sys.argv[1])
+          dist = pathlib.Path("dist")
+          built = sorted(dist.glob("*.whl")) + sorted(dist.glob("*.tar.gz"))
+          if not built:
+              print("::error::uv build produced no distribution in dist/ -- there is nothing to publish or verify")
+              sys.exit(1)
+
+          mismatched = []
+          for artifact in built:
+              parse = parse_wheel_filename if artifact.name.endswith(".whl") else parse_sdist_filename
+              found = parse(artifact.name)[1]
+              print(f"{artifact.name}: {found}")
+              if found != expected:
+                  mismatched.append(f"{artifact.name} carries {found}")
+
+          if mismatched:
+              print(
+                  f"::error::Built distribution does not carry the release version {expected}: "
+                  + ", ".join(mismatched)
+                  + ". A version derived from the VCS falls back to a dev version when the tag "
+                  "is not visible to the build -- check the checkout depth and that tags were fetched."
+              )
+              sys.exit(1)
+          print(f"Built distribution verified at {expected}")
+          ' "$TAG_VERSION"
 
       - name: Install Python for SBOM generation
         if: hashFiles('pyproject.toml') != ''

--- a/bundles/gitlab/.gitlab/workflows/rhiza_release.yml
+++ b/bundles/gitlab/.gitlab/workflows/rhiza_release.yml
@@ -19,7 +19,10 @@
 #   - For custom feeds, use PYPI_REPOSITORY_URL and PYPI_TOKEN variables
 #
 # 📄 Requirements:
-#   - pyproject.toml with top-level version field (for Python packages)
+#   - pyproject.toml declaring a version (for Python packages): either written as
+#     `[project].version`, or listed in `[project].dynamic` for the build backend to
+#     derive from the VCS (hatch-vcs, setuptools-scm). A derived version is checked
+#     against the tag on the built distribution rather than in the file.
 #   - PYPI_TOKEN variable for PyPI publishing
 #
 # ✅ To Trigger:
@@ -144,19 +147,80 @@ release:build:
       # Verify version matches tag
       if [ -f "pyproject.toml" ]; then
         TAG_VERSION="${CI_COMMIT_TAG#v}"
-        PROJECT_VERSION=$(uv version --short)
 
-        if [ "$PROJECT_VERSION" != "$TAG_VERSION" ]; then
-          echo "❌ Version mismatch: pyproject.toml has '$PROJECT_VERSION' but tag is '$TAG_VERSION'"
-          exit 1
-        fi
-        echo "✅ Version verified: $PROJECT_VERSION matches tag"
+        # A project may derive its version from the VCS rather than write one: PEP 621's
+        # `dynamic = ["version"]` with a backend plugin such as hatch-vcs. There is then no
+        # number in the file to compare, and `uv version --short` does not return a
+        # differing one -- it exits 2 ("We cannot get or set dynamic project versions"),
+        # which would fail every release of such a project. The check moves to the built
+        # distribution below, which is where a derived version can actually be wrong.
+        DYNAMIC=$(uv run --with tomli --no-project python3 -c "
+        import pathlib, tomli
+        project = tomli.loads(pathlib.Path('pyproject.toml').read_text()).get('project') or {}
+        print('dynamic' if 'version' in (project.get('dynamic') or []) else 'written')")
+
+        case "$DYNAMIC" in
+          dynamic)
+            echo "ℹ️ [project].version is dynamic: derived from the VCS, so there is no written number to compare against $TAG_VERSION"
+            ;;
+          written)
+            PROJECT_VERSION=$(uv version --short)
+            if [ "$PROJECT_VERSION" != "$TAG_VERSION" ]; then
+              echo "❌ Version mismatch: pyproject.toml has '$PROJECT_VERSION' but tag is '$TAG_VERSION'"
+              exit 1
+            fi
+            echo "✅ Version verified: $PROJECT_VERSION matches tag"
+            ;;
+          *)
+            # Never assume "written": that would call `uv version --short` on a dynamic
+            # project and fail with an error about the probe, not about the release.
+            echo "❌ Could not tell whether [project].version is written or dynamic (probe returned '$DYNAMIC')"
+            exit 1
+            ;;
+        esac
       fi
 
       # Detect buildable Python package
       if [ -f "pyproject.toml" ] && grep -q '^\[build-system\]' pyproject.toml; then
         echo "📦 Building package..."
         uv build
+
+        # The only place a version *derived* from the VCS can be caught being wrong:
+        # hatch-vcs and setuptools-scm fall back rather than fail, so a shallow clone
+        # builds `0.1.dev1+g<sha>` and publishes it with a green pipeline and no error
+        # anywhere. GIT_DEPTH must therefore reach the tag; this is what says so out loud.
+        uv run --with packaging --no-project python3 -c '
+        import pathlib
+        import sys
+
+        from packaging.utils import parse_sdist_filename, parse_wheel_filename
+        from packaging.version import Version
+
+        expected = Version(sys.argv[1])
+        dist = pathlib.Path("dist")
+        built = sorted(dist.glob("*.whl")) + sorted(dist.glob("*.tar.gz"))
+        if not built:
+            print("❌ uv build produced no distribution in dist/ -- there is nothing to publish or verify")
+            sys.exit(1)
+
+        mismatched = []
+        for artifact in built:
+            parse = parse_wheel_filename if artifact.name.endswith(".whl") else parse_sdist_filename
+            found = parse(artifact.name)[1]
+            print(f"{artifact.name}: {found}")
+            if found != expected:
+                mismatched.append(f"{artifact.name} carries {found}")
+
+        if mismatched:
+            print(
+                f"❌ Built distribution does not carry the release version {expected}: "
+                + ", ".join(mismatched)
+                + ". A version derived from the VCS falls back to a dev version when the tag "
+                "is not visible to the build -- check GIT_DEPTH and that tags were fetched."
+            )
+            sys.exit(1)
+        print(f"✅ Built distribution verified at {expected}")
+        ' "${CI_COMMIT_TAG#v}"
       else
         echo "⏭️ No buildable package detected, skipping build"
         mkdir -p dist  # Create empty dist directory

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,24 @@
 [project]
 name = "rhiza"
-version = "1.7.3"
+# Derived from the git tag, not written here — the second shape python-core permits, and
+# the one that leaves this repo's version in exactly one place. There is no build backend
+# to derive it *for* a consumer of the metadata, and nothing needs one: rhiza is a uv
+# *virtual* project (no `[build-system]`, nothing built, nothing published — see the
+# kill-switch classifier below), so the only thing that ever read a written number was the
+# release path, which now reads the tag it is cutting.
+#
+# Two consequences worth knowing before touching this. `uv lock` records `(dynamic)` where
+# it used to record a version, so the third copy that used to fall behind a release cannot
+# exist. And `uv version` exits 2 by design ("We cannot get or set dynamic project
+# versions"), which is why rhiza_release.yml's "Verify version matches tag" step detects a
+# dynamic declaration and skips rather than calling it — the tag-versus-version comparison
+# lives in "Verify built distribution matches the tag", the step that only runs for a
+# project that builds one.
+#
+# PEP 621 allows a version to be written or listed in `dynamic`, never both and never
+# neither; pytest-rhiza's `test_pyproject` asserts exactly that, and skips its six
+# written-version assertions here because a version read from git cannot disagree with git.
+dynamic = ["version"]
 description = "Reusable configuration templates for modern Python projects"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -70,7 +88,15 @@ Issues = "https://github.com/jebel-quant/rhiza/issues"
 # python-core bundle no longer ships a `.rhiza/.cfg.toml` copy of this block; the
 # Rust and Go layers ship a root `.bumpversion.toml` instead, since neither
 # language has a discoverable file of its own.
-current_version = "1.7.3"
+#
+# No `current_version`, deliberately, since [project].version is dynamic: there is no
+# written number for it to agree with, and a second copy here is exactly the drift the
+# dynamic declaration removes. bump-my-version then reads the current version from the
+# newest tag matching `tag_name` (default `v{new_version}`) — the same mechanism
+# rust-core's and go-core's synced `.bumpversion.toml` rely on, and the signal
+# `/rhiza:release` reads to tell a tag-derived repo from one with a written version.
+# Before the first tag it fails with "Unable to determine the current version", which is
+# a declared location with nothing in it yet, not a missing config.
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:[-]?(?P<release>[a-z]+)[\\.]?(?P<pre_n>\\d+))?(?:\\+build\\.(?P<build_n>\\d+))?"
 serialize = [
     "{major}.{minor}.{patch}-{release}.{pre_n}+build.{build_n}",
@@ -88,13 +114,11 @@ tag = false
 optional_value = "prod"
 values = ["dev", "alpha", "a", "beta", "b", "rc", "prod"]
 
-# Anchored to the [project] table: an unanchored `version = "..."` search would
-# also rewrite any [tool.*] table that happens to share the current number.
-[[tool.bumpversion.files]]
-filename = "pyproject.toml"
-regex = true
-search = '(?ms)^\[project\]((?:(?!^\[)[\s\S])*?)^version = "{current_version}"'
-replace = '[project]\1version = "{new_version}"'
+# pyproject.toml is deliberately absent from the list below: [project] carries
+# `dynamic = ["version"]`, so there is no `version = "..."` line for a bump to rewrite.
+# The entry that used to sit here was anchored to the [project] table precisely so an
+# unanchored search could not also rewrite a [tool.*] table sharing the number — a hazard
+# that goes away with the line it was guarding.
 
 # The live workflows under .github/workflows/ are deliberately NOT listed, and
 # neither is any pin of jebel-quant/actions. configure-git-auth lives in that
@@ -180,9 +204,10 @@ typechecker = "both"
 # it can compare. So this line's job is now to keep the pin managed, not to keep it ahead.
 #
 # 0.6.0 collects the same five modules and the same 35 checks as 0.5.0 on this repo. Its one
-# behavioural change is a *relaxation* of a check the mother repo does not exercise:
-# `test_pyproject` now accepts a `[project].version` derived from the VCS, and this repo
-# declares a literal one.
+# behavioural change is what makes the dynamic `[project].version` above legal at all:
+# `test_pyproject` accepts a version derived from the VCS, where 0.5.0 required a written
+# one and matched it against a semver pattern. So this pin is a floor for this repo rather
+# than only a managed number — reverting it below 0.6.0 fails `make rhiza-test`.
 pytest-rhiza = "pytest-rhiza==0.6.0"
 
 # Restores this repo's own book override, which the migration to the shim dropped. The old root

--- a/tests/api/test_release_version_verification.py
+++ b/tests/api/test_release_version_verification.py
@@ -1,0 +1,378 @@
+"""Behavioural tests for the release workflow's version checks.
+
+The ``build`` job answers one question twice: does the thing being released actually
+carry the version the tag names? For a project that *writes* its version, reading
+``pyproject.toml`` answers it. For one that derives it from the VCS — PEP 621's
+``dynamic = ["version"]`` with a backend plugin such as hatch-vcs, which rhiza itself
+now uses — there is nothing written to read, and ``uv version --short`` does not return
+a differing number: it exits 2 with "We cannot get or set dynamic project versions". The
+step that called it unconditionally therefore failed *every* release of such a project,
+which is why the check is in two halves now:
+
+- ``Verify version matches tag`` compares the written number, and says so and skips when
+  the declaration is dynamic.
+- ``Verify built distribution matches the tag`` compares what ``uv build`` produced. That
+  is where a derived version can actually be wrong, and the failure it catches is silent
+  otherwise: hatch-vcs and setuptools-scm fall back rather than fail, so a checkout that
+  cannot see the tag builds ``0.1.dev1+g<sha>`` and publishes it under a green tick.
+
+Both are run here as shell, lifted out of the workflow YAML the way
+``test_release_tag_reachability.py`` runs the reachability guard, so a rewrite that keeps
+the step name but breaks the logic still fails. The scripts read their tag from ``TAG``
+in the environment rather than from an interpolated ``${{ }}`` expression, which is what
+makes that possible at all.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess  # nosec B404 - running the workflow's own shell against fixture projects
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+import yaml
+
+_ROOT = Path(__file__).resolve().parents[2]
+_BASH = shutil.which("bash")
+_UV = shutil.which("uv")
+
+_LIVE_WORKFLOW = _ROOT / ".github" / "workflows" / "rhiza_release.yml"
+_BUNDLE_WORKFLOW = _ROOT / "bundles" / "github" / ".github" / "workflows" / "rhiza_release.yml"
+
+_WRITTEN_STEP = "Verify version matches tag"
+_BUILT_STEP = "Verify built distribution matches the tag"
+
+
+def _step(workflow: Path, name: str) -> dict:
+    """Return the single ``build`` step with this name.
+
+    Args:
+        workflow: The release workflow to read.
+        name: The step's ``name:``.
+
+    Returns:
+        The step mapping.
+    """
+    steps = yaml.safe_load(workflow.read_text(encoding="utf-8"))["jobs"]["build"]["steps"]
+    matching = [step for step in steps if step.get("name") == name]
+    assert len(matching) == 1, (
+        f"{workflow.relative_to(_ROOT)}: expected exactly one '{name}' step in the build job, found {len(matching)}"
+    )
+    return matching[0]
+
+
+def _run(script: str, cwd: Path, tag: str) -> subprocess.CompletedProcess:
+    """Execute a step's shell the way the workflow would.
+
+    Args:
+        script: The step's ``run:`` body.
+        cwd: The project directory to run it in.
+        tag: The value of ``TAG``, i.e. the release tag.
+
+    Returns:
+        The completed process.
+    """
+    assert _BASH is not None  # guarded by the skipif on the classes below
+    return subprocess.run(  # nosec B603
+        # `-e` because that is how GitHub invokes a `run:` block (`bash -e {0}`): a probe
+        # that cannot run must fail the step rather than fall through to a branch chosen
+        # from an empty variable.
+        [_BASH, "-e", "-c", script],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "TAG": tag},
+    )
+
+
+def _project(directory: Path, body: str) -> Path:
+    """Write a minimal ``pyproject.toml`` and return its directory.
+
+    Args:
+        directory: Where to write it.
+        body: The ``[project]`` lines that follow ``name``.
+
+    Returns:
+        The directory, for chaining.
+    """
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "pyproject.toml").write_text(
+        f'[project]\nname = "demo"\n{body}requires-python = ">=3.11"\ndependencies = []\n',
+        encoding="utf-8",
+    )
+    return directory
+
+
+@pytest.fixture(scope="module")
+def uv_provisioning() -> None:
+    """Skip the module when uv cannot provision the scripts' ephemeral dependencies.
+
+    Both steps reach for `uv run --with ...`, so offline they fail for a reason that has
+    nothing to do with the logic under test — the same trade
+    ``test_bundle_cli_targets.py`` makes. CI has a network, where the distinction stops
+    mattering.
+    """
+    if _UV is None:
+        pytest.skip("uv not available; the workflow's version checks are uv scripts")
+    result = subprocess.run(  # nosec B603
+        [_UV, "run", "--with", "tomli", "--with", "packaging", "--no-project", "python3", "-c", "import tomli"],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=300,
+    )
+    if result.returncode != 0:
+        pytest.skip(f"uv cannot provision tomli/packaging (offline?):\n{result.stderr[-400:]}")
+
+
+@pytest.fixture(scope="module")
+def written_check() -> str:
+    """The written-version check as shipped in the bundle (what downstream repos run).
+
+    Returns:
+        The step's shell.
+    """
+    return _step(_BUNDLE_WORKFLOW, _WRITTEN_STEP)["run"]
+
+
+@pytest.fixture(scope="module")
+def built_check() -> str:
+    """The built-distribution check as shipped in the bundle.
+
+    Returns:
+        The step's shell.
+    """
+    return _step(_BUNDLE_WORKFLOW, _BUILT_STEP)["run"]
+
+
+class TestBothChecksAreWiredIntoBothWorkflows:
+    """Structural half: the steps exist, agree across the two copies, and are ordered."""
+
+    @pytest.mark.parametrize("name", [_WRITTEN_STEP, _BUILT_STEP])
+    def test_live_and_bundle_workflows_share_one_script(self, name: str) -> None:
+        """The mother repo's live workflow and the synced bundle must run the same check.
+
+        The two files differ by design (SHA-pinned actions here, tag-pinned downstream),
+        so nothing byte-compares them — but a check that exists only upstream protects
+        exactly the repo that never had the problem.
+
+        Args:
+            name: The step whose shell is compared.
+        """
+        assert _step(_LIVE_WORKFLOW, name)["run"] == _step(_BUNDLE_WORKFLOW, name)["run"]
+
+    @pytest.mark.parametrize("workflow", [_LIVE_WORKFLOW, _BUNDLE_WORKFLOW])
+    def test_each_check_reads_the_tag_from_the_environment(self, workflow: Path) -> None:
+        """`TAG` must come through ``env:``, not be interpolated into the shell.
+
+        Interpolating ``${{ needs.tag.outputs.tag }}`` into the script would put a tag
+        chosen by whoever pushed it into a shell command, and would leave the logic
+        untestable outside Actions — which is how it went unnoticed that the step could
+        not run on a dynamic version at all.
+
+        Args:
+            workflow: The release workflow to read.
+        """
+        for name in (_WRITTEN_STEP, _BUILT_STEP):
+            step = _step(workflow, name)
+            assert step.get("env", {}).get("TAG") == "${{ needs.tag.outputs.tag }}", (
+                f"{workflow.relative_to(_ROOT)}: '{name}' must take the tag from env.TAG"
+            )
+            assert "needs.tag.outputs.tag" not in step["run"], (
+                f"{workflow.relative_to(_ROOT)}: '{name}' interpolates the tag into its shell"
+            )
+
+    @pytest.mark.parametrize("workflow", [_LIVE_WORKFLOW, _BUNDLE_WORKFLOW])
+    def test_the_built_distribution_is_checked_after_the_build(self, workflow: Path) -> None:
+        """A check that runs before ``uv build`` would measure a stale or absent dist/.
+
+        Args:
+            workflow: The release workflow to read.
+        """
+        names = [
+            step.get("name") for step in yaml.safe_load(workflow.read_text(encoding="utf-8"))["jobs"]["build"]["steps"]
+        ]
+        assert names.index(_BUILT_STEP) > names.index("Build"), (
+            f"{workflow.relative_to(_ROOT)}: '{_BUILT_STEP}' must follow the Build step"
+        )
+
+    @pytest.mark.parametrize("workflow", [_LIVE_WORKFLOW, _BUNDLE_WORKFLOW])
+    def test_the_built_distribution_check_is_gated_on_a_buildable_project(self, workflow: Path) -> None:
+        """It shares the Build step's condition: a virtual project produces no dist/.
+
+        Args:
+            workflow: The release workflow to read.
+        """
+        condition = _step(workflow, _BUILT_STEP)["if"]
+        assert condition == _step(workflow, "Build")["if"], (
+            f"{workflow.relative_to(_ROOT)}: '{_BUILT_STEP}' must run exactly when Build does"
+        )
+
+
+def test_this_repo_declares_its_version_in_exactly_one_place() -> None:
+    """Rhiza's own version is the git tag — and all three halves of that must agree.
+
+    ``[project]`` deriving the version while ``[tool.bumpversion]`` still carries a
+    ``current_version`` (or a ``[[files]]`` entry naming pyproject.toml) would put the
+    number back in a file, and a release would then bump a copy nothing reads. The
+    absent ``current_version`` is also the signal ``/rhiza:release`` uses to tell a
+    tag-derived repo from one with a written version, so it is load-bearing rather than
+    tidy.
+    """
+    config = tomllib.loads((_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+    assert "version" in config["project"].get("dynamic", []), (
+        "[project] must derive its version from the VCS; see the comment above `dynamic`"
+    )
+    assert "version" not in config["project"], "[project] cannot both write a version and list it in `dynamic`"
+
+    bumpversion = config["tool"]["bumpversion"]
+    assert "current_version" not in bumpversion, (
+        "[tool.bumpversion] must not carry a version of its own — it is read from the newest tag"
+    )
+    assert not [entry for entry in bumpversion.get("files", []) if entry.get("filename") == "pyproject.toml"], (
+        "there is no `version = ...` line in pyproject.toml for a bump to rewrite"
+    )
+
+
+@pytest.mark.skipif(
+    _BASH is None or sys.platform == "win32",
+    reason=(
+        "these are GitHub Actions `run:` steps, and the release job they belong to runs on "
+        "ubuntu-latest only — executing their shell through Git Bash would exercise the MSYS "
+        "argument-translation layer rather than the checks. The structural tests above still "
+        "run on every platform."
+    ),
+)
+@pytest.mark.usefixtures("uv_provisioning")
+class TestTheWrittenVersionCheck:
+    """Run the written-version check against the three shapes a project can have."""
+
+    def test_a_written_version_matching_the_tag_passes(self, written_check: str, tmp_path: Path) -> None:
+        """The ordinary case.
+
+        Args:
+            written_check: The step's shell.
+            tmp_path: pytest's temporary directory.
+        """
+        project = _project(tmp_path / "match", 'version = "1.2.3"\n')
+
+        result = _run(written_check, project, "v1.2.3")
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "Version verified: 1.2.3" in result.stdout
+
+    def test_a_written_version_that_differs_from_the_tag_fails(self, written_check: str, tmp_path: Path) -> None:
+        """The failure the step exists for, named in an operator-facing annotation.
+
+        Args:
+            written_check: The step's shell.
+            tmp_path: pytest's temporary directory.
+        """
+        project = _project(tmp_path / "mismatch", 'version = "1.2.2"\n')
+
+        result = _run(written_check, project, "v1.2.3")
+
+        assert result.returncode == 1, result.stdout + result.stderr
+        assert "::error::Version mismatch" in result.stdout
+
+    def test_a_dynamic_version_is_reported_and_not_compared(self, written_check: str, tmp_path: Path) -> None:
+        """The regression this split exists for: `uv version --short` must not be called.
+
+        A project on hatch-vcs has no written number, and calling uv for one exits 2 —
+        failing a release that is perfectly well-formed. The step must say what it did
+        instead of passing silently, since a check that measures nothing reads exactly
+        like one that passed.
+
+        Args:
+            written_check: The step's shell.
+            tmp_path: pytest's temporary directory.
+        """
+        project = _project(tmp_path / "dynamic", 'dynamic = ["version"]\n')
+
+        result = _run(written_check, project, "v1.2.3")
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "dynamic" in result.stdout
+        assert "::error::" not in result.stdout
+
+
+@pytest.mark.skipif(
+    _BASH is None or sys.platform == "win32",
+    reason="see TestTheWrittenVersionCheck — the release job runs on ubuntu-latest only",
+)
+@pytest.mark.usefixtures("uv_provisioning")
+class TestTheBuiltDistributionCheck:
+    """Run the artifact check against the distributions a build can leave behind.
+
+    The filenames are fabricated rather than built: the step parses names, so a real
+    ``uv build`` would only add a toolchain dependency and the wait for it. What matters
+    is that the dev-version fallback is refused and the tagged version is not.
+    """
+
+    @staticmethod
+    def _dist(directory: Path, *names: str) -> Path:
+        """Create ``dist/`` holding empty files with these names.
+
+        Args:
+            directory: The project directory to create.
+            names: The distribution filenames.
+
+        Returns:
+            The project directory.
+        """
+        dist = directory / "dist"
+        dist.mkdir(parents=True, exist_ok=True)
+        for name in names:
+            (dist / name).touch()
+        return directory
+
+    def test_a_distribution_at_the_tag_version_passes(self, built_check: str, tmp_path: Path) -> None:
+        """Both artifacts carry the released version.
+
+        Args:
+            built_check: The step's shell.
+            tmp_path: pytest's temporary directory.
+        """
+        project = self._dist(tmp_path / "ok", "demo-1.2.3-py3-none-any.whl", "demo-1.2.3.tar.gz")
+
+        result = _run(built_check, project, "v1.2.3")
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "Built distribution verified at 1.2.3" in result.stdout
+
+    def test_a_dev_version_from_an_invisible_tag_is_refused(self, built_check: str, tmp_path: Path) -> None:
+        """The silent failure: setuptools-scm/hatch-vcs fall back instead of failing.
+
+        A shallow checkout, or one without tags, derives ``0.1.dev1+g<sha>`` — and every
+        earlier step in the release is green, so without this the wrong version reaches
+        PyPI with no error anywhere.
+
+        Args:
+            built_check: The step's shell.
+            tmp_path: pytest's temporary directory.
+        """
+        project = self._dist(tmp_path / "devfallback", "demo-0.1.dev1-py3-none-any.whl", "demo-0.1.dev1.tar.gz")
+
+        result = _run(built_check, project, "v1.2.3")
+
+        assert result.returncode == 1, result.stdout + result.stderr
+        assert "::error::Built distribution does not carry the release version 1.2.3" in result.stdout
+        assert "fetch" in result.stdout, "the annotation must name the checkout as the thing to look at"
+
+    def test_an_empty_dist_is_refused(self, built_check: str, tmp_path: Path) -> None:
+        """A build that produced nothing must not read as a verified release.
+
+        Args:
+            built_check: The step's shell.
+            tmp_path: pytest's temporary directory.
+        """
+        project = self._dist(tmp_path / "empty")
+
+        result = _run(built_check, project, "v1.2.3")
+
+        assert result.returncode == 1, result.stdout + result.stderr
+        assert "no distribution in dist/" in result.stdout

--- a/tests/deps/test_dependency_health.py
+++ b/tests/deps/test_dependency_health.py
@@ -13,12 +13,19 @@ def _load_pyproject(root):
 
 
 def test_pyproject_has_required_project_metadata(root):
-    """Verify that pyproject.toml declares required basic project metadata."""
+    """Verify that pyproject.toml declares required basic project metadata.
+
+    ``version`` is required to be *declared*, not to be written: PEP 621 lets a project
+    derive it from the VCS by listing it in ``dynamic``, which is what this repo does. This
+    check listed it among the string fields until then, which is the same shape pytest-rhiza
+    relaxed in its ``test_pyproject`` (pytest-rhiza#96) — a repo doing the right thing failed
+    for having no number in the file.
+    """
     pyproject = _load_pyproject(root)
     project = pyproject.get("project")
     assert isinstance(project, dict), "[project] section missing from pyproject.toml"
 
-    required_fields = ["name", "version", "description", "readme", "requires-python"]
+    required_fields = ["name", "description", "readme", "requires-python"]
     missing = [field for field in required_fields if field not in project]
     assert not missing, f"Missing required [project] fields in pyproject.toml: {', '.join(missing)}"
 
@@ -26,6 +33,13 @@ def test_pyproject_has_required_project_metadata(root):
         value = project[field]
         assert isinstance(value, str), f"[project].{field} must be a string"
         assert value.strip(), f"[project].{field} cannot be empty"
+
+    written = isinstance(project.get("version"), str) and project["version"].strip()
+    derived = "version" in project.get("dynamic", [])
+    assert written or derived, (
+        "[project] must either write `version` or list it in `dynamic` for the build backend to derive from the VCS"
+    )
+    assert not (written and derived), "[project] cannot both write `version` and list it in `dynamic`"
 
 
 def test_pyproject_has_dependency_groups_section(root):

--- a/tests/test_suite_structure.py
+++ b/tests/test_suite_structure.py
@@ -93,6 +93,10 @@ _CONTROLS = {
 _NOT_DERIVERS = {
     "tests/integration/test_sbom.py": "runs `uvx cyclonedx-bom`; the pin is not involved",
     "tests/security/test_security_patterns.py": "runs `uvx bandit` out-of-tree; the pin is not involved",
+    # It runs the release workflow's own `run:` blocks, which reach for `uv run --with
+    # tomli/packaging`. Nothing about the pinned CLI, and nothing derived: every expectation
+    # is a literal version written into a fixture project.
+    "tests/api/test_release_version_verification.py": "runs `uv run --with tomli`; the pin is not involved",
     # This module matches its own detector: `_NAMES_UV` and `_TOUCHES_THE_PIN` are literals in
     # the source above. It reads files and never runs anything.
     "tests/test_suite_structure.py": "holds the detector's own patterns as string literals",

--- a/uv.lock
+++ b/uv.lock
@@ -866,7 +866,6 @@ wheels = [
 
 [[package]]
 name = "rhiza"
-version = "1.7.3"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## What

Two halves of one change: rhiza stops writing its own version down, and the release workflow it ships stops failing on repos that do the same.

### rhiza's version is the tag now

- `[project]` carries `dynamic = ["version"]`. rhiza is a uv *virtual* project — no `[build-system]`, nothing built, nothing published — so there is no backend to derive a version *for* anything, and none is needed: the tag was already the only source `/rhiza:release` and the `@vX.Y.Z` stub pins read.
- `[tool.bumpversion]` keeps its table and loses `current_version`; the newest tag matching `tag_name` answers instead, exactly as in rust-core's and go-core's synced configs. The absent key is also the signal `/rhiza:release` reads to tell a tag-derived repo from one with a written version (rhiza-claude#225).
- The `[[files]]` entry for `pyproject.toml` goes with the line it used to rewrite; the stub-pin glob stays.
- `uv lock` records `(dynamic)` where it recorded a version.

Verified against the tools rather than assumed: `bump-my-version show current_version` → `1.7.3` from the tag, and a real `bump --new-version 1.7.4` rewrites all 11 stub pins and touches `pyproject.toml` not at all. `uv lock --check` passes.

### The release path had to be fixed first, and for every consumer

`rhiza_release.yml`'s `Verify version matches tag` called `uv version --short` unconditionally. On a dynamic project that does not return a number that differs — it exits **2** (`We cannot get or set dynamic project versions`). So the workflow rhiza ships failed *every* release of a repo that adopted the shape #1679 declared legal, in the one job whose failure means no release at all.

- The step now probes the declaration and, when it is dynamic, says so and exits 0.
- The tag-versus-version comparison moves to a new step, **`Verify built distribution matches the tag`**, which parses the version out of what `uv build` wrote into `dist/`. That is the honest place for it: a derived version cannot disagree with a file that holds no number, but it can be *wrong* — and being wrong looks exactly like the `0.1.dev1+g<sha>` fallback a checkout that cannot see the tag produces. The `fetch-depth: 0` requirement CLAUDE.md warned about is now checked instead of documented.
- It runs for a written version too (one filename parse, and it closes the gap between what the earlier step read and what the build produced), and not at all for a project that builds nothing — so this repo's own release stays verified by the tag job alone.
- Both copies (live + `bundles/github`) and the GitLab twin carry both halves.

## Tests

- `tests/api/test_release_version_verification.py` (new): lifts both `run:` blocks out of the YAML and runs their actual shell against fixture projects — written-match, written-mismatch, dynamic; tagged dist, dev-fallback dist, empty dist — plus structural checks (live ≡ bundle, ordered after `Build`, same `if` as `Build`, tag read from `env:`) and one asserting rhiza's three version halves agree. Both steps read `TAG` from `env:` rather than interpolating the tag output, which is what makes that possible at all.
- `tests/deps/test_dependency_health.py` required `version` as a string in `[project]` — the same trap pytest-rhiza#96 fixed upstream, where a repo doing the right thing failed for having no number in the file. It now requires the version to be *declared*, written or dynamic, and refuses both.
- `tests/test_suite_structure.py`: the new module is declared in `_NOT_DERIVERS` (it runs `uv run --with tomli`, not the pinned CLI).

`make all`, `make fmt` and `make rhiza-test` are green; `rhiza-test` skips exactly the six written-version assertions, as documented.

## Docs

`CLAUDE.md`'s dynamic-versioning section gains why the release path blocked adoption and what replaced the check; `Validate Tag` is now described as the only gate *before anything is built*. Each workflow's header requirement line no longer claims a top-level `version` field is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
