### PR TITLE
chore: release v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com),
 and entries are generated from [Conventional Commits](https://www.conventionalcommits.org).
 
+## [1.8.0] - 2026-09-07
+
+### New Features
+- Derive rhiza's own version from the git tag (#1681)
+
+### Documentation
+- Record dynamic versioning as a second legal shape for python-core (#1679)
+
+### Dependencies
+- *(deps)* Update pre-commit hook astral-sh/ruff-pre-commit to v0.16.6 (#1671)
+- *(deps)* Lock file maintenance (#1673)
+- *(deps)* Update pre-commit hook igorshubovych/markdownlint-cli to v0.49.1 (#1672)
+- *(deps)* Update pre-commit hook astral-sh/uv-pre-commit to v0.12.10 (#1675)
+- *(deps)* Lock file maintenance (#1676)
+- *(deps)* Update rhiza-task to v1.7.0 and pytest-rhiza to v0.6.0 (#1680)
+
 ## [1.7.3] - 2026-09-04
 
 ### Dependencies

--- a/bundles/github-book/.github/workflows/rhiza_book.yml
+++ b/bundles/github-book/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.7.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.8.0
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml
+++ b/bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   devcontainer:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v1.7.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v1.8.0
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-docker/.github/workflows/rhiza_docker.yml
+++ b/bundles/github-docker/.github/workflows/rhiza_docker.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   docker:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v1.7.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v1.8.0
     secrets: inherit
     permissions:
       contents: read

--- a/bundles/github-marimo/.github/workflows/rhiza_marimo.yml
+++ b/bundles/github-marimo/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.7.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.8.0
     secrets: inherit

--- a/bundles/github-paper/.github/workflows/rhiza_paper.yml
+++ b/bundles/github-paper/.github/workflows/rhiza_paper.yml
@@ -39,7 +39,7 @@ on:
 
 jobs:
   paper:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v1.7.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v1.8.0
     secrets: inherit
     # `contents: write` is for the `paper` branch publish and nothing else. A pull request
     # never reaches that step, so the scope is unused on every PR run.

--- a/bundles/github-quality-review/.github/workflows/rhiza_quality_review.yml
+++ b/bundles/github-quality-review/.github/workflows/rhiza_quality_review.yml
@@ -34,5 +34,5 @@ on:
 
 jobs:
   quality-review:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_quality_review.yml@v1.7.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_quality_review.yml@v1.8.0
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_benchmark.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.7.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.8.0
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_ci.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.7.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.8.0
     secrets: inherit

--- a/bundles/github-tests/.github/workflows/rhiza_codeql.yml
+++ b/bundles/github-tests/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.7.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.8.0
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/bundles/github/.github/workflows/rhiza_scorecard.yml
+++ b/bundles/github/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.7.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.8.0
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/bundles/github/.github/workflows/rhiza_weekly.yml
+++ b/bundles/github/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.7.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.8.0
     secrets: inherit


### PR DESCRIPTION
Release **v1.8.0**, up from `1.7.3`.

## Merging this PR publishes the release

The `/rhiza:release` run that opened this PR is waiting for the merge and will tag the
merged commit as `v1.8.0`, which triggers `rhiza_release.yml`. If that run has ended,
re-running `/rhiza:release` finishes the job — it detects the merged-but-untagged state
and goes straight to tagging.

## Why minor

One `feat` in the range: #1681, which makes this repo's `[project].version` dynamic and
rewrites `rhiza_release.yml`'s version verification. That workflow is template-owned, so
the change reaches every consumer's release path on their next sync — new behaviour, not a
fix.

## The version bump

`1.7.3` is derived from the newest tag, so there is no written version to rewrite:
`[tool.bumpversion]` carries no `current_version` and `pyproject.toml` is deliberately
absent from `[[tool.bumpversion.files]]`. What moved is the eleven self-referencing
`uses:` pins in the bundle stubs, all via the
`bundles/**/.github/workflows/*.yml` glob:

- `bundles/github/.github/workflows/rhiza_weekly.yml`
- `bundles/github/.github/workflows/rhiza_scorecard.yml`
- `bundles/github-tests/.github/workflows/rhiza_ci.yml`
- `bundles/github-tests/.github/workflows/rhiza_codeql.yml`
- `bundles/github-tests/.github/workflows/rhiza_benchmark.yml`
- `bundles/github-book/.github/workflows/rhiza_book.yml`
- `bundles/github-docker/.github/workflows/rhiza_docker.yml`
- `bundles/github-devcontainer/.github/workflows/rhiza_devcontainer.yml`
- `bundles/github-marimo/.github/workflows/rhiza_marimo.yml`
- `bundles/github-paper/.github/workflows/rhiza_paper.yml`
- `bundles/github-quality-review/.github/workflows/rhiza_quality_review.yml`

Each goes `@v1.7.3` → `@v1.8.0`, one line per file. The live workflows under
`.github/workflows/` are untouched by design — they reference `jebel-quant/actions` by
commit SHA, which carries that repo's version and not this one.

## Changelog

`CHANGELOG.md` gains the `## [1.8.0]` section and nothing below it changes:

- **New Features** — derive rhiza's own version from the git tag (#1681)
- **Documentation** — record dynamic versioning as a second legal shape for python-core (#1679)
- **Dependencies** — six `chore(deps)` entries (#1671, #1672, #1673, #1675, #1676, #1680)
